### PR TITLE
Create, Update時にcreate, updateされたレコードを返す修正

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -131,6 +131,26 @@ const docTemplate = `{
                 },
             },
         },
+        "/budgets/{id}/details": {
+            "get": {
+                tags: ["budget"],
+                "description": "IDで指定されたbudgetに紐づくyearとsourceを取得",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "budgetに紐づくyearとsourceを取得",
+                    }
+                }
+            },
+        },
     }
 }`
 

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -15,7 +15,123 @@ const docTemplate = `{
     },
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
-    "paths": {}
+    "paths": {
+        "/budgets": {
+            "get": {
+                tags: ["budget"],
+                "description": "budgetの一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "budgetの一覧の取得",
+                    }
+                }
+            },
+            "post": {
+                tags: ["budget"],
+                "description": "budgetの作成",
+                responses: {
+                    "200": {
+                        "description": "create されたbudgetが返ってくる",
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "price",
+                        "in": "query",
+                        "description": "price",
+                        "required": true,
+                        "type": "integer"
+                    },
+                    {
+                        "name": "year_id",
+                        "in": "query",
+                        "description": "year_id",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "source_id",
+                        "in": "query",
+                        "description": "source_id",
+                        "type": "integer"
+                    }
+                ],
+            },
+        },
+        "/budgets/{id}": {
+            "get": {
+                tags: ["budget"],
+                "description": "IDで指定されたbudgetの取得",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "budgetの取得",
+                    }
+                }
+            },
+            "put": {
+                tags: ["budget"],
+                "description": "budgetの更新",
+                responses: {
+                    "200": {
+                        "description": "更新されたbudgetが返ってくる",
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    },
+                    {
+                        "name": "price",
+                        "in": "query",
+                        "description": "price",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "year_id",
+                        "in": "query",
+                        "description": "year_id",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "source_id",
+                        "in": "query",
+                        "description": "source_id",
+                        "type": "integer"
+                    },
+                ],
+            },
+            "delete": {
+                tags: ["budget"],
+                "description": "IDを指定してbudgetの削除",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                responses: {
+                    "200": {
+                        "description": "budgetの削除完了",
+                    }
+                },
+            },
+        },
+    }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it

--- a/api/externals/controller/budget_controller.go
+++ b/api/externals/controller/budget_controller.go
@@ -1,9 +1,10 @@
 package controller
 
 import (
+	"net/http"
+
 	"github.com/NUTFes/FinanSu/api/internals/usecase"
 	"github.com/labstack/echo/v4"
-	"net/http"
 )
 
 type budgetController struct {
@@ -16,15 +17,13 @@ type BudgetController interface {
 	CreateBudget(echo.Context) error
 	UpdateBudget(echo.Context) error
 	DestroyBudget(echo.Context) error
-	//budgetに紐づくyearとsourceの取得
-	ShowBudgetWithYearAndSource(echo.Context) error
+	ShowBudgetDetail(echo.Context) error
 }
 
 func NewBudgetController(u usecase.BudgetUseCase) BudgetController {
 	return &budgetController{u}
 }
 
-// Index
 func (b *budgetController) IndexBudget(c echo.Context) error {
 	budgets, err := b.u.GetBudgets(c.Request().Context())
 	if err != nil {
@@ -33,9 +32,9 @@ func (b *budgetController) IndexBudget(c echo.Context) error {
 	return c.JSON(http.StatusOK, budgets)
 }
 
-// Show
 func (b *budgetController) ShowBudget(c echo.Context) error {
 	id := c.Param("id")
+
 	budget, err := b.u.GetBudgetByID(c.Request().Context(), id)
 	if err != nil {
 		return err
@@ -43,11 +42,11 @@ func (b *budgetController) ShowBudget(c echo.Context) error {
 	return c.JSON(http.StatusOK, budget)
 }
 
-// Create
 func (b *budgetController) CreateBudget(c echo.Context) error {
 	price := c.QueryParam("price")
 	yearID := c.QueryParam("year_id")
 	sourceID := c.QueryParam("source_id")
+
 	latastBudget, err := b.u.CreateBudget(c.Request().Context(), price, yearID, sourceID)
 	if err != nil {
 		return err
@@ -55,12 +54,12 @@ func (b *budgetController) CreateBudget(c echo.Context) error {
 	return c.JSON(http.StatusOK, latastBudget)
 }
 
-// Update
 func (b *budgetController) UpdateBudget(c echo.Context) error {
 	id := c.Param("id")
 	price := c.QueryParam("price")
 	yearID := c.QueryParam("year_id")
 	sourceID := c.QueryParam("source_id")
+
 	updatedBudget, err := b.u.UpdateBudget(c.Request().Context(), id, price, yearID, sourceID)
 	if err != nil {
 		return err
@@ -68,9 +67,9 @@ func (b *budgetController) UpdateBudget(c echo.Context) error {
 	return c.JSON(http.StatusOK, updatedBudget)
 }
 
-// Destroy
 func (b *budgetController) DestroyBudget(c echo.Context) error {
 	id := c.Param("id")
+
 	err := b.u.DestroyBudget(c.Request().Context(), id)
 	if err != nil {
 		return err
@@ -78,12 +77,13 @@ func (b *budgetController) DestroyBudget(c echo.Context) error {
 	return c.String(http.StatusOK, "Destroy Budget")
 }
 
-//Show Budget with year and source 
-func (b *budgetController) ShowBudgetWithYearAndSource(c echo.Context) error {
+// IDを指定してBudgetに紐づくyearとsourceの取得
+func (b *budgetController) ShowBudgetDetail(c echo.Context) error {
 	id := c.Param("id")
-	budgetyearsource ,err :=b.u.GetBudgetWithYearAndSource(c.Request().Context(), id)
+
+	budgetDetail, err := b.u.GetBudgetDetailByID(c.Request().Context(), id)
 	if err != nil {
 		return err
 	}
-	return c.JSON(http.StatusOK, budgetyearsource)
-} 
+	return c.JSON(http.StatusOK, budgetDetail)
+}

--- a/api/externals/controller/budget_controller.go
+++ b/api/externals/controller/budget_controller.go
@@ -48,11 +48,11 @@ func (b *budgetController) CreateBudget(c echo.Context) error {
 	price := c.QueryParam("price")
 	yearID := c.QueryParam("year_id")
 	sourceID := c.QueryParam("source_id")
-	err := b.u.CreateBudget(c.Request().Context(), price, yearID, sourceID)
+	latastBudget, err := b.u.CreateBudget(c.Request().Context(), price, yearID, sourceID)
 	if err != nil {
 		return err
 	}
-	return c.String(http.StatusCreated, "Created Budget")
+	return c.JSON(http.StatusOK, latastBudget)
 }
 
 // Update
@@ -61,11 +61,11 @@ func (b *budgetController) UpdateBudget(c echo.Context) error {
 	price := c.QueryParam("price")
 	yearID := c.QueryParam("year_id")
 	sourceID := c.QueryParam("source_id")
-	err := b.u.UpdateBudget(c.Request().Context(), id, price, yearID, sourceID)
+	updatedBudget, err := b.u.UpdateBudget(c.Request().Context(), id, price, yearID, sourceID)
 	if err != nil {
 		return err
 	}
-	return c.String(http.StatusOK, "Updated Budget")
+	return c.JSON(http.StatusOK, updatedBudget)
 }
 
 // Destroy

--- a/api/externals/repository/budget_repository.go
+++ b/api/externals/repository/budget_repository.go
@@ -19,9 +19,7 @@ type BudgetRepository interface {
 	Create(context.Context, string, string, string) error
 	Update(context.Context, string, string, string, string) error
 	Destroy(context.Context, string) error
-	//Budgetに紐づくyearとsourceを取得する
-	FindYearAndSource(context.Context, string) (*sql.Row, error)
-	//最新のbudgetを取得する
+	FindDetail(context.Context, string) (*sql.Row, error)
 	FindLatestRecord(context.Context) (*sql.Row, error)
 }
 
@@ -29,39 +27,71 @@ func NewBudgetRepository(c db.Client, ac abstract.Crud) BudgetRepository {
 	return &budgetRepository{c, ac}
 }
 
-// 全件取得
 func (br *budgetRepository) All(c context.Context) (*sql.Rows, error) {
-	query := "select * from budgets"
+	query := "SELECT * FROM budgets"
 	return br.crud.Read(c, query)
 }
 
-// 1件取得
 func (br *budgetRepository) Find(c context.Context, id string) (*sql.Row, error) {
-	query := "select * from budgets where id = " + id
+	query := "SELECT * FROM budgets WHERE id = " + id
 	return br.crud.ReadByID(c, query)
 }
 
-// 作成
 func (br *budgetRepository) Create(c context.Context, price string, yearID string, sourceID string) error {
-	query := "insert into budgets (price, year_id, source_id) values (" + price + "," + yearID + "," + sourceID + ")"
+	query := `
+		INSERT INTO
+			budgets (price, year_id, source_id)
+		VALUES
+			(` + price + "," + yearID + "," + sourceID + ")"
 	return br.crud.UpdateDB(c, query)
 }
 
-// 編集
 func (br *budgetRepository) Update(c context.Context, id string, price string, yearID string, sourceID string) error {
-	query := "update budgets set price = " + price + ", year_id = " + yearID + ", source_id = " + sourceID + " where id = " + id
+	query := `
+		UPDATE
+			budgets
+		SET
+			price = ` + price +
+			", year_id = " + yearID +
+			", source_id = " + sourceID +
+			" where id = " + id
 	return br.crud.UpdateDB(c, query)
 }
 
-// 削除
 func (br *budgetRepository) Destroy(c context.Context, id string) error {
-	query := "delete from budgets where id = " + id
+	query := "DELETE FROM budgets WHERE id = " + id
 	return br.crud.UpdateDB(c, query)
 }
 
 // Budgetに紐づくyearとsourceを取得する
-func (br *budgetRepository) FindYearAndSource(c context.Context, id string) (*sql.Row, error) {
-	query := "SELECT budgets.id, budgets.price, budgets.year_id, budgets.source_id, budgets.created_at, budgets.updated_at, years.id, years.year, years.created_at, years.updated_at, sources.id, sources.name, sources.created_at, sources.updated_at FROM budgets INNER JOIN years ON budgets.year_id = years.id INNER JOIN sources ON budgets.source_id = sources.id where budgets.id = " + id
+func (br *budgetRepository) FindDetail(c context.Context, id string) (*sql.Row, error) {
+	query := `
+		SELECT
+			budgets.id,
+			budgets.price,
+			budgets.year_id,
+			budgets.source_id,
+			budgets.created_at,
+			budgets.updated_at,
+			years.id,
+			years.year,
+			years.created_at,
+			years.updated_at,
+			sources.id,
+			sources.name,
+			sources.created_at,
+			sources.updated_at
+		FROM
+			budgets
+		INNER JOIN
+			years
+		ON
+			budgets.year_id = years.id
+		INNER JOIN
+			sources
+		ON
+			budgets.source_id = sources.id
+		WHERE budgets.id = ` + id
 	return br.crud.ReadByID(c, query)
 }
 

--- a/api/externals/repository/budget_repository.go
+++ b/api/externals/repository/budget_repository.go
@@ -21,6 +21,8 @@ type BudgetRepository interface {
 	Destroy(context.Context, string) error
 	//Budgetに紐づくyearとsourceを取得する
 	FindYearAndSource(context.Context, string) (*sql.Row, error)
+	//最新のbudgetを取得する
+	FindLatestRecord(context.Context) (*sql.Row, error)
 }
 
 func NewBudgetRepository(c db.Client, ac abstract.Crud) BudgetRepository {
@@ -60,5 +62,19 @@ func (br *budgetRepository) Destroy(c context.Context, id string) error {
 // Budgetに紐づくyearとsourceを取得する
 func (br *budgetRepository) FindYearAndSource(c context.Context, id string) (*sql.Row, error) {
 	query := "SELECT budgets.id, budgets.price, budgets.year_id, budgets.source_id, budgets.created_at, budgets.updated_at, years.id, years.year, years.created_at, years.updated_at, sources.id, sources.name, sources.created_at, sources.updated_at FROM budgets INNER JOIN years ON budgets.year_id = years.id INNER JOIN sources ON budgets.source_id = sources.id where budgets.id = " + id
+	return br.crud.ReadByID(c, query)
+}
+
+// 最新のbudgetを取得する
+func (br *budgetRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
+	query := `
+		SELECT
+			*
+		FROM
+			budgets
+		ORDER BY
+			id
+		DESC LIMIT 1
+	`
 	return br.crud.ReadByID(c, query)
 }

--- a/api/internals/domain/budget.go
+++ b/api/internals/domain/budget.go
@@ -13,7 +13,7 @@ type Budget struct {
 	UpdatedAt time.Time `json:"updatedAt"`
 }
 
-type BudgetYearSource struct {
+type BudgetDetail struct {
 	Budget Budget `json:"budget"`
 	Year   Year   `json:"year"`
 	Source Source `json:"source"`

--- a/api/internals/domain/budget.go
+++ b/api/internals/domain/budget.go
@@ -5,10 +5,10 @@ import (
 )
 
 type Budget struct {
-	ID        ID        `json:"id"`
-	Price     Price     `json:"price"`
-	YearID    YearID    `json:"yearID"`
-	SourceID  SourceID  `json:"sourceID"`
+	ID        int       `json:"id"`
+	Price     uint       `json:"price"`
+	YearID    uint       `json:"yearID"`
+	SourceID  uint       `json:"sourceID"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }

--- a/api/internals/usecase/budget_usecase.go
+++ b/api/internals/usecase/budget_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+
 	rep "github.com/NUTFes/FinanSu/api/externals/repository"
 	"github.com/NUTFes/FinanSu/api/internals/domain"
 	"github.com/pkg/errors"
@@ -17,21 +18,17 @@ type BudgetUseCase interface {
 	CreateBudget(context.Context, string, string, string) (domain.Budget, error)
 	UpdateBudget(context.Context, string, string, string, string) (domain.Budget, error)
 	DestroyBudget(context.Context, string) error
-	//budgetsに紐づくyearとsourceの取得
-	GetBudgetWithYearAndSource(context.Context, string) (domain.BudgetYearSource, error)
+	GetBudgetDetailByID(context.Context, string) (domain.BudgetDetail, error)
 }
 
 func NewBudgetUseCase(rep rep.BudgetRepository) BudgetUseCase {
 	return &budgetUseCase{rep}
 }
 
-//budgetsの取得(Gets)
 func (b *budgetUseCase) GetBudgets(c context.Context) ([]domain.Budget, error) {
-
 	budget := domain.Budget{}
 	var budgets []domain.Budget
 
-	// クエリー実行
 	rows, err := b.rep.All(c)
 	if err != nil {
 		return nil, err
@@ -47,17 +44,14 @@ func (b *budgetUseCase) GetBudgets(c context.Context) ([]domain.Budget, error) {
 			&budget.CreatedAt,
 			&budget.UpdatedAt,
 		)
-
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot connect SQL")
 		}
-
 		budgets = append(budgets, budget)
 	}
 	return budgets, nil
 }
 
-//budgetの取得(Get)
 func (b *budgetUseCase) GetBudgetByID(c context.Context, id string) (domain.Budget, error) {
 	var budget domain.Budget
 
@@ -70,18 +64,16 @@ func (b *budgetUseCase) GetBudgetByID(c context.Context, id string) (domain.Budg
 		&budget.CreatedAt,
 		&budget.UpdatedAt,
 	)
-
 	if err != nil {
 		return budget, err
 	}
-
 	return budget, nil
 }
 
-//budgetの作成(Create)
 func (b *budgetUseCase) CreateBudget(c context.Context, price string, yearID string, sourceID string) (domain.Budget, error) {
+	latastBudget := domain.Budget{}
+
 	err := b.rep.Create(c, price, yearID, sourceID)
-	latastBudget:= domain.Budget{}
 	row, err := b.rep.FindLatestRecord(c)
 	err = row.Scan(
 		&latastBudget.ID,
@@ -97,10 +89,10 @@ func (b *budgetUseCase) CreateBudget(c context.Context, price string, yearID str
 	return latastBudget, nil
 }
 
-//budgetの更新(Update)
 func (b *budgetUseCase) UpdateBudget(c context.Context, id string, price string, yearID string, sourceID string) (domain.Budget, error) {
+	updatedBudget := domain.Budget{}
+
 	err := b.rep.Update(c, id, price, yearID, sourceID)
-	updatedBudget:= domain.Budget{}
 	row, err := b.rep.Find(c, id)
 	err = row.Scan(
 		&updatedBudget.ID,
@@ -116,35 +108,34 @@ func (b *budgetUseCase) UpdateBudget(c context.Context, id string, price string,
 	return updatedBudget, nil
 }
 
-//budgetの削除(Delete)
 func (b *budgetUseCase) DestroyBudget(c context.Context, id string) error {
 	err := b.rep.Destroy(c, id)
 	return err
 }
 
-//budgetに紐づくyearとsourceの取得(Get)
-func (b *budgetUseCase) GetBudgetWithYearAndSource(c context.Context, id string) (domain.BudgetYearSource, error) {
-	var budgetyearsource domain.BudgetYearSource
+// budgetに紐づくyearとsourceの取得(Get)
+func (b *budgetUseCase) GetBudgetDetailByID(c context.Context, id string) (domain.BudgetDetail, error) {
+	var budgetDetail domain.BudgetDetail
 
-	row, err := b.rep.FindYearAndSource(c, id)
+	row, err := b.rep.FindDetail(c, id)
 	err = row.Scan(
-		&budgetyearsource.Budget.ID,
-		&budgetyearsource.Budget.Price,	
-		&budgetyearsource.Budget.YearID,	
-		&budgetyearsource.Budget.SourceID,	
-		&budgetyearsource.Budget.CreatedAt,
-		&budgetyearsource.Budget.UpdatedAt,
-		&budgetyearsource.Year.ID,
-		&budgetyearsource.Year.Year,
-		&budgetyearsource.Year.CreatedAt,
-		&budgetyearsource.Year.UpdatedAt,
-		&budgetyearsource.Source.ID,
-		&budgetyearsource.Source.Name,
-		&budgetyearsource.Source.CreatedAt,
-		&budgetyearsource.Source.UpdatedAt,
+		&budgetDetail.Budget.ID,
+		&budgetDetail.Budget.Price,
+		&budgetDetail.Budget.YearID,
+		&budgetDetail.Budget.SourceID,
+		&budgetDetail.Budget.CreatedAt,
+		&budgetDetail.Budget.UpdatedAt,
+		&budgetDetail.Year.ID,
+		&budgetDetail.Year.Year,
+		&budgetDetail.Year.CreatedAt,
+		&budgetDetail.Year.UpdatedAt,
+		&budgetDetail.Source.ID,
+		&budgetDetail.Source.Name,
+		&budgetDetail.Source.CreatedAt,
+		&budgetDetail.Source.UpdatedAt,
 	)
 	if err != nil {
-		return budgetyearsource, err
+		return budgetDetail, err
 	}
-	return budgetyearsource , nil
+	return budgetDetail, nil
 }

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -118,7 +118,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.PUT("/budgets/:id", r.budgetController.UpdateBudget)
 	e.DELETE("/budgets/:id", r.budgetController.DestroyBudget)
 	//budgetに紐づくyearとsourceの取得
-	e.GET("get_budgets_for_view/:id", r.budgetController.ShowBudgetWithYearAndSource)
+	e.GET("/budgets/:id/details", r.budgetController.ShowBudgetDetail)
 
 	// fund informations
 	e.GET("/fund_informations", r.fundInformationController.IndexFundInformation)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #417 

# 概要
<!-- 開発内容の概要を記載 -->
## Create, Update時にcreate, updateされたレコードを返す修正を行った b3f57566955a6daaec886d20c6e7f58956edf930
## Budgetに関するリファクタリング 55af9efdb9107480f7628a61698ab0aa530dc940
- repository, usecase, controller, router, domainにかけてメソッド名や変数名の修正
- **budgetに紐づくyearとsourceのデータを取得するURIも変わっているので、フロントでも修正をお願いします！**
## swaggerでbudgetのAPIを叩けるようにした 3ecce3d8f5b05e5892b7a6c73d5c0ef4a5f48d5f db48fb0f309bd850ddf5479a902d2ccc959685d4

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://user-images.githubusercontent.com/50622120/214321371-0dce50e3-7c52-4821-9623-4d9cb91fc7d7.png)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] create, update時にそれぞれのレコードが返ってくるか
- `make run-api`
- `http://localhost:1323/swagger/index.html#/`にて確認お願いします。swaggerの使い方が分からない場合は聞いてください。

# 備考
