### PR TITLE
[mod]予算一覧ページにタブ追加(#462)

### DIFF
--- a/view/next-project/src/components/budgets/AddModal.tsx
+++ b/view/next-project/src/components/budgets/AddModal.tsx
@@ -20,6 +20,7 @@ import { Dispatch, SetStateAction, useState } from 'react';
 import { FC } from 'react';
 import { RiCloseCircleLine } from 'react-icons/ri';
 
+import { SOURCES } from '@/constants/sources';
 import { post } from '@api/budget';
 import theme from '@assets/theme';
 import { PrimaryButton } from '@components/common';
@@ -116,7 +117,7 @@ const BudgetAddModal: FC<ModalProps> = (props) => {
                       value={formData.sourceID}
                       onChange={handler('sourceID')}
                     >
-                      {props.sources.map((source) => (
+                      {SOURCES.map((source) => (
                         <option key={source.id} value={source.id}>
                           {source.name}
                         </option>

--- a/view/next-project/src/components/budgets/EditModal.tsx
+++ b/view/next-project/src/components/budgets/EditModal.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'next/router';
 import { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
 import { RiCloseCircleLine } from 'react-icons/ri';
 
+import { SOURCES } from '@/constants/sources';
 import { get, put } from '@api/budget';
 import theme from '@assets/theme';
 import RegistButton from '@components/common/RegistButton';
@@ -125,7 +126,7 @@ const BudgetEditModal: FC<BudgetProps> = (props) => {
                       value={formData.sourceID}
                       onChange={handler('sourceID')}
                     >
-                      {props.sources.map((source) => (
+                      {SOURCES.map((source) => (
                         <option key={source.id} value={source.id}>
                           {source.name}
                         </option>

--- a/view/next-project/src/constants/sources.ts
+++ b/view/next-project/src/constants/sources.ts
@@ -1,0 +1,12 @@
+export const SOURCES = [
+  { id: 1, name: '教育振興会費' },
+  { id: 2, name: '同窓会費' },
+  { id: 3, name: '企業協賛金' },
+  { id: 4, name: '学内募金' },
+  { id: 5, name: '検便受験者負担金' },
+  { id: 6, name: '留学生会ステージ使用・広告代' },
+  { id: 7, name: '備品整備費' },
+  { id: 8, name: '雑収入' },
+  { id: 9, name: '昨年度繰越金' },
+  { id: 10, name: '利息' },
+];

--- a/view/next-project/src/pages/budgets/index.tsx
+++ b/view/next-project/src/pages/budgets/index.tsx
@@ -1,25 +1,12 @@
-import {
-  Box,
-  Table,
-  Thead,
-  Tbody,
-  Tfoot,
-  Tr,
-  Th,
-  Td,
-  Flex,
-  Spacer,
-  Select,
-  Center,
-  Grid,
-  GridItem,
-} from '@chakra-ui/react';
+import clsx from 'clsx';
+import Head from 'next/head';
 import { RiAddCircleLine } from 'react-icons/ri';
 
 import { get } from '@api/budget';
 import OpenAddModalButton from '@components/budgets/OpenAddModalButton';
 import OpenDeleteModalButton from '@components/budgets/OpenDeleteModalButton';
 import OpenEditModalButton from '@components/budgets/OpenEditModalButton';
+import { Card, Title } from '@components/common';
 import MainLayout from '@components/layout/MainLayout';
 import { Budget, Source, Year } from '@type/common';
 
@@ -52,7 +39,6 @@ export async function getServerSideProps() {
 export default function BudgetList(props: Props) {
   const sources = props.sources;
   const years = props.years;
-
   // 合計金額用の変数
   let totalFee = 0;
 
@@ -74,128 +60,125 @@ export default function BudgetList(props: Props) {
     totalFee += props.budgets[i].price;
   }
 
+  const formatDate = (date: string) => {
+    const datetime = date.replace('T', ' ');
+    const datetime2 = datetime.substring(10, datetime.length - 20);
+    return datetime2;
+  };
+
   return (
     <MainLayout>
-      <Flex justify='center' align='center'>
-        <Box m='10' px='10' boxShadow='base' rounded='lg'>
-          <Box mt='10' mx='5'>
-            <Flex>
-              <Center mr='5' fontSize='2xl' fontWeight='100' color='black.0'>
-                予算一覧
-              </Center>
-              <Select variant='flushed' w='100'>
-                <option value='2021'>2021</option>
-                <option value='2022'>2022</option>
-              </Select>
-            </Flex>
-            <Flex>
-              <Spacer />
-              <Box>
-                <OpenAddModalButton sources={sources} years={years}>
-                  <RiAddCircleLine
-                    size={20}
-                    style={{
-                      marginRight: 5,
-                    }}
-                  />
-                  予算登録
-                </OpenAddModalButton>
-              </Box>
-            </Flex>
-          </Box>
-          <Box p='5' mb='2'>
-            <Table>
-              <Thead>
-                <Tr>
-                  <Th borderBottomColor='#76E4F7'>
-                    <Center fontSize='sm' color='black.600'>
-                      ID
-                    </Center>
-                  </Th>
-                  <Th borderBottomColor='#76E4F7' isNumeric>
-                    <Center fontSize='sm' color='black.600'>
-                      項目
-                    </Center>
-                  </Th>
-                  <Th borderBottomColor='#76E4F7'>
-                    <Center fontSize='sm' color='black.600'>
-                      年度
-                    </Center>
-                  </Th>
-                  <Th borderBottomColor='#76E4F7' isNumeric>
-                    <Center fontSize='sm' color='black.600'>
-                      金額
-                    </Center>
-                  </Th>
-                  <Th borderBottomColor='#76E4F7'>
-                    <Center></Center>
-                  </Th>
-                  <Th borderBottomColor='#76E4F7'>
-                    <Center color='black.600'>作成日時</Center>
-                  </Th>
-                  <Th borderBottomColor='#76E4F7'>
-                    <Center color='black.600'>更新日時</Center>
-                  </Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {props.budgets.map((budgetItem) => (
-                  <Tr key={budgetItem.id}>
-                    <Td>
-                      <Center color='black.300'>{budgetItem.id}</Center>
-                    </Td>
-                    <Td>{/* <Center color='black.300'>{budgetItem.source}</Center> */}</Td>
-                    <Td>
-                      <Center color='black.300'>{budgetItem.yearID}</Center>
-                    </Td>
-                    <Td isNumeric color='black.300'>
+      <Head>
+        <title>予算一覧</title>
+        <meta name='viewport' content='initial-scale=1.0, width=device-width' />
+      </Head>
+      <Card>
+        <div className={clsx('mx-5 mt-10')}>
+          <div className={clsx('flex')}>
+            <Title title={'予算一覧'} />
+            <select className={clsx('w-100 ')}>
+              <option value='2021'>2021</option>
+              <option value='2022'>2022</option>
+            </select>
+          </div>
+          <div className={clsx('flex justify-end')}>
+            <OpenAddModalButton sources={sources} years={years}>
+              <RiAddCircleLine
+                size={20}
+                style={{
+                  marginRight: 5,
+                }}
+              />
+              予算登録
+            </OpenAddModalButton>
+          </div>
+          <div className={clsx('w-100 mb-2 p-5')}>
+            <table className={clsx('mb-5 w-full table-fixed border-collapse')}>
+              <thead>
+                <tr
+                  className={clsx(
+                    'border border-x-white-0 border-b-primary-1 border-t-white-0 py-3',
+                  )}
+                >
+                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                    <div className={clsx('text-center text-sm text-black-600')}>項目</div>
+                  </th>
+                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                    <div className={clsx('text-center text-sm text-black-600')}>年度</div>
+                  </th>
+                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                    <div className={clsx('text-center text-sm text-black-600')}>金額</div>
+                  </th>
+                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                    <div className={clsx('text-center text-sm text-black-600')}>作成日時</div>
+                  </th>
+                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                    <div className={clsx('text-center text-sm text-black-600')}>更新日時</div>
+                  </th>
+                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                    <div className={clsx('text-center text-sm text-black-600')}></div>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {props.budgets.map((budgetItem, index) => (
+                  <tr key={budgetItem.id}>
+                    {props.sources.map((sourceItem) => (
+                      <td
+                        key={sourceItem.id}
+                        className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}
+                      >
+                        {sourceItem.name}
+                      </td>
+                    ))}
+                    {props.years.map((yearItem) => (
+                      <td
+                        key={yearItem.id}
+                        className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}
+                      >
+                        {yearItem.year}
+                      </td>
+                    ))}
+                    <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
                       {budgetItem.price}
-                    </Td>
-                    <Td>
-                      <Grid templateColumns='repeat(2, 1fr)' gap={3}>
-                        <GridItem>
-                          <Center>
-                            <OpenEditModalButton
-                              id={budgetItem.id ? budgetItem.id : 0}
-                              sources={sources}
-                              years={years}
-                            />
-                          </Center>
-                        </GridItem>
-                        <GridItem>
-                          <Center>
-                            <OpenDeleteModalButton id={budgetItem.id ? budgetItem.id : 0} />
-                          </Center>
-                        </GridItem>
-                      </Grid>
-                    </Td>
-                    <Td>
-                      <Center color='black.300'>{budgetItem.createdAt}</Center>
-                    </Td>
-                    <Td>
-                      <Center color='black.300'>{budgetItem.updatedAt}</Center>
-                    </Td>
-                  </Tr>
+                    </td>
+                    <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                      {formatDate(budgetItem.createdAt ? budgetItem.createdAt : '')}
+                    </td>
+                    <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                      {formatDate(budgetItem.updatedAt ? budgetItem.updatedAt : '')}
+                    </td>
+                    <td className={clsx('content-center p-3 text-black-600')}>
+                      <div className={clsx('flex text-center')}>
+                        <div className={clsx('flex-auto')}>
+                          <OpenEditModalButton
+                            id={budgetItem.id ? budgetItem.id : 0}
+                            sources={sources}
+                            years={years}
+                          />
+                        </div>
+                        <div className={clsx('flex-auto')}>
+                          <OpenDeleteModalButton id={budgetItem.id ? budgetItem.id : 0} />
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
                 ))}
-              </Tbody>
-              <Tfoot>
-                <Tr>
-                  <Th />
-                  <Th />
-                  <Th>
-                    <Center fontSize='sm' fontWeight='500' color='black.600'>
-                      合計金額
-                    </Center>
-                  </Th>
-                  <Th isNumeric fontSize='sm' fontWeight='500' color='black.300'>
-                    {totalFee}
-                  </Th>
-                </Tr>
-              </Tfoot>
-            </Table>
-          </Box>
-        </Box>
-      </Flex>
+              </tbody>
+              <tfoot
+                className={clsx('border border-x-white-0 border-t-primary-1 border-b-white-0')}
+              >
+                <tr>
+                  <th />
+                  <th className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>合計金額</th>
+                  <th className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>{totalFee}</th>
+                  <th />
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
+      </Card>
     </MainLayout>
   );
 }

--- a/view/next-project/src/pages/budgets/index.tsx
+++ b/view/next-project/src/pages/budgets/index.tsx
@@ -1,3 +1,4 @@
+import { Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react';
 import clsx from 'clsx';
 import Head from 'next/head';
 import { RiAddCircleLine } from 'react-icons/ri';
@@ -72,113 +73,234 @@ export default function BudgetList(props: Props) {
         <title>予算一覧</title>
         <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       </Head>
-      <Card>
-        <div className={clsx('mx-5 mt-10')}>
-          <div className={clsx('flex')}>
-            <Title title={'予算一覧'} />
-            <select className={clsx('w-100 ')}>
-              <option value='2021'>2021</option>
-              <option value='2022'>2022</option>
-            </select>
-          </div>
-          <div className={clsx('flex justify-end')}>
-            <OpenAddModalButton sources={sources} years={years}>
-              <RiAddCircleLine
-                size={20}
-                style={{
-                  marginRight: 5,
-                }}
-              />
-              予算登録
-            </OpenAddModalButton>
-          </div>
-          <div className={clsx('w-100 mb-2 p-5')}>
-            <table className={clsx('mb-5 w-full table-fixed border-collapse')}>
-              <thead>
-                <tr
-                  className={clsx(
-                    'border border-x-white-0 border-b-primary-1 border-t-white-0 py-3',
-                  )}
-                >
-                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
-                    <div className={clsx('text-center text-sm text-black-600')}>項目</div>
-                  </th>
-                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
-                    <div className={clsx('text-center text-sm text-black-600')}>年度</div>
-                  </th>
-                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
-                    <div className={clsx('text-center text-sm text-black-600')}>金額</div>
-                  </th>
-                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
-                    <div className={clsx('text-center text-sm text-black-600')}>作成日時</div>
-                  </th>
-                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
-                    <div className={clsx('text-center text-sm text-black-600')}>更新日時</div>
-                  </th>
-                  <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
-                    <div className={clsx('text-center text-sm text-black-600')}></div>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {props.budgets.map((budgetItem, index) => (
-                  <tr key={budgetItem.id}>
-                    {props.sources.map((sourceItem) => (
-                      <td
-                        key={sourceItem.id}
-                        className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}
+      <Tabs variant='soft-rounded' className={clsx('primary-1')}>
+        <TabList className={clsx('mx-10 mt-10')}>
+          <Tab>収入</Tab>
+          <Tab>支出</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Card>
+              <div className={clsx('mx-5 mt-10')}>
+                <div className={clsx('flex')}>
+                  <Title title={'収入一覧'} />
+                  <select className={clsx('w-100 ')}>
+                    <option value='2021'>2021</option>
+                    <option value='2022'>2022</option>
+                  </select>
+                </div>
+                <div className={clsx('flex justify-end')}>
+                  <OpenAddModalButton sources={sources} years={years}>
+                    <RiAddCircleLine
+                      size={20}
+                      style={{
+                        marginRight: 5,
+                      }}
+                    />
+                    収入登録
+                  </OpenAddModalButton>
+                </div>
+                <div className={clsx('w-100 mb-2 p-5')}>
+                  <table className={clsx('mb-5 w-full table-fixed border-collapse')}>
+                    <thead>
+                      <tr
+                        className={clsx(
+                          'border border-x-white-0 border-b-primary-1 border-t-white-0 py-3',
+                        )}
                       >
-                        {sourceItem.name}
-                      </td>
-                    ))}
-                    {props.years.map((yearItem) => (
-                      <td
-                        key={yearItem.id}
-                        className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>収入元</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>年度</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>金額</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>作成日時</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>更新日時</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}></div>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {props.budgets.map((budgetItem, index) => (
+                        <tr key={budgetItem.id}>
+                          {props.sources.map((sourceItem) => (
+                            <td
+                              key={sourceItem.id}
+                              className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}
+                            >
+                              {sourceItem.name}
+                            </td>
+                          ))}
+                          {props.years.map((yearItem) => (
+                            <td
+                              key={yearItem.id}
+                              className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}
+                            >
+                              {yearItem.year}
+                            </td>
+                          ))}
+                          <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                            {budgetItem.price}
+                          </td>
+                          <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                            {formatDate(budgetItem.createdAt ? budgetItem.createdAt : '')}
+                          </td>
+                          <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                            {formatDate(budgetItem.updatedAt ? budgetItem.updatedAt : '')}
+                          </td>
+                          <td className={clsx('content-center p-3 text-black-600')}>
+                            <div className={clsx('flex text-center')}>
+                              <div className={clsx('flex-auto')}>
+                                <OpenEditModalButton
+                                  id={budgetItem.id ? budgetItem.id : 0}
+                                  sources={sources}
+                                  years={years}
+                                />
+                              </div>
+                              <div className={clsx('flex-auto')}>
+                                <OpenDeleteModalButton id={budgetItem.id ? budgetItem.id : 0} />
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                    <tfoot
+                      className={clsx(
+                        'border border-x-white-0 border-t-primary-1 border-b-white-0',
+                      )}
+                    >
+                      <tr>
+                        <th />
+                        <th className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                          合計金額
+                        </th>
+                        <th className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                          {totalFee}
+                        </th>
+                        <th />
+                      </tr>
+                    </tfoot>
+                  </table>
+                </div>
+              </div>
+            </Card>
+          </TabPanel>
+          <TabPanel>
+            <Card>
+              <div className={clsx('mx-5 mt-10')}>
+                <div className={clsx('flex')}>
+                  <Title title={'支出一覧'} />
+                  <select className={clsx('w-100 ')}>
+                    <option value='2021'>2021</option>
+                    <option value='2022'>2022</option>
+                  </select>
+                </div>
+                <div className={clsx('flex justify-end')}>
+                  <OpenAddModalButton sources={sources} years={years}>
+                    <RiAddCircleLine
+                      size={20}
+                      style={{
+                        marginRight: 5,
+                      }}
+                    />
+                    支出登録
+                  </OpenAddModalButton>
+                </div>
+                <div className={clsx('w-100 mb-2 p-5')}>
+                  <table className={clsx('mb-5 w-full table-fixed border-collapse')}>
+                    <thead>
+                      <tr
+                        className={clsx(
+                          'border border-x-white-0 border-b-primary-1 border-t-white-0 py-3',
+                        )}
                       >
-                        {yearItem.year}
-                      </td>
-                    ))}
-                    <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
-                      {budgetItem.price}
-                    </td>
-                    <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
-                      {formatDate(budgetItem.createdAt ? budgetItem.createdAt : '')}
-                    </td>
-                    <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
-                      {formatDate(budgetItem.updatedAt ? budgetItem.updatedAt : '')}
-                    </td>
-                    <td className={clsx('content-center p-3 text-black-600')}>
-                      <div className={clsx('flex text-center')}>
-                        <div className={clsx('flex-auto')}>
-                          <OpenEditModalButton
-                            id={budgetItem.id ? budgetItem.id : 0}
-                            sources={sources}
-                            years={years}
-                          />
-                        </div>
-                        <div className={clsx('flex-auto')}>
-                          <OpenDeleteModalButton id={budgetItem.id ? budgetItem.id : 0} />
-                        </div>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-              <tfoot
-                className={clsx('border border-x-white-0 border-t-primary-1 border-b-white-0')}
-              >
-                <tr>
-                  <th />
-                  <th className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>合計金額</th>
-                  <th className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>{totalFee}</th>
-                  <th />
-                </tr>
-              </tfoot>
-            </table>
-          </div>
-        </div>
-      </Card>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>支出元</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>項目</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>金額</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>作成日時</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}>更新日時</div>
+                        </th>
+                        <th className={clsx('w-1/6 border-b-primary-1 pb-2')}>
+                          <div className={clsx('text-center text-sm text-black-600')}></div>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {props.budgets.map((budgetItem, index) => (
+                        <tr key={budgetItem.id}>
+                          <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                            総務局
+                          </td>
+                          <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                            消耗品代
+                          </td>
+                          <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                            {budgetItem.price}
+                          </td>
+                          <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                            {formatDate(budgetItem.createdAt ? budgetItem.createdAt : '')}
+                          </td>
+                          <td className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                            {formatDate(budgetItem.updatedAt ? budgetItem.updatedAt : '')}
+                          </td>
+                          <td className={clsx('content-center p-3 text-black-600')}>
+                            <div className={clsx('flex text-center')}>
+                              <div className={clsx('flex-auto')}>
+                                <OpenEditModalButton
+                                  id={budgetItem.id ? budgetItem.id : 0}
+                                  sources={sources}
+                                  years={years}
+                                />
+                              </div>
+                              <div className={clsx('flex-auto')}>
+                                <OpenDeleteModalButton id={budgetItem.id ? budgetItem.id : 0} />
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                    <tfoot
+                      className={clsx(
+                        'border border-x-white-0 border-t-primary-1 border-b-white-0',
+                      )}
+                    >
+                      <tr>
+                        <th />
+                        <th className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                          合計金額
+                        </th>
+                        <th className={clsx('py-3 pt-4 pb-3 text-center text-black-600')}>
+                          {totalFee}
+                        </th>
+                        <th />
+                      </tr>
+                    </tfoot>
+                  </table>
+                </div>
+              </div>
+            </Card>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </MainLayout>
   );
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #462 

# 概要
<!-- 開発内容の概要を記載 -->
予算一覧ページに収入と支出のタブ追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `[URL](http://localhost:3000/budgets)`
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/83533261/219827925-91e426ea-5eaf-45d5-bc3d-13d071a4e3d1.png">
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/83533261/219827949-f0ac0a78-e9b9-49e6-8f10-7a0247173517.png">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- コンテナを立ち上げて，'http://localhost:3000/budgets'にアクセスして確認お願いします．
-
-

# 備考
- 支出側のカラムとかは全部適当です．
- 「予算」と「支出」でタブ分けするより，「予算」一覧ページ内で「支出」と「収入」をタブ分けした方がいい気がします．
