### PR TITLE
budgetに紐づくデータの全件取得

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -131,7 +131,18 @@ const docTemplate = `{
                 },
             },
         },
-        "/budgets/{id}/details": {
+        "/budgets/details": {
+            "get": {
+                tags: ["budget"],
+                "description": "budgetに紐づくyearとsourceの一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "budgetに紐づくyearとsourceの一覧を取得",
+                    }
+                }
+            },
+        },
+        "/budgets/details/{id}": {
             "get": {
                 tags: ["budget"],
                 "description": "IDで指定されたbudgetに紐づくyearとsourceを取得",

--- a/api/externals/controller/budget_controller.go
+++ b/api/externals/controller/budget_controller.go
@@ -17,7 +17,8 @@ type BudgetController interface {
 	CreateBudget(echo.Context) error
 	UpdateBudget(echo.Context) error
 	DestroyBudget(echo.Context) error
-	ShowBudgetDetail(echo.Context) error
+	ShowBudgetDetailById(echo.Context) error
+	ShowBudgetDetails(echo.Context) error
 }
 
 func NewBudgetController(u usecase.BudgetUseCase) BudgetController {
@@ -78,7 +79,7 @@ func (b *budgetController) DestroyBudget(c echo.Context) error {
 }
 
 // IDを指定してBudgetに紐づくyearとsourceの取得
-func (b *budgetController) ShowBudgetDetail(c echo.Context) error {
+func (b *budgetController) ShowBudgetDetailById(c echo.Context) error {
 	id := c.Param("id")
 
 	budgetDetail, err := b.u.GetBudgetDetailByID(c.Request().Context(), id)
@@ -86,4 +87,13 @@ func (b *budgetController) ShowBudgetDetail(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, budgetDetail)
+}
+
+// Budgetに紐づくyearとsourceの全件取得
+func (b *budgetController) ShowBudgetDetails(c echo.Context) error {
+	budgetDetails, err := b.u.GetBudgetDetails(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, budgetDetails)
 }

--- a/api/internals/usecase/budget_usecase.go
+++ b/api/internals/usecase/budget_usecase.go
@@ -173,5 +173,5 @@ func (b *budgetUseCase) GetBudgetDetails(c context.Context) ([]domain.BudgetDeta
 		}
 		budgetDetails = append(budgetDetails, budgetDetail)
 	}
-	return budgetsDetails, nil
+	return budgetDetails, nil
 }

--- a/api/internals/usecase/budget_usecase.go
+++ b/api/internals/usecase/budget_usecase.go
@@ -171,7 +171,7 @@ func (b *budgetUseCase) GetBudgetDetails(c context.Context) ([]domain.BudgetDeta
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot connect SQL")
 		}
-		budgets = append(budgets, budgetDetail)
+		budgetsDetails = append(budgetsDetails, budgetDetail)
 	}
 	return budgets, nil
 }

--- a/api/internals/usecase/budget_usecase.go
+++ b/api/internals/usecase/budget_usecase.go
@@ -143,7 +143,7 @@ func (b *budgetUseCase) GetBudgetDetailByID(c context.Context, id string) (domai
 
 func (b *budgetUseCase) GetBudgetDetails(c context.Context) ([]domain.BudgetDetail, error) {
 	budgetDetail := domain.BudgetDetail{}
-	var budgets []domain.BudgetDetail
+	var budgetDetails []domain.BudgetDetail
 
 	rows, err := b.rep.FindDetail(c)
 	if err != nil {

--- a/api/internals/usecase/budget_usecase.go
+++ b/api/internals/usecase/budget_usecase.go
@@ -171,7 +171,7 @@ func (b *budgetUseCase) GetBudgetDetails(c context.Context) ([]domain.BudgetDeta
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot connect SQL")
 		}
-		budgetsDetails = append(budgetsDetails, budgetDetail)
+		budgetDetails = append(budgetDetails, budgetDetail)
 	}
 	return budgetsDetails, nil
 }

--- a/api/internals/usecase/budget_usecase.go
+++ b/api/internals/usecase/budget_usecase.go
@@ -173,5 +173,5 @@ func (b *budgetUseCase) GetBudgetDetails(c context.Context) ([]domain.BudgetDeta
 		}
 		budgetsDetails = append(budgetsDetails, budgetDetail)
 	}
-	return budgets, nil
+	return budgetsDetails, nil
 }

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -117,7 +117,9 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.PUT("/budgets/:id", r.budgetController.UpdateBudget)
 	e.DELETE("/budgets/:id", r.budgetController.DestroyBudget)
 	//budgetに紐づくyearとsourceの取得
-	e.GET("/budgets/:id/details", r.budgetController.ShowBudgetDetail)
+	e.GET("/budgets/details/:id", r.budgetController.ShowBudgetDetailById)
+	//budgetに紐づくyearとsourceの全件取得
+	e.GET("/budgets/details", r.budgetController.ShowBudgetDetails)
 
 	// fund informations
 	e.GET("/fund_informations", r.fundInformationController.IndexFundInformation)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#440 
<!-- 対応したIssue番号を記載 -->
resolve #440 

# 概要
<!-- 開発内容の概要を記載 -->
- swaggerの`/budgets/details`の追加
- swgger　`/budgets/{id}/details`→`/budgets/details/{id}`
- `ShowBudgetDetail`のメソッド名の変更 (末尾にByIdを追加)
- `ShowBudgetDetails`(budgetに紐づく全件データの取得)の実装

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="430" alt="スクリーンショット 2023-02-03 9 09 57" src="https://user-images.githubusercontent.com/115447919/216479275-2a0780d3-fc7e-4148-86f4-53a9c367a4c3.png">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- swaggerよりapiを叩き動作に問題ないか確認する
- (budgetとyearsとsourcesのテーブルにデータが1つしかない可能性があるためデータを追加してからテストを行う)
- メソッド名を変更しているため問題ないか確認する


# 備考
