### PR TITLE
[issue359] purchasereportをpostとputした際のレコード取得

### DIFF
--- a/api/externals/controller/purchase_report_controller.go
+++ b/api/externals/controller/purchase_report_controller.go
@@ -4,7 +4,6 @@ import(
 	"github.com/NUTFes/FinanSu/api/internals/usecase"
 	"github.com/labstack/echo/v4"
 	"net/http"
-	"fmt"
 )
 
 type purchaseReportController struct {
@@ -19,6 +18,8 @@ type PurchaseReportController interface {
 	DestroyPurchaseReport(echo.Context) error
 	IndexPurchaseReportWithOrderItem(echo.Context) error
 	ShowPurchaseReportWithOrderItem(echo.Context) error
+	ShowPurchaseReportPostRecord(echo.Context) error
+	ShowPurchaseReportPutRecord(echo.Context) error
 }
 
 func NewPurchaseReportController(u usecase.PurchaseReportUseCase) PurchaseReportController {
@@ -52,7 +53,6 @@ func (p *purchaseReportController) CreatePurchaseReport(c echo.Context)error{
 	financeCheck :=c.QueryParam("finance_check") 
 	purchaseOrderID := c.QueryParam("purchase_order_id")
 	remark :=c.QueryParam("remark")
-	fmt.Println("aaaaaaaaaaaaaaa")
 	err := p.u.CreatePurchaseReport(c.Request().Context(),userID, discount,addition,financeCheck,purchaseOrderID,remark)
 	if err != nil {
 		return err
@@ -104,4 +104,35 @@ func (p *purchaseReportController) ShowPurchaseReportWithOrderItem(c echo.Contex
 		return err
 	}
 	return c.JSON(http.StatusOK, purchaseReportwithorderitem)
+}
+
+//ShowPurchaseReportPostRecord
+func (p *purchaseReportController) ShowPurchaseReportPostRecord(c echo.Context) error {
+	userID :=c.QueryParam("user_id")
+	discount :=c.QueryParam("discount")
+	addition :=c.QueryParam("addition")
+	financeCheck :=c.QueryParam("finance_check") 
+	purchaseOrderID := c.QueryParam("purchase_order_id")
+	remark :=c.QueryParam("remark")
+	purchaseReport, err := p.u.GetPurchaseReportPostRecord(c.Request().Context(),userID, discount, addition, financeCheck, purchaseOrderID, remark)
+	if err != nil {
+		return nil
+	}
+	return c.JSON(http.StatusOK, purchaseReport)
+}
+
+//ShowPurchaseReportPutRecord
+func (p *purchaseReportController) ShowPurchaseReportPutRecord(c echo.Context) error {
+	id := c.Param("id")
+	userID :=c.QueryParam("user_id")
+	discount :=c.QueryParam("discount")
+	addition :=c.QueryParam("addition")
+	financeCheck :=c.QueryParam("finance_check") 
+	purchaseOrderID := c.QueryParam("purchase_order_id")
+	remark :=c.QueryParam("remark")
+	purchaseReport, err:= p.u.GetPurchaseReportPutRecord(c.Request().Context(), id, userID, discount, addition, financeCheck, purchaseOrderID, remark)
+	if err != nil {
+		return nil
+	}
+	return c.JSON(http.StatusOK, purchaseReport)
 }

--- a/api/externals/repository/purchase_report_repository.go
+++ b/api/externals/repository/purchase_report_repository.go
@@ -21,7 +21,9 @@ type PurchaseReportRepository interface {
 	AllWithOrderItem(context.Context) (*sql.Rows, error)
 	FindWithOrderItem(context.Context, string) (*sql.Row, error)
 	GetPurchaseItemByPurchaseOrderID(context.Context, string) (*sql.Rows, error)
+	FindNewRecord(context.Context) (*sql.Row,error)
 }
+
 
 func NewPurchaseReportRepository(client db.Client) PurchaseReportRepository {
 	return &purchaseReportRepository{client}
@@ -118,4 +120,12 @@ func (ppr *purchaseReportRepository) GetPurchaseItemByPurchaseOrderID(c context.
 	}
 	fmt.Printf("\x1b[36m%s\n", query)
 	return rows, nil
+}
+
+//purchasereportの最新のレコード取得
+func (ppr *purchaseReportRepository) FindNewRecord(c context.Context) (*sql.Row, error) {
+	query := "select * from purchase_reports order by id desc limit 1"
+	row := ppr.client.DB().QueryRowContext(c, query)
+	fmt.Printf("\x1b[36m%s\n", query)
+	return row, nil
 }

--- a/api/internals/usecase/purchase_report_usecase.go
+++ b/api/internals/usecase/purchase_report_usecase.go
@@ -19,6 +19,8 @@ type PurchaseReportUseCase interface {
 	DestroyPurchaseReport(context.Context, string) error
 	GetPurchaseReportsWithOrderItem(context.Context) ([]domain.PurchaseReportWithOrderItem, error)
 	GetPurchaseReportWithOrderItemByID(context.Context, string) (domain.PurchaseReportWithOrderItem, error)
+	GetPurchaseReportPostRecord(context.Context, string, string, string, string, string, string) (domain.PurchaseReport, error)
+	GetPurchaseReportPutRecord(context.Context, string, string, string, string, string, string, string) (domain.PurchaseReport, error)
 }
 
 func NewPurchaseReportUseCase(rep rep.PurchaseReportRepository) PurchaseReportUseCase {
@@ -240,4 +242,65 @@ func (p *purchaseReportUseCase) GetPurchaseReportWithOrderItemByID(c context.Con
 	}
 	purchaseReportwithorderitem.PurchaseItems = purchaseItems
 	return purchaseReportwithorderitem, nil
+}
+
+//postした際に作成されるレコードの取得
+func (p *purchaseReportUseCase) GetPurchaseReportPostRecord(
+	c context.Context,
+	UserID string,
+	Discount string,
+	Addition string,
+	FinanceCheck string,
+	PurchaseOrderID string,
+	Remark string,
+)(domain.PurchaseReport,error){
+	p.rep.Create(c, UserID ,Discount, Addition, FinanceCheck, PurchaseOrderID,Remark)
+	purchaseReport := domain.PurchaseReport{}
+	row, err := p.rep.FindNewRecord(c)
+	err = row.Scan(
+		&purchaseReport.ID,
+		&purchaseReport.UserID,
+		&purchaseReport.Discount,
+		&purchaseReport.Addition,
+		&purchaseReport.FinanceCheck,
+		&purchaseReport.PurchaseOrderID,
+		&purchaseReport.Remark,
+		&purchaseReport.CreatedAt,
+		&purchaseReport.UpdatedAt,
+	)
+	if err != nil {
+		return purchaseReport, err
+	}
+	return purchaseReport, nil
+}
+
+//putした際に更新されるレコードの取得
+func (p *purchaseReportUseCase) GetPurchaseReportPutRecord(
+	c context.Context,
+	id string,
+	UserID string,
+	Discount string,
+	Addition string,
+	FinanceCheck string,
+	PurchaseOrderID string,
+	Remark string,
+)(domain.PurchaseReport, error) {
+	p.rep.Update(c,id, UserID, Discount, Addition, FinanceCheck, PurchaseOrderID, Remark)
+	purchaseReport := domain.PurchaseReport{}
+	row, err := p.rep.Find(c, id)
+	err = row.Scan(
+		&purchaseReport.ID,
+		&purchaseReport.UserID,
+		&purchaseReport.Discount,
+		&purchaseReport.Addition,
+		&purchaseReport.FinanceCheck,
+		&purchaseReport.PurchaseOrderID,
+		&purchaseReport.Remark,
+		&purchaseReport.CreatedAt,
+		&purchaseReport.UpdatedAt,
+	)
+	if err != nil {
+		return purchaseReport, err
+	}
+	return purchaseReport, nil
 }

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -148,6 +148,8 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.DELETE("/purchasereports/:id", r.purchaseReportController.DestroyPurchaseReport)
 	e.GET("/get_purchasereports_for_view", r.purchaseReportController.IndexPurchaseReportWithOrderItem)
 	e.GET("/get_purchasereports_for_view/:id", r.purchaseReportController.ShowPurchaseReportWithOrderItem)
+	e.POST("/get_post_purchasereports_record", r.purchaseReportController.ShowPurchaseReportPostRecord)
+	e.PUT("/get_put_purchasereports_record/:id", r.purchaseReportController.ShowPurchaseReportPutRecord)
 
 	// purchasereport_for_viewのRoute
 	


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #359 

# 概要
<!-- 開発内容の概要を記載 -->
・`purchaseReport`を`post`した際に作成されるレコードの取得
・`purchaseReport`を`puy`した際に更新されるレコードの取得


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] `http://localhost:1323/get_post_purchasereports_record`
をたたきpostした際に作成されるレコードを取得できるか
- [ ] `http://localhost:1323/get_put_purchasereports_record/:id`
をたたきputした際に更新されるレコードを取得できるか

入力フィールド例
```
    "user_id": 6,
    "discount": 200,
    "addition": 300,
    "finance_check": true,
    "remark": "test-remark",
    "purchase_order_id": 3,
```
# 備考
藤崎環境で動作確認済み