### PR TITLE
[issue320] purchaseordersのpost,putしたレコードの取得機能の作成

### DIFF
--- a/api/externals/controller/purhcase_order_controller.go
+++ b/api/externals/controller/purhcase_order_controller.go
@@ -18,6 +18,8 @@ type PurchaseOrderController interface {
 	DestroyPurchaseOrder(echo.Context) error
 	IndexOrderWithUserItem(echo.Context) error
 	ShowOrderWithUserItem(echo.Context) error
+	ShowNewPurchaseOrder(echo.Context) error
+	ShowEditPurchaseOrder(echo.Context) error
 }
 
 func NewPurchaseOrderController(u usecase.PurchaseOrderUseCase) PurchaseOrderController {
@@ -95,4 +97,29 @@ func (p *purchaseOrderController) ShowOrderWithUserItem(c echo.Context) error{
 		return err
 	}
 	return c.JSON(http.StatusOK,orderWithUserAndItem)
+}
+
+//ShowNewPurchaseOrder
+func (p *purchaseOrderController) ShowNewPurchaseOrder(c echo.Context) error{
+	deadLine := c.QueryParam("deadline")
+	userID := c.QueryParam("user_id")
+	financeCheck := c.QueryParam("finance_check")
+	purchaseOrder, err := p.u.GetPurchaseOrderNewRecord(c.Request().Context(),deadLine, userID, financeCheck)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, purchaseOrder)
+}
+
+//ShowEditPurchaseOrder
+func (p *purchaseOrderController) ShowEditPurchaseOrder(c echo.Context) error{
+	id := c.Param("id")
+	deadLine := c.QueryParam("deadline")
+	userID := c.QueryParam("user_id")
+	financeCheck := c.QueryParam("finance_check")
+	purchaseOrder,err :=p.u.GetPurchaseOrderEdit(c.Request().Context(), id, deadLine, userID, financeCheck)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, purchaseOrder)
 }

--- a/api/externals/repository/purchase_order_repository.go
+++ b/api/externals/repository/purchase_order_repository.go
@@ -21,6 +21,7 @@ type PurchaseOrderRepository interface {
 	AllOrderWithUser(context.Context) (*sql.Rows,error)
 	FindWithOrderItem(context.Context,string) (*sql.Row,error)
 	GetPurchaseItemByOrderId(context.Context, string) (*sql.Rows,error)
+	FindNewRecord(context.Context) (*sql.Row,error)
 }
 
 func NewPurchaseOrderRepository(client db.Client) PurchaseOrderRepository {
@@ -111,4 +112,12 @@ func (p *purchaseOrderRepository) GetPurchaseItemByOrderId(c context.Context, pu
 	}
 	fmt.Printf("\x1b[36m%s\n", query)
 	return rows, nil
+}
+
+//最新のレコードを取得
+func (por *purchaseOrderRepository) FindNewRecord(c context.Context) (*sql.Row,error) {
+	query := "select * from purchase_orders order by id desc limit 1"
+	row:= por.client.DB().QueryRowContext(c,query)
+	fmt.Printf("\x1b[36m%s\n", query)
+	return row ,nil
 }

--- a/api/externals/repository/purchase_order_repository.go
+++ b/api/externals/repository/purchase_order_repository.go
@@ -54,7 +54,7 @@ func (por * purchaseOrderRepository) Create(
 	userId string,
 	financeCheck string,
 ) error {
-		var query = "insert into purchase_orders (deadline, user_id, finance_check) values ( " + deadLine + "," + userId + "," + financeCheck +")"
+		var query = "insert into purchase_orders (deadline, user_id, finance_check) values ('" + deadLine + "'," + userId + "," + financeCheck +")"
 		_, err := por.client.DB().ExecContext(c, query)
 		fmt.Printf("\x1b[36m%s\n", query)
 		return err

--- a/api/externals/repository/purchase_report_repository.go
+++ b/api/externals/repository/purchase_report_repository.go
@@ -56,7 +56,7 @@ func (ppr *purchaseReportRepository) Create(
 	purchaseOrderId string,
 	remark string,
 ) error {
-	var query = "insert into purchase_reports (user_id, discount, addition, finance_check, purchase_order_id, remark) values (" + userId + "," + discount + "," + addition + "," + finance_check + "," + purchaseOrderId + "," + remark + ")"
+	var query = "insert into purchase_reports (user_id, discount, addition, finance_check, purchase_order_id, remark) values (" + userId + "," + discount + "," + addition + "," + finance_check + "," + purchaseOrderId + ",'" + remark + "')"
 	_, err := ppr.client.DB().ExecContext(c, query)
 	fmt.Printf("\x1b[36m%s\n", query)
 	return err

--- a/api/internals/usecase/purchase_order_usecase.go
+++ b/api/internals/usecase/purchase_order_usecase.go
@@ -5,6 +5,7 @@ import (
 	rep "github.com/NUTFes/FinanSu/api/externals/repository"
 	"github.com/NUTFes/FinanSu/api/internals/domain"
 	"strconv"
+	"fmt"
 )
 
 type purchaseOrderUseCase struct {
@@ -19,7 +20,10 @@ type PurchaseOrderUseCase interface {
 	DestroyPurchaseOrder(context.Context, string) error
 	GetOrderWithUserItem(context.Context) ([]domain.OrderWithItemAndUser,error)
 	GetOrderWithUserItemByID(context.Context, string) (domain.OrderWithItemAndUser,error)
+	GetPurchaseOrderNewRecord(context.Context, string, string,string) (domain.PurchaseOrder,error)
+	GetPurchaseOrderEdit(context.Context,string,string,string,string) (domain.PurchaseOrder,error)
 }
+
 
 func NewPurchaseOrderUseCase(rep rep.PurchaseOrderRepository) PurchaseOrderUseCase {
 	return &purchaseOrderUseCase{rep}
@@ -198,4 +202,55 @@ func (p *purchaseOrderUseCase) GetOrderWithUserItemByID(c context.Context, id st
 	}
 	orderWithUserAndItem.PurchaseItem = purchaseItems
 	return orderWithUserAndItem, nil
+}
+
+//postした時に作成されたレコードの取得
+func (p *purchaseOrderUseCase) GetPurchaseOrderNewRecord(
+	c context.Context,
+	deadLine string,
+	userID string,
+	finansuCheck string,
+	)(domain.PurchaseOrder,error) {
+	purchaseOrder := domain.PurchaseOrder{}
+	p.rep.Create(c,deadLine,userID,finansuCheck)
+	row, err := p.rep.FindNewRecord(c)
+	err = row.Scan(
+		&purchaseOrder.ID,
+		&purchaseOrder.DeadLine,
+		&purchaseOrder.UserID,
+		&purchaseOrder.FinanceCheck,
+		&purchaseOrder.CreatedAt,
+		&purchaseOrder.UpdatedAt,
+	)
+	if err != nil {
+		fmt.Println("---------------------------")
+		fmt.Println(err)
+		return purchaseOrder, err
+	}	
+	return purchaseOrder,nil
+}
+
+//putした時に更新されたレコードの取得
+func (p *purchaseOrderUseCase) GetPurchaseOrderEdit(
+	c context.Context,
+	id string,
+	deadLine string,
+	userID string,
+	finansuCheck string,
+)(domain.PurchaseOrder,error){
+	purchaseOrder :=domain.PurchaseOrder{}
+	p.rep.Update(c,id,deadLine,userID,finansuCheck)
+	row, err := p.rep.Find(c, id)
+	err = row.Scan(
+		&purchaseOrder.ID,
+		&purchaseOrder.DeadLine,
+		&purchaseOrder.UserID,
+		&purchaseOrder.FinanceCheck,
+		&purchaseOrder.CreatedAt,
+		&purchaseOrder.UpdatedAt,
+	)
+	if err != nil {
+		return purchaseOrder, err
+	}
+	return purchaseOrder, nil
 }

--- a/api/internals/usecase/purchase_order_usecase.go
+++ b/api/internals/usecase/purchase_order_usecase.go
@@ -5,7 +5,6 @@ import (
 	rep "github.com/NUTFes/FinanSu/api/externals/repository"
 	"github.com/NUTFes/FinanSu/api/internals/domain"
 	"strconv"
-	"fmt"
 )
 
 type purchaseOrderUseCase struct {
@@ -223,8 +222,6 @@ func (p *purchaseOrderUseCase) GetPurchaseOrderNewRecord(
 		&purchaseOrder.UpdatedAt,
 	)
 	if err != nil {
-		fmt.Println("---------------------------")
-		fmt.Println(err)
 		return purchaseOrder, err
 	}	
 	return purchaseOrder,nil

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -134,8 +134,8 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.DELETE("/purchaseorders/:id", r.purchaseOrderController.DestroyPurchaseOrder)
 	e.GET("/get_purchaseorders_for_view", r.purchaseOrderController.IndexOrderWithUserItem)
 	e.GET("/get_purchaseorders_for_view/:id", r.purchaseOrderController.ShowOrderWithUserItem)
-	e.GET("/get_post_purchaseorder_record", r.purchaseOrderController.ShowNewPurchaseOrder)
-	e.GET("/get_put_purchaseorder_record/:id", r.purchaseOrderController.ShowEditPurchaseOrder)
+	e.POST("/get_post_purchaseorder_record", r.purchaseOrderController.ShowNewPurchaseOrder)
+	e.PUT("/get_put_purchaseorder_record/:id", r.purchaseOrderController.ShowEditPurchaseOrder)
 
 	// purchasereportsのRoute
 	e.GET("/purchasereports", r.purchaseReportController.IndexPurchaseReport)

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -144,7 +144,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.PUT("/purchasereports/:id", r.purchaseReportController.UpdatePurchaseReport)
 	e.DELETE("/purchasereports/:id", r.purchaseReportController.DestroyPurchaseReport)
 	e.GET("/get_purchasereports_for_view", r.purchaseReportController.IndexPurchaseReportWithOrderItem)
-	e.POST("/get_purchasereports_for_view/:id", r.purchaseReportController.ShowPurchaseReportWithOrderItem)
+	e.GET("/get_purchasereports_for_view/:id", r.purchaseReportController.ShowPurchaseReportWithOrderItem)
 
 	// purchasereport_for_viewのRoute
 	

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -134,6 +134,8 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.DELETE("/purchaseorders/:id", r.purchaseOrderController.DestroyPurchaseOrder)
 	e.GET("/get_purchaseorders_for_view", r.purchaseOrderController.IndexOrderWithUserItem)
 	e.GET("/get_purchaseorders_for_view/:id", r.purchaseOrderController.ShowOrderWithUserItem)
+	e.GET("/get_post_purchaseorder_record", r.purchaseOrderController.ShowNewPurchaseOrder)
+	e.GET("/get_put_purchaseorder_record/:id", r.purchaseOrderController.ShowEditPurchaseOrder)
 
 	// purchasereportsのRoute
 	e.GET("/purchasereports", r.purchaseReportController.IndexPurchaseReport)
@@ -142,7 +144,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.PUT("/purchasereports/:id", r.purchaseReportController.UpdatePurchaseReport)
 	e.DELETE("/purchasereports/:id", r.purchaseReportController.DestroyPurchaseReport)
 	e.GET("/get_purchasereports_for_view", r.purchaseReportController.IndexPurchaseReportWithOrderItem)
-	e.GET("/get_purchasereports_for_view/:id", r.purchaseReportController.ShowPurchaseReportWithOrderItem)
+	e.POST("/get_purchasereports_for_view/:id", r.purchaseReportController.ShowPurchaseReportWithOrderItem)
 
 	// purchasereport_for_viewのRoute
 	


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #320 

# 概要
<!-- 開発内容の概要を記載 -->
`purchaseorders`を`post`または、`put`した際にできるレコードを取得する機能の作成

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
postman等で以下のようなAPIをたたく
- post
`http://localhost:1323/get_post_purchaseorder_record?deadline="test-DeadLine-post"&user_id=3&finance_check=true`
- [x] レコードを取得できたか

- put 
`http://localhost:1323/get_post_purchaseorder_record/id?deadline="test-DeadLine-put"&user_id=2&finance_check=true`
- [x] レコードを取得できたか

# 備考
藤崎の環境では動作確認済み