### PR TITLE
立て替えの代わりに備考の列を追加 & 購入報告ページのリファクタリング

### DIFF
--- a/view/next-project/src/components/purchasereports/DetailModal.tsx
+++ b/view/next-project/src/components/purchasereports/DetailModal.tsx
@@ -51,190 +51,128 @@ const DetailModal: FC<ModalProps> = (props) => {
 
   return (
     <Modal>
-      <div className={clsx('w-full')}>
-        <div className={clsx('mr-5 grid w-full justify-items-end')}>
-          <RiCloseCircleLine size={'23px'} color={'gray'} onClick={onClose} />
+      <div className='ml-auto w-fit'>
+        <RiCloseCircleLine size={'23px'} color={'gray'} onClick={onClose} />
+      </div>
+      <div className='w-fit mx-auto mb-10'>
+        <p className='text-2xl font-thin text-black-600'>報告の詳細</p>
+      </div>
+      <div className='mx-auto mb-10 grid w-9/10 grid-cols-4 justify-items-end gap-y-3 gap-x-10'>
+        <p className='text-black-600'>ID</p>
+        <div className='w-full border-b border-b-primary-1 text-right'>
+          <p>{props.purchaseReportViewItem && props.purchaseReportViewItem.purchaseReport.id}</p>
         </div>
-      </div>
-      <div
-        className={clsx(
-          'mb-8 grid w-full justify-items-center text-2xl font-thin leading-8 tracking-widest text-black-600',
-        )}
-      >
-        報告の詳細
-      </div>
-      <div className={clsx('mb-8 grid grid-cols-12 gap-4')}>
-        <div className={clsx('col-span-1 grid')} />
-        <div className={clsx('col-span-10 grid')}>
-          <div className={clsx('my-2 grid w-full grid-cols-12')}>
-            <div className={clsx('col-span-3 mr-2 grid justify-items-end')}>
-              <div className={clsx('text-md flex items-center text-black-600')}>ID</div>
-            </div>
-            <div
-              className={clsx(
-                'col-span-3 grid w-full border border-x-white-0 border-b-primary-1 border-t-white-0 pl-1',
-              )}
-            >
-              {props.purchaseReportViewItem && props.purchaseReportViewItem.purchaseReport.id}
-            </div>
-            <div className={clsx('col-span-3 mr-2 grid justify-items-end')}>
-              <div className={clsx('text-md flex items-center text-black-600')}>合計金額</div>
-            </div>
-            <div
-              className={clsx(
-                'col-span-3 grid w-full border border-x-white-0 border-b-primary-1 border-t-white-0 pl-1',
-              )}
-            >
-              {props.purchaseReportViewItem &&
-                TotalFee(
-                  props.purchaseReportViewItem.purchaseReport,
-                  props.purchaseReportViewItem.purchaseItems,
-                )}
-            </div>
-          </div>
-          <div className={clsx('col-span-1 grid ')} />
-          <div className={clsx('my-2 grid w-full grid-cols-12')}>
-            <div className={clsx('col-span-3 mr-2 grid justify-items-end')}>
-              <div className={clsx('text-md flex items-center text-black-600')}>報告した局</div>
-            </div>
-            <div
-              className={clsx(
-                'col-span-3 grid w-full border border-x-white-0 border-b-primary-1 border-t-white-0 pl-1',
-              )}
-            >
-              {props.purchaseReportViewItem &&
-                props.purchaseReportViewItem.reportUser.bureauID === 1 &&
-                '総務局'}
-              {props.purchaseReportViewItem &&
-                props.purchaseReportViewItem.reportUser.bureauID === 2 &&
-                '渉外局'}
-              {props.purchaseReportViewItem &&
-                props.purchaseReportViewItem.reportUser.bureauID === 3 &&
-                '財務局'}
-              {props.purchaseReportViewItem &&
-                props.purchaseReportViewItem.reportUser.bureauID === 4 &&
-                '企画局'}
-              {props.purchaseReportViewItem &&
-                props.purchaseReportViewItem.reportUser.bureauID === 5 &&
-                '政策局'}
-              {props.purchaseReportViewItem &&
-                props.purchaseReportViewItem.reportUser.bureauID === 6 &&
-                '情報局'}
-            </div>
-            <div className={clsx('col-span-3 mr-2 grid justify-items-end')}>
-              <div className={clsx('text-md flex items-center text-black-600')}>報告日</div>
-            </div>
-            <div
-              className={clsx(
-                'col-span-3 grid w-full border border-x-white-0 border-b-primary-1 border-t-white-0 pl-1',
-              )}
-            >
-              {props.purchaseReportViewItem &&
-                formatDate(
-                  props.purchaseReportViewItem.purchaseReport.createdAt
-                    ? props.purchaseReportViewItem.purchaseReport.createdAt
-                    : '',
-                )}
-            </div>
-          </div>
-          <div className={clsx('my-2 grid w-full grid-cols-12')}>
-            <div className={clsx('col-span-3 mr-2 grid justify-items-end')}>
-              <div className={clsx('text-md flex items-center text-black-600')}>割引</div>
-            </div>
-            <div
-              className={clsx(
-                'col-span-3 grid w-full border border-x-white-0 border-b-primary-1 border-t-white-0 pl-1',
-              )}
-            >
-              {props.purchaseReportViewItem && props.purchaseReportViewItem.purchaseReport.discount}
-            </div>
-            <div className={clsx('col-span-3 mr-2 grid justify-items-end')}>
-              <div className={clsx('text-md flex items-center text-black-600')}>加算</div>
-            </div>
-            <div
-              className={clsx(
-                'col-span-3 grid w-full border border-x-white-0 border-b-primary-1 border-t-white-0 pl-1',
-              )}
-            >
-              {props.purchaseReportViewItem && props.purchaseReportViewItem.purchaseReport.addition}
-            </div>
-          </div>
-          <div className={clsx('my-2 grid w-full grid-cols-12')}></div>
-          <div className={clsx('col-span-1 grid ')} />
+        <p className='text-black-600'>合計金額</p>
+        <div className='w-full border-b border-b-primary-1 text-right'>
+          {props.purchaseReportViewItem &&
+            TotalFee(
+              props.purchaseReportViewItem.purchaseReport,
+              props.purchaseReportViewItem.purchaseItems,
+            )}
+        </div>
+        <p className='text-black-600'>報告した局</p>
+        <div className='w-full border-b border-b-primary-1 text-right'>
+          {props.purchaseReportViewItem &&
+            props.purchaseReportViewItem.reportUser.bureauID === 1 &&
+            '総務局'}
+          {props.purchaseReportViewItem &&
+            props.purchaseReportViewItem.reportUser.bureauID === 2 &&
+            '渉外局'}
+          {props.purchaseReportViewItem &&
+            props.purchaseReportViewItem.reportUser.bureauID === 3 &&
+            '財務局'}
+          {props.purchaseReportViewItem &&
+            props.purchaseReportViewItem.reportUser.bureauID === 4 &&
+            '企画局'}
+          {props.purchaseReportViewItem &&
+            props.purchaseReportViewItem.reportUser.bureauID === 5 &&
+            '政策局'}
+          {props.purchaseReportViewItem &&
+            props.purchaseReportViewItem.reportUser.bureauID === 6 &&
+            '情報局'}
+        </div>
+        <p className='text-black-600'>報告日</p>
+        <div className='w-full border-b border-b-primary-1 text-right'>
+          {props.purchaseReportViewItem &&
+            formatDate(
+              props.purchaseReportViewItem.purchaseReport.createdAt
+                ? props.purchaseReportViewItem.purchaseReport.createdAt
+                : '',
+            )}
+        </div>
+        <p className='text-black-600'>割引</p>
+        <div className='w-full border-b border-b-primary-1 text-right'>
+          {props.purchaseReportViewItem && props.purchaseReportViewItem.purchaseReport.discount}
+        </div>
+        <p className='text-black-600'>加算</p>
+        <div className='w-full border-b border-b-primary-1 text-right'>
+          {props.purchaseReportViewItem && props.purchaseReportViewItem.purchaseReport.addition}
+        </div>
+        <p className='text-black-600'>立替先</p>
+        <div className='w-full border-b border-b-primary-1 text-right'>
+          {props.purchaseReportViewItem && props.purchaseReportViewItem.purchaseReport.remark}
         </div>
       </div>
 
-      <div className={clsx('mt-2 mb-5 grid w-full justify-items-center text-base text-black-600')}>
-        購入物品
+      <div className='w-fit mx-auto mb-10'>
+        <p className='text-2xl font-thin text-black-600'>購入物品</p>
       </div>
-      <div className={clsx('grid h-[20rem] w-full justify-items-center')}>
-        <div
-          className={clsx('w-6/7 overflow-auto border border-x-0 border-t-0 border-b-primary-1')}
-        >
-          <table className={clsx('w-full table-fixed border-collapse')}>
+      <div className='grid h-[20rem] w-full justify-items-center'>
+        <div className='w-6/7 overflow-auto border border-x-0 border-t-0 border-b-primary-1'>
+          <table className='w-full table-fixed border-collapse'>
             <thead>
-              <tr
-                className={clsx('border border-x-white-0 border-b-primary-1 border-t-white-0 py-3')}
-              >
+              <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
                 {user.roleID === 1 ? (
-                  <th className={clsx('w-3/12 pb-2')}>
-                    <div className={clsx('text-center text-sm text-black-600')}>品名</div>
+                  <th className='w-3/12 pb-2'>
+                    <div className='text-center text-sm text-black-600'>品名</div>
                   </th>
                 ) : (
-                  <th className={clsx('w-4/12 pb-2')}>
-                    <div className={clsx('text-center text-sm text-black-600')}>品名</div>
+                  <th className='w-4/12 pb-2'>
+                    <div className='text-center text-sm text-black-600'>品名</div>
                   </th>
                 )}
-                <th className={clsx('w-2/12 border-b-primary-1 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>単価</div>
+                <th className='w-2/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>単価</div>
                 </th>
-                <th className={clsx('w-1/12 border-b-primary-1 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>個数</div>
+                <th className='w-1/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>個数</div>
                 </th>
-                <th className={clsx('w-3/12 border-b-primary-1 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>詳細</div>
+                <th className='w-3/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>詳細</div>
                 </th>
-                <th className={clsx('w-2/12 border-b-primary-1 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>URL</div>
+                <th className='w-2/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>URL</div>
                 </th>
                 {user.roleID === 3 ? (
-                  <th className={clsx('w-2/12 border-b-primary-1 pb-2')}>
-                    <div className={clsx('text-center text-sm text-black-600')}>局長確認</div>
+                  <th className='w-2/12 border-b-primary-1 pb-2'>
+                    <div className='text-center text-sm text-black-600'>局長確認</div>
                   </th>
                 ) : null}
               </tr>
             </thead>
-            <tbody
-              className={clsx('w-full border border-x-white-0 border-b-primary-1 border-t-white-0')}
-            >
-              {/* <div className={clsx('flex items-start')}> */}
+            <tbody className='w-full border border-x-white-0 border-b-primary-1 border-t-white-0'>
+              {/* <div className='flex items-start'> */}
               {props.purchaseReportViewItem?.purchaseItems.map((purchaseItem) => (
-                <tr key={purchaseItem.id} className={clsx('w-full')}>
-                  <td className={clsx('border-b py-3')}>
-                    <div className={clsx('text-center text-sm text-black-300')}>
-                      {purchaseItem.item}
-                    </div>
+                <tr key={purchaseItem.id} className='w-full'>
+                  <td className='border-b py-3'>
+                    <div className='text-center text-sm text-black-300'>{purchaseItem.item}</div>
                   </td>
-                  <td className={clsx('border-b py-3')}>
-                    <div className={clsx('text-center text-sm text-black-300')}>
-                      {purchaseItem.price}
-                    </div>
+                  <td className='border-b py-3'>
+                    <div className='text-center text-sm text-black-300'>{purchaseItem.price}</div>
                   </td>
-                  <td className={clsx('border-b py-3')}>
-                    <div className={clsx('text-center text-sm text-black-300')}>
+                  <td className='border-b py-3'>
+                    <div className='text-center text-sm text-black-300'>
                       {purchaseItem.quantity}
                     </div>
                   </td>
-                  <td className={clsx('border-b py-3')}>
-                    <div className={clsx('text-center text-sm text-black-300')}>
-                      {purchaseItem.detail}
-                    </div>
+                  <td className='border-b py-3'>
+                    <div className='text-center text-sm text-black-300'>{purchaseItem.detail}</div>
                   </td>
-                  <td className={clsx('border-b py-3')}>
-                    <div className={clsx('text-center text-sm text-black-300')}>
-                      <div className={clsx('flex justify-center')}>
+                  <td className='border-b py-3'>
+                    <div className='text-center text-sm text-black-300'>
+                      <div className='flex justify-center'>
                         <a
-                          className={clsx('mx-1')}
+                          className='mx-1'
                           href={purchaseItem.url}
                           target='_blank'
                           rel='noopener noreferrer'
@@ -243,7 +181,7 @@ const DetailModal: FC<ModalProps> = (props) => {
                         </a>
                         <Tooltip text={'copy URL'}>
                           <RiFileCopyLine
-                            className={clsx('mx-1')}
+                            className='mx-1'
                             size={'16px'}
                             onClick={() => {
                               navigator.clipboard.writeText(purchaseItem.url);
@@ -254,8 +192,8 @@ const DetailModal: FC<ModalProps> = (props) => {
                     </div>
                   </td>
                   {user.roleID === 3 ? (
-                    <td className={clsx('border-b py-3')}>
-                      <div className={clsx('text-center text-sm text-black-300')}>
+                    <td className='border-b py-3'>
+                      <div className='text-center text-sm text-black-300'>
                         <Checkbox checked={purchaseItem.financeCheck} disabled={true} />
                       </div>
                     </td>
@@ -266,7 +204,7 @@ const DetailModal: FC<ModalProps> = (props) => {
           </table>
         </div>
       </div>
-      <div className={clsx('mt-3 grid w-full justify-items-center')}>
+      <div className='mt-3 grid w-full justify-items-center'>
         {props.isDelete && (
           <RedButton
             onClick={() => {

--- a/view/next-project/src/components/purchasereports/EditModal.tsx
+++ b/view/next-project/src/components/purchasereports/EditModal.tsx
@@ -170,40 +170,31 @@ export default function EditModal(props: ModalProps) {
 
   // 購入物品の情報
   const content = (data: PurchaseItem) => (
-    <div className={clsx('my-6 grid grid-cols-12 gap-4')}>
-      <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-        <div className={clsx('text-md flex items-center text-black-600')}>物品名</div>
+    <div className='my-6 grid grid-cols-4 justify-items-center items-center gap-4 w-9/10 mx-auto'>
+      <p className='text-lg text-black-600'>物品名</p>
+      <div className='col-span-3 w-full'>
+        <Input className='w-full' id={String(data.id)} value={data.item} onChange={formDataListHandler('item')} />
       </div>
-      <div className={clsx('col-span-10 grid w-full')}>
-        <Input id={String(data.id)} value={data.item} onChange={formDataListHandler('item')} />
+      <p className='text-lg text-black-600'>単価</p>
+      <div className='col-span-3 w-full'>
+        <Input className='w-full' id={String(data.id)} value={data.price} onChange={formDataListHandler('price')} />
       </div>
-      <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-        <div className={clsx('text-md flex items-center text-black-600')}>単価</div>
-      </div>
-      <div className={clsx('col-span-10 grid w-full')}>
-        <Input id={String(data.id)} value={data.price} onChange={formDataListHandler('price')} />
-      </div>
-      <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-        <div className={clsx('text-md flex items-center text-black-600')}>個数</div>
-      </div>
-      <div className={clsx('col-span-10 grid w-full')}>
+      <p className='text-lg text-black-600'>個数</p>
+      <div className='col-span-3 w-full'>
         <Input
+          className='w-full' 
           id={String(data.id)}
           value={data.quantity}
           onChange={formDataListHandler('quantity')}
         />
       </div>
-      <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-        <div className={clsx('text-md flex items-center text-black-600')}>詳細</div>
+      <p className='text-lg text-black-600'>詳細</p>
+      <div className='col-span-3 w-full'>
+        <Input className='w-full' id={String(data.id)} value={data.detail} onChange={formDataListHandler('detail')} />
       </div>
-      <div className={clsx('col-span-10 grid w-full')}>
-        <Input id={String(data.id)} value={data.detail} onChange={formDataListHandler('detail')} />
-      </div>
-      <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-        <div className={clsx('text-md flex items-center text-black-600')}>URL</div>
-      </div>
-      <div className={clsx('col-span-10 grid w-full')}>
-        <Input id={String(data.id)} value={data.url} onChange={formDataListHandler('url')} />
+      <p className='text-lg text-black-600'>URL</p>
+      <div className='col-span-3 w-full'>
+        <Input className='w-full' id={String(data.id)} value={data.url} onChange={formDataListHandler('url')} />
       </div>
     </div>
   );
@@ -211,9 +202,9 @@ export default function EditModal(props: ModalProps) {
   return (
     <>
       {props.isOpen ? (
-        <Modal className='!w-1/2'>
-          <div className={clsx('w-full')}>
-            <div className={clsx('mr-5 grid w-full justify-items-end')}>
+        <Modal className='w-1/2'>
+          <div className='w-full'>
+            <div className='w-fit ml-auto'>
               <CloseButton
                 onClick={() => {
                   props.setIsOpen(false);
@@ -221,70 +212,58 @@ export default function EditModal(props: ModalProps) {
               />
             </div>
           </div>
-          <div className={clsx('mb-10 grid w-full justify-items-center text-xl text-black-600')}>
-            購入物品の修正
+          <div className='mb-10 w-fit mx-auto text-xl text-black-600'>
+            <p>購入物品の修正</p>
           </div>
-          <div className={clsx('my-6 grid grid-cols-12 gap-4')}>
-            <div className={clsx('col-span-1 grid')} />
-            <div className={clsx('col-span-10 grid w-full')}>
+          <div>
+            <div>
               {/* 購入物品があればステッパで表示、なければないと表示  */}
               {formDataList.length > 0 ? (
                 <Stepper stepNum={formDataList.length} activeStep={activeStep} isDone={isDone}>
                   {!isDone && <>{content(formDataList[activeStep - 1])}</>}
                 </Stepper>
               ) : (
-                <div className={clsx('ml-5 grid justify-items-center')}>
+                <div className='ml-5 grid justify-items-center'>
                   <Title>報告した物品はありません</Title>
                 </div>
               )}
               {isDone ? (
                 // 編集完了した時に完了と戻るボタンを表示
-                <div className={clsx('my-10 grid grid-cols-12 gap-4')}>
-                  <div className={clsx('col-span-1 grid')} />
-                  <div className={clsx('col-span-10 grid w-full justify-items-center')}>
-                    <div className={clsx('mb-6 grid w-full grid-cols-12 gap-4')}>
-                      <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-                        <div className={clsx('text-md flex items-center text-black-600')}>割引</div>
-                      </div>
-                      <div className={clsx('col-span-10 grid w-full')}>
-                        <Input value={formData.discount} onChange={formDataHandler('discount')} />
-                      </div>
-                      <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-                        <div className={clsx('text-md flex items-center text-black-600')}>加算</div>
-                      </div>
-                      <div className={clsx('col-span-10 grid w-full')}>
-                        <Input value={formData.addition} onChange={formDataHandler('addition')} />
-                      </div>
-                      <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-                        <div className={clsx('text-md flex items-center text-black-600')}>備考</div>
-                      </div>
-                      <div className={clsx('col-span-10 grid w-full')}>
-                        <Textarea value={formData.remark} onChange={formDataHandler('remark')} />
-                      </div>
+                <>
+                  <div className='w-9/10 mb-6 grid mx-auto grid-cols-4 gap-4 my-5 justify-items-center items-center'>
+                    <p className='text-lg text-black-600'>割引</p>
+                    <div className='col-span-3 w-full'>
+                      <Input className='w-full' value={formData.discount} onChange={formDataHandler('discount')} />
                     </div>
-                    <div className={clsx('flex')}>
-                      <OutlinePrimaryButton onClick={reset} className={'mx-2'}>
-                        戻る
-                      </OutlinePrimaryButton>
-                      <PrimaryButton
-                        className={'mx-2'}
-                        onClick={() => {
-                          submit(formDataList, formData, props.purchaseReportId);
-                        }}
-                      >
-                        編集完了
-                      </PrimaryButton>
+                    <p className='text-lg text-black-600'>加算</p>
+                    <div className='col-span-3 w-full'>
+                      <Input className='w-full' value={formData.addition} onChange={formDataHandler('addition')} />
+                    </div>
+                    <p className='text-lg text-black-600'>備考</p>
+                    <div className='col-span-3 w-full'>
+                      <Textarea className='w-full' value={formData.remark} onChange={formDataHandler('remark')} />
                     </div>
                   </div>
-                  <div className={clsx('col-span-1 grid')} />
-                </div>
+                  <div className='flex flex-row gap-4 justify-center'>
+                    <OutlinePrimaryButton onClick={reset}>
+                      戻る
+                    </OutlinePrimaryButton>
+                    <PrimaryButton
+                      onClick={() => {
+                        submit(formDataList, formData, props.purchaseReportId);
+                      }}
+                    >
+                      編集完了
+                    </PrimaryButton>
+                  </div>
+                </>
               ) : (
                 <>
-                  <div className={clsx('mt-6 grid grid-cols-12 gap-4')}>
-                    <div className={clsx('col-span-1 grid')} />
-                    <div className={clsx('col-span-10 grid justify-items-center')}>
+                  <div className='mt-6 grid grid-cols-12 gap-4'>
+                    <div className='col-span-1 grid'/>
+                    <div className='col-span-10 grid justify-items-center'>
                       {formDataList.length > 0 ? (
-                        <div className={clsx('flex')}>
+                        <div className='flex'>
                           {/* stepが1より大きい時のみ戻るボタンを表示 */}
                           {activeStep > 1 && (
                             <OutlinePrimaryButton onClick={prevStep} className={'mx-2'}>
@@ -300,7 +279,7 @@ export default function EditModal(props: ModalProps) {
                               isFinanceCheckHandler(formDataList[activeStep - 1].id, true);
                             }}
                           >
-                            <div className={clsx('flex')}>
+                            <div className='flex'>
                               {activeStep === formDataList.length
                                 ? '登録して編集を完了'
                                 : '登録して次へ'}
@@ -309,7 +288,7 @@ export default function EditModal(props: ModalProps) {
                           </PrimaryButton>
                         </div>
                       ) : (
-                        <div className={clsx('flex')}>
+                        <div className='flex'>
                           <OutlinePrimaryButton
                             onClick={() => {
                               props.setIsOpen(false);
@@ -321,12 +300,12 @@ export default function EditModal(props: ModalProps) {
                         </div>
                       )}
                     </div>
-                    <div className={clsx('col-span-1 grid')} />
+                    <div className='col-span-1 grid'/>
                   </div>
                 </>
               )}
             </div>
-            <div className={clsx('col-span-1 grid')} />
+            <div className='col-span-1 grid'/>
           </div>
         </Modal>
       ) : null}

--- a/view/next-project/src/components/purchasereports/PurchaseReportAddModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportAddModal.tsx
@@ -184,44 +184,36 @@ export default function PurchaseReportAddModal(props: ModalProps) {
   // 購入物品の情報
   const content = (data: PurchaseItem) => (
     <>
-      <div className={clsx('my-6 grid grid-cols-12 gap-4')}>
-        <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-          <div className={clsx('text-md flex items-center text-black-600')}>物品名</div>
+      <div className='my-6 grid grid-cols-5 gap-4 w-9/10 mx-auto'>
+        <p className='text-black-600'>物品名</p>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' id={String(data.id)} value={data.item} onChange={formDataListHandler('item')} />
         </div>
-        <div className={clsx('col-span-10 grid w-full')}>
-          <Input id={String(data.id)} value={data.item} onChange={formDataListHandler('item')} />
+        <p className='text-black-600'>単価</p>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' id={String(data.id)} value={data.price} onChange={formDataListHandler('price')} />
         </div>
-        <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-          <div className={clsx('text-md flex items-center text-black-600')}>単価</div>
-        </div>
-        <div className={clsx('col-span-10 grid w-full')}>
-          <Input id={String(data.id)} value={data.price} onChange={formDataListHandler('price')} />
-        </div>
-        <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-          <div className={clsx('text-md flex items-center text-black-600')}>個数</div>
-        </div>
-        <div className={clsx('col-span-10 grid w-full')}>
+        <p className='text-black-600'>個数</p>
+        <div className='col-span-4 w-full'>
           <Input
+            className='w-full' 
             id={String(data.id)}
             value={data.quantity}
             onChange={formDataListHandler('quantity')}
           />
         </div>
-        <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-          <div className={clsx('text-md flex items-center text-black-600')}>詳細</div>
-        </div>
-        <div className={clsx('col-span-10 grid w-full')}>
+        <p className='text-black-600'>詳細</p>
+        <div className='col-span-4 w-full'>
           <Input
+            className='w-full' 
             id={String(data.id)}
             value={data.detail}
             onChange={formDataListHandler('detail')}
           />
         </div>
-        <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-          <div className={clsx('text-md flex items-center text-black-600')}>URL</div>
-        </div>
-        <div className={clsx('col-span-10 grid w-full')}>
-          <Input id={String(data.id)} value={data.url} onChange={formDataListHandler('url')} />
+        <p className='text-black-600'>URL</p>
+        <div className='col-span-4 w-full'>
+          <Input className='w-full' id={String(data.id)} value={data.url} onChange={formDataListHandler('url')} />
         </div>
       </div>
     </>
@@ -230,134 +222,108 @@ export default function PurchaseReportAddModal(props: ModalProps) {
   return (
     <>
       {props.isOpen ? (
-        <Modal className='!w-1/2'>
-          <div className={clsx('w-full')}>
-            <div className={clsx('mr-5 grid w-full justify-items-end')}>
-              <CloseButton
-                onClick={() => {
-                  props.setIsOpen(false);
-                }}
-              />
-            </div>
+        <Modal className='w-1/2'>
+          <div className='w-fit ml-auto'>
+            <CloseButton
+              onClick={() => {
+                props.setIsOpen(false);
+              }}
+            />
           </div>
-          <div className={clsx('mb-10 grid w-full justify-items-center text-xl text-black-600')}>
+          <div className='mb-10 w-fit mx-auto text-xl text-black-600'>
             購入物品の登録
           </div>
-          <div className={clsx('my-6 grid grid-cols-12 gap-4')}>
-            <div className={clsx('col-span-1 grid')} />
-            <div className={clsx('col-span-10 grid w-full')}>
-              <Stepper stepNum={props.purchaseItemNum} activeStep={activeStep} isDone={isDone}>
-                {!isDone && <>{content(formDataList[activeStep - 1])}</>}
-              </Stepper>
-              {isDone ? (
-                <>
-                  <div className={clsx('my-10 grid grid-cols-12 gap-4')}>
-                    <div className={clsx('col-span-1 grid')} />
-                    <div className={clsx('col-span-10 grid w-full justify-items-center')}>
-                      <div className={clsx('my-6 grid w-full grid-cols-12 gap-4')}>
-                        <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-                          <div className={clsx('text-md flex items-center text-black-600')}>
-                            割引
-                          </div>
-                        </div>
-                        <div className={clsx('col-span-10 grid w-full')}>
-                          <Input value={formData.discount} onChange={formDataHandler('discount')} />
-                        </div>
-                        <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-                          <div className={clsx('text-md flex items-center text-black-600')}>
-                            加算
-                          </div>
-                        </div>
-                        <div className={clsx('col-span-10 grid w-full')}>
-                          <Input value={formData.addition} onChange={formDataHandler('addition')} />
-                        </div>
-                        <div className={clsx('col-span-2 mr-2 grid justify-items-end')}>
-                          <div className={clsx('text-md flex items-center text-black-600')}>
-                            備考
-                          </div>
-                        </div>
-                        <div className={clsx('col-span-10 grid w-full')}>
-                          <Textarea value={formData.remark} onChange={formDataHandler('remark')} />
-                        </div>
-                      </div>
-                    </div>
+            <Stepper stepNum={props.purchaseItemNum} activeStep={activeStep} isDone={isDone}>
+              {!isDone && <>{content(formDataList[activeStep - 1])}</>}
+            </Stepper>
+            {isDone ? (
+              <>
+                <div className='mt-3 mb-10 w-9/10 mx-auto grid grid-cols-5 items-center justify-items-center gap-4'>
+                  <p className='text-black-600'>
+                    割引
+                  </p>
+                  <div className='col-span-4 w-full'>
+                    <Input className='w-full' value={formData.discount} onChange={formDataHandler('discount')} />
                   </div>
-                  <div className={clsx('col-span-1 grid')} />
-                  <div className={clsx('grid justify-items-center')}>
-                    <div className={clsx('flex')}>
-                      <OutlinePrimaryButton onClick={reset} className={'mx-2'}>
-                        戻る
-                      </OutlinePrimaryButton>
-                      <PrimaryButton
-                        className={'mx-2'}
-                        onClick={() => {
-                          submit(formDataList);
-                        }}
-                      >
-                        登録して確認
-                      </PrimaryButton>
-                      {isOpen && (
-                        <PurchaseReportConfirmModal
-                          purchaseReportId={purchaseReportId}
-                          formDataList={formDataList}
-                          isOpen={isOpen}
-                          setIsOpen={setIsOpen}
-                        />
-                      )}
-                    </div>
+                  <p className='text-black-600'>
+                    加算
+                  </p>
+                  <div className='col-span-4 w-full'>
+                    <Input className='w-full' value={formData.addition} onChange={formDataHandler('addition')} />
                   </div>
-                </>
-              ) : (
-                <>
-                  <div className={clsx('mt-6 grid grid-cols-12 gap-4')}>
-                    <div className={clsx('col-span-1 grid')} />
-                    <div className={clsx('col-span-10 grid justify-items-center')}>
-                      <div className={clsx('flex')}>
-                        {/* stepが1より大きい時のみ戻るボタンを表示 */}
-                        {activeStep > 1 && (
-                          <OutlinePrimaryButton onClick={prevStep} className={'mx-2'}>
-                            戻る
-                          </OutlinePrimaryButton>
-                        )}
-                        <PrimaryButton
-                          className={'mx-2 pl-4 pr-2'}
-                          onClick={() => {
-                            {
-                              activeStep === steps.length ? setIsDone(true) : nextStep();
-                            }
-                            isFinanceCheckHandler(formDataList[activeStep - 1].id, true);
-                          }}
-                        >
-                          <div className={clsx('flex')}>
-                            {activeStep === steps.length ? '登録して確認' : '登録して次へ'}
-                            <RiArrowDropRightLine size={23} />
-                          </div>
-                        </PrimaryButton>
-                      </div>
-                    </div>
-                    <div className={clsx('col-span-1 grid')} />
-                    {!props.isOnlyReported && (
-                      <div className={clsx('col-span-12 grid w-full justify-items-center')}>
-                        <UnderlinePrimaryButton
-                          className={'pr-1'}
-                          onClick={() => {
-                            {
-                              activeStep === steps.length ? setIsDone(true) : nextStep();
-                            }
-                            isFinanceCheckHandler(formDataList[activeStep - 1].id, false);
-                          }}
-                        >
-                          {activeStep === steps.length ? '登録せずに確認' : '登録せずに次へ'}
-                          <RiArrowDropRightLine size={23} />
-                        </UnderlinePrimaryButton>
-                      </div>
+                  <p className='text-black-600'>
+                    備考
+                  </p>
+                  <div className='col-span-4 w-full'>
+                    <Textarea className='w-full' value={formData.remark} onChange={formDataHandler('remark')} />
+                  </div>
+                </div>
+                <div className='grid justify-items-center'>
+                  <div className='flex flex-row gap-4'>
+                    <OutlinePrimaryButton onClick={reset}>
+                      戻る
+                    </OutlinePrimaryButton>
+                    <PrimaryButton
+                      onClick={() => {
+                        submit(formDataList);
+                      }}
+                    >
+                      登録して確認
+                    </PrimaryButton>
+                    {isOpen && (
+                      <PurchaseReportConfirmModal
+                        purchaseReportId={purchaseReportId}
+                        formDataList={formDataList}
+                        isOpen={isOpen}
+                        setIsOpen={setIsOpen}
+                      />
                     )}
                   </div>
-                </>
-              )}
-            </div>
-            <div className={clsx('col-span-1 grid')} />
-          </div>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className='flex flex-col items-center gap-5'>
+                  <div className='flex flex-row gap-4'>
+                    {/* stepが1より大きい時のみ戻るボタンを表示 */}
+                    {activeStep > 1 && (
+                      <OutlinePrimaryButton onClick={prevStep}>
+                        戻る
+                      </OutlinePrimaryButton>
+                    )}
+                    <PrimaryButton
+                      onClick={() => {
+                        {
+                          activeStep === steps.length ? setIsDone(true) : nextStep();
+                        }
+                        isFinanceCheckHandler(formDataList[activeStep - 1].id, true);
+                      }}
+                    >
+                      <div className='flex'>
+                        {activeStep === steps.length ? '登録して確認' : '登録して次へ'}
+                        <RiArrowDropRightLine size={23} />
+                      </div>
+                    </PrimaryButton>
+                  </div>
+                  {!props.isOnlyReported && (
+                    <div className='col-span-12 grid w-full justify-items-center'>
+                      <UnderlinePrimaryButton
+                        className={'pr-1'}
+                        onClick={() => {
+                          {
+                            activeStep === steps.length ? setIsDone(true) : nextStep();
+                          }
+                          isFinanceCheckHandler(formDataList[activeStep - 1].id, false);
+                        }}
+                      >
+                        {activeStep === steps.length ? '登録せずに確認' : '登録せずに次へ'}
+                        <RiArrowDropRightLine size={23} />
+                      </UnderlinePrimaryButton>
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
         </Modal>
       ) : null}
     </>

--- a/view/next-project/src/components/purchasereports/PurchaseReportConfirmModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportConfirmModal.tsx
@@ -54,17 +54,17 @@ export default function PurchaseItemNumModal(props: ModalProps) {
 
   const PurchaseItemTable = (purchaseItems: PurchaseItem[]) => {
     return (
-      <table className={clsx('table-fixed border-collapse')}>
+      <table className='table-fixed border-collapse'>
         <thead>
-          <tr className={clsx('border border-x-white-0 border-b-primary-1 border-t-white-0 py-3')}>
+          <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
             {tableColumns.map((tableColumn: string) => (
-              <th key={tableColumn} className={clsx('border-b-primary-1 px-6 pb-2')}>
-                <div className={clsx('text-center text-sm text-black-600')}>{tableColumn}</div>
+              <th key={tableColumn} className='border-b-primary-1 px-6 pb-2'>
+                <div className='text-center text-sm text-black-600'>{tableColumn}</div>
               </th>
             ))}
           </tr>
         </thead>
-        <tbody className={clsx('border border-x-white-0 border-b-primary-1 border-t-white-0')}>
+        <tbody className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
           {purchaseItems.map((purchaseItem, index) => (
             <tr key={purchaseItem.id}>
               <td
@@ -74,7 +74,7 @@ export default function PurchaseItemNumModal(props: ModalProps) {
                   index === purchaseItems.length - 1 ? 'pb-4 pt-3' : 'border-b py-3',
                 )}
               >
-                <div className={clsx('text-center text-sm text-black-300')}>
+                <div className='text-center text-sm text-black-300'>
                   {purchaseItem.item}
                 </div>
               </td>
@@ -85,7 +85,7 @@ export default function PurchaseItemNumModal(props: ModalProps) {
                   index === purchaseItems.length - 1 ? 'pb-4 pt-3' : 'border-b py-3',
                 )}
               >
-                <div className={clsx('text-center text-sm text-black-300')}>
+                <div className='text-center text-sm text-black-300'>
                   {purchaseItem.price}
                 </div>
               </td>
@@ -96,7 +96,7 @@ export default function PurchaseItemNumModal(props: ModalProps) {
                   index === purchaseItems.length - 1 ? 'pb-4 pt-3' : 'border-b py-3',
                 )}
               >
-                <div className={clsx('text-center text-sm text-black-300')}>
+                <div className='text-center text-sm text-black-300'>
                   {purchaseItem.quantity}
                 </div>
               </td>
@@ -107,7 +107,7 @@ export default function PurchaseItemNumModal(props: ModalProps) {
                   index === purchaseItems.length - 1 ? 'pb-4 pt-3' : 'border-b py-3',
                 )}
               >
-                <div className={clsx('text-center text-sm text-black-300')}>
+                <div className='text-center text-sm text-black-300'>
                   {purchaseItem.detail}
                 </div>
               </td>
@@ -118,10 +118,10 @@ export default function PurchaseItemNumModal(props: ModalProps) {
                   index === purchaseItems.length - 1 ? 'pb-4 pt-3' : 'border-b py-3',
                 )}
               >
-                <div className={clsx('text-center text-sm text-black-300')}>
-                  <div className={clsx('flex')}>
+                <div className='text-center text-sm text-black-300'>
+                  <div className='flex'>
                     <a
-                      className={clsx('mx-1')}
+                      className='mx-1'
                       href={purchaseItem.url}
                       target='_blank'
                       rel='noopener noreferrer'
@@ -130,7 +130,7 @@ export default function PurchaseItemNumModal(props: ModalProps) {
                     </a>
                     <Tooltip text={'copy URL'}>
                       <RiFileCopyLine
-                        className={clsx('mx-1')}
+                        className='mx-1'
                         size={'16px'}
                         onClick={() => {
                           navigator.clipboard.writeText(purchaseItem.url);
@@ -149,80 +149,51 @@ export default function PurchaseItemNumModal(props: ModalProps) {
 
   return (
     <Modal>
-      <div className={clsx('w-full')}>
-        <div className={clsx('mr-5 grid w-full justify-items-end')}>
+      <div className='w-full'>
+        <div className='mr-5 grid w-full justify-items-end'>
           <CloseButton onClick={onClose} />
         </div>
       </div>
-      <div className={clsx('mb-10 grid w-full justify-items-center text-xl text-black-600')}>
+      <div className='mb-10 grid w-full justify-items-center text-xl text-black-600'>
         購入申請
       </div>
-      <div className={clsx('mb-4 grid grid-cols-12 gap-4')}>
-        <div className={clsx('col-span-1 grid')} />
-        <div className={clsx('col-span-10 grid')}>
-          <div
-            className={clsx(
-              'text-md h-100 grid w-full justify-items-center font-bold text-black-300',
-            )}
-          >
-            購入物品
+      <div className='flex flex-col items-center gap-5'>
+        <div className='w-fit mx-auto font-bold text-black-300'>購入物品</div>
+        <div className='w-full max-h-60 overflow-scroll'>{PurchaseItemTable(reportedPurchaseItems)}</div>
+        <div className='w-fit mx-auto font-bold text-black-300'>
+          登録しなかった物品
+        </div>
+        {notReportedPurchaseItems.length === 0 ? (
+          <div className='w-fit mx-auto text-black-300'>
+            登録しなかった物品はありません
           </div>
-          <div className={clsx('w-100 mb-2 p-5')}>{PurchaseItemTable(reportedPurchaseItems)}</div>
-          <div
-            className={clsx(
-              'text-md h-100 grid w-full justify-items-center font-bold text-black-300',
-            )}
-          >
-            登録しなかった物品
-          </div>
-          {notReportedPurchaseItems.length === 0 ? (
-            <div className={clsx('text-md h-100 grid w-full justify-items-center text-black-300')}>
-              登録しなかった物品はありません
+        ) : (
+          <>
+            <div className='w-fit mx-auto font-bold text-black-300'>
+              購入しなかったものとして処理します
             </div>
-          ) : (
-            <>
-              <div
-                className={clsx('text-md h-100 grid w-full justify-items-center text-black-300')}
-              >
-                購入しなかったものとして処理します
-              </div>
-              <div className={clsx('w-100 mb-2 p-5')}>
-                {PurchaseItemTable(notReportedPurchaseItems)}
-              </div>
-            </>
+            <div className='w-full'>
+              {PurchaseItemTable(notReportedPurchaseItems)}
+            </div>
+          </>
+        )}
+        <div className='flex justify-center'>
+          <PrimaryButton
+            onClick={() => {
+              onOpen();
+            }}
+          >
+            確認を終了
+          </PrimaryButton>
+          {isOpen && (
+            <ReceiptModal
+              purchaseReportId={props.purchaseReportId}
+              isOpen={isOpen}
+              setIsOpen={setIsOpen}
+            />
           )}
         </div>
-        <div className={clsx('col-span-1 grid ')} />
       </div>
-      <div className={clsx('grid w-full grid-cols-12 pb-5')}>
-        <div className={clsx('h-100 col-span-1 grid')} />
-        <div
-          className={clsx(
-            'text-md h-100 col-span-10 grid w-full justify-items-center pr-3 text-black-600',
-          )}
-        >
-          <div className={clsx('flex')}>
-            <div className={clsx('mx-2')}>
-              <PrimaryButton
-                onClick={() => {
-                  onOpen();
-                }}
-              >
-                確認を終了
-              </PrimaryButton>
-              {isOpen && (
-                <ReceiptModal
-                  purchaseReportId={props.purchaseReportId}
-                  isOpen={isOpen}
-                  setIsOpen={setIsOpen}
-                />
-              )}
-            </div>
-          </div>
-        </div>
-        <div className={clsx('h-100 col-span-1 grid')} />
-      </div>
-      <div className={clsx('grid justify-items-center px-1')}></div>
     </Modal>
   );
 }

--- a/view/next-project/src/components/purchasereports/PurchaseReportConfirmModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportConfirmModal.tsx
@@ -47,11 +47,6 @@ export default function PurchaseItemNumModal(props: ModalProps) {
   }, [props.formDataList, setReportedPurchaseItems, setNotReportedPurchaseItems]);
 
   useEffect(() => {
-    console.log(reportedPurchaseItems);
-    console.log(notReportedPurchaseItems);
-  }, [reportedPurchaseItems, notReportedPurchaseItems]);
-
-  useEffect(() => {
     if (router.isReady) {
       judgeItems();
     }

--- a/view/next-project/src/pages/purchasereports/index.tsx
+++ b/view/next-project/src/pages/purchasereports/index.tsx
@@ -124,46 +124,49 @@ export default function PurchaseReports(props: Props) {
         <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       </Head>
       <Card>
-        <div className={clsx('mx-5 mt-10')}>
-          <div className={clsx('flex')}>
+        <div className='mx-5 mt-10'>
+          <div className='flex'>
             <Title title={'購入報告一覧'} />
-            <select className={clsx('w-100 ')}>
+            <select className='w-100 '>
               <option value='2021'>2021</option>
               <option value='2022'>2022</option>
             </select>
           </div>
-          <div className={clsx('flex justify-end')}>
+          <div className='flex justify-end'>
             <OpenAddModalButton>報告登録</OpenAddModalButton>
           </div>
         </div>
-        <div className={clsx('w-100 mb-2 p-5')}>
-          <table className={clsx('mb-5 w-full table-fixed border-collapse')}>
+        <div className='w-100 mb-2 p-5'>
+          <table className='mb-5 w-full table-fixed border-collapse'>
             <thead>
               <tr
-                className={clsx('border border-x-white-0 border-b-primary-1 border-t-white-0 py-3')}
+                className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'
               >
-                <th className={clsx('w-2/12 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>財務局長チェック</div>
+                <th className='w-1/12 pb-2'>
+                  <div className='text-center text-sm text-black-600'>財務局長チェック</div>
                 </th>
-                <th className={clsx('w-2/12 border-b-primary-1 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>報告した局</div>
+                <th className='w-2/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>報告した局</div>
                 </th>
-                <th className={clsx('w-1/12 border-b-primary-1 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>報告日</div>
+                <th className='w-1/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>報告日</div>
                 </th>
-                <th className={clsx('w-1/12 border-b-primary-1 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>期限日</div>
+                <th className='w-1/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>期限日</div>
                 </th>
-                <th className={clsx('w-4/12 border-b-primary-1 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>購入物品</div>
+                <th className='w-3/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>購入物品</div>
                 </th>
-                <th className={clsx('w-1/12 border-b-primary-1 pb-2')}>
-                  <div className={clsx('text-center text-sm text-black-600')}>合計金額</div>
+                <th className='w-1/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>合計金額</div>
                 </th>
-                <th className={clsx('w-1/12 border-b-primary-1 pb-2')}></th>
+                <th className='w-2/12 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>立替先</div>
+                </th>
+                <th className='w-1/12 border-b-primary-1 pb-2'></th>
               </tr>
             </thead>
-            <tbody className={clsx('border border-x-white-0 border-b-primary-1 border-t-white-0')}>
+            <tbody className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
               {props.purchaseReportView.map((purchaseReportViewItem, index) => (
                 <tr key={purchaseReportViewItem.purchaseReport.id}>
                   <td
@@ -181,7 +184,7 @@ export default function PurchaseReports(props: Props) {
                       );
                     }}
                   >
-                    <div className={clsx('text-center text-sm text-black-600')}>
+                    <div className='text-center text-sm text-black-600'>
                       {user.roleID === 3
                         ? changeableCheckboxContent(
                             purchaseReportViewItem.purchaseReport.financeCheck,
@@ -206,7 +209,7 @@ export default function PurchaseReports(props: Props) {
                       );
                     }}
                   >
-                    <div className={clsx('text-center text-sm text-black-600')}>
+                    <div className='text-center text-sm text-black-600'>
                       {purchaseReportViewItem.orderUser.bureauID === 1 && '総務局'}
                       {purchaseReportViewItem.orderUser.bureauID === 2 && '渉外局'}
                       {purchaseReportViewItem.orderUser.bureauID === 3 && '財務局'}
@@ -230,7 +233,7 @@ export default function PurchaseReports(props: Props) {
                       );
                     }}
                   >
-                    <div className={clsx('text-center text-sm text-black-600')}>
+                    <div className='text-center text-sm text-black-600'>
                       {formatDate(
                         purchaseReportViewItem.purchaseReport.createdAt
                           ? purchaseReportViewItem.purchaseReport.createdAt
@@ -253,7 +256,7 @@ export default function PurchaseReports(props: Props) {
                       );
                     }}
                   >
-                    <div className={clsx('text-center text-sm text-black-600')}>
+                    <div className='text-center text-sm text-black-600'>
                       {purchaseReportViewItem.purchaseOrder.deadline}
                     </div>
                   </td>
@@ -306,7 +309,7 @@ export default function PurchaseReports(props: Props) {
                       );
                     }}
                   >
-                    <div className={clsx('text-center text-sm text-black-600')}>
+                    <div className='text-center text-sm text-black-600'>
                       {TotalFee(
                         purchaseReportViewItem.purchaseReport,
                         purchaseReportViewItem.purchaseItems,
@@ -319,9 +322,28 @@ export default function PurchaseReports(props: Props) {
                       index === 0 ? 'pt-4 pb-3' : 'py-3',
                       index === purchaseReports.length - 1 ? 'pb-4 pt-3' : 'border-b py-3',
                     )}
+                    onClick={() => {
+                      onOpen(
+                        purchaseReportViewItem.purchaseReport.id
+                          ? purchaseReportViewItem.purchaseReport.id
+                          : 0,
+                        purchaseReportViewItem,
+                      );
+                    }}
                   >
-                    <div className={clsx('flex')}>
-                      <div className={clsx('mx-1')}>
+                    <div className='text-center text-sm text-black-600'>
+                      {purchaseReportViewItem.purchaseReport.remark || '無し'}
+                    </div>
+                  </td>
+                  <td
+                    className={clsx(
+                      'px-1',
+                      index === 0 ? 'pt-4 pb-3' : 'py-3',
+                      index === purchaseReports.length - 1 ? 'pb-4 pt-3' : 'border-b py-3',
+                    )}
+                  >
+                    <div className='flex'>
+                      <div className='mx-1'>
                         <OpenEditModalButton
                           id={
                             purchaseReportViewItem.purchaseReport.id
@@ -336,7 +358,7 @@ export default function PurchaseReports(props: Props) {
                           }
                         />
                       </div>
-                      <div className={clsx('mx-1')}>
+                      <div className='mx-1'>
                         <OpenDeleteModalButton
                           id={
                             purchaseReportViewItem.purchaseReport.id

--- a/view/next-project/src/pages/purchasereports/index.tsx
+++ b/view/next-project/src/pages/purchasereports/index.tsx
@@ -161,7 +161,7 @@ export default function PurchaseReports(props: Props) {
                   <div className='text-center text-sm text-black-600'>合計金額</div>
                 </th>
                 <th className='w-2/12 border-b-primary-1 pb-2'>
-                  <div className='text-center text-sm text-black-600'>立替先</div>
+                  <div className='text-center text-sm text-black-600'>備考</div>
                 </th>
                 <th className='w-1/12 border-b-primary-1 pb-2'></th>
               </tr>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #484

# 概要
<!-- 開発内容の概要を記載 -->

- 立て替えしてる人を表示するために、そのカラムを増やそうかと思ったが、備考で補えそうなのでパス
- その代わりに備考を列に追加した
- clsxや複雑なstyleをなくし、シンプルなものにリファクタリングした

# テスト項目
<!-- テストしてほしい内容を記載 -->

- [ ] 購入報告ページが見え、備考列が追加されているか
- [ ] 購入報告が追加できるか
- [ ] 購入報告が編集できるか

# 備考

- 途中でdevelopブランチにコミットしていることに気づいて戻したので、リファクタリングと備考関係の作業がくっついてる部分がります！ごめんなさい！