### PR TITLE
[mod] 矢印アイコンをボタン化 (#64)

### DIFF
--- a/view/next-project/src/components/General/PulldownButton.tsx
+++ b/view/next-project/src/components/General/PulldownButton.tsx
@@ -1,0 +1,25 @@
+import { ChakraProvider, Button } from '@chakra-ui/react';
+import { ChevronDownIcon } from "@chakra-ui/icons";
+import * as React from 'react';
+import theme from '@assets/theme';
+
+class PulldownButton extends React.Component {
+  render() {
+    return (
+      <ChakraProvider theme={theme}>
+        <Button
+          background="transparent"
+          w='25px'
+          h='25px'
+          p='0'
+          minWidth='0'
+          borderRadius='full' 
+        >
+          <ChevronDownIcon />
+        </Button>
+      </ChakraProvider>
+    );
+  }
+}
+
+export default PulldownButton;

--- a/view/next-project/src/components/Header.tsx
+++ b/view/next-project/src/components/Header.tsx
@@ -5,7 +5,7 @@ import {
   Text,
   ChakraProvider
 } from "@chakra-ui/react";
-import { ChevronDownIcon } from "@chakra-ui/icons";
+import PulldownButton from '../components/General/PulldownButton';
 import { Avatar } from '@chakra-ui/react'
 import theme from "@assets/theme";
 
@@ -53,8 +53,10 @@ const Header = () => {
               小林諒大
               </Text>
             </Box>
-            <Box marginRight="5">
-              <ChevronDownIcon />
+            <Box 
+              marginRight="5"
+            >
+              <PulldownButton />
             </Box>
           </Flex>
       </Flex>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #64 

# 概要
<!-- 開発内容の概要を記載 -->
ヘッダー右側にある下矢印のアイコンをボタン化，コンポーネント化する．

# 変更ファイル
<!-- 変更したファイルを箇条書きで記載 -->
<!-- 例) `api/app/controller/groups_controller.rb` -->
-view/next-project/src/components/Header.tsx
-view/next-project/src/components/General/PulldownButton.tsx
-

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/83533261/148240288-05b5fa9b-dff2-43f0-a067-d0e0287bd7f1.png">

# テスト項目
<!-- テストしてほしい内容を記載 -->
-動作確認をお願いします．
-
-

# 備考
