### PR TITLE
expenses/detailsの修正

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -482,7 +482,7 @@ const docTemplate = `{
                 },
             },
         },
-        "/expense": {
+        "/expenses": {
             "get": {
                 tags: ["expense"],
                 "description": "expenseの一覧の取得",
@@ -516,7 +516,7 @@ const docTemplate = `{
                 ],
             },
         },
-        "/expense/details": {
+        "/expenses/details": {
             "get": {
                 tags: ["expense"],
                 "description": "expenseに紐づくpurchase_itemの一覧を取得",
@@ -527,18 +527,7 @@ const docTemplate = `{
                 }
             },
         },
-        "/expense/updateTP": {
-            "get": {
-                tags: ["expense"],
-                "description": "totalPriceの更新",
-                "responses": {
-                    "200": {
-                        "description": "totalPriceの更新",
-                    }
-                }
-            },
-        },
-        "/expense/{id}": {
+        "/expenses/{id}": {
             "get": {
                 tags: ["expense"],
                 "description": "IDで指定されたexpenseの取得",
@@ -606,7 +595,7 @@ const docTemplate = `{
                 },
             },
         },
-        "/expense/{id}/details": {
+        "/expenses/{id}/details": {
             "get": {
                 tags: ["expense"],
                 "description": "IDで指定されたexpenseに紐づくpurchase_itemsを取得",

--- a/api/externals/repository/expense_repository.go
+++ b/api/externals/repository/expense_repository.go
@@ -22,6 +22,7 @@ type ExpenseRepository interface {
 	Destroy(context.Context, string) error
 	FindLatestRecord(context.Context) (*sql.Row, error)
 	AllItemInfo(context.Context, string) (*sql.Rows, error)
+	AllOrderAndReportInfo(context.Context, string) (*sql.Rows, error)
 }
 
 func NewExpenseRepository(c db.Client, ac abstract.Crud) ExpenseRepository {
@@ -145,32 +146,36 @@ func (er *expenseRepository) UpdateTotalprice(c context.Context) error {
 	return er.crud.UpdateDB(c, query)
 }
 
-// expense_idに紐づいたpuchase_itemの金額が多い順に3件取得
-func (er *expenseRepository) AllItemInfo(c context.Context, expenseID string) (*sql.Rows, error) {
+// purchase_order_idに紐づいたpuchase_itemsを取得
+func (er *expenseRepository) AllItemInfo(c context.Context, purchaseOrderID string) (*sql.Rows, error) {
 	query := `
 		SELECT
-			pi.id,
-			pi.item
+			*
 		FROM
 			purchase_items pi
+		WHERE
+			pi.purchase_order_id = ` + purchaseOrderID + `
+		AND
+			pi.finance_check IS true;`
+	return er.crud.Read(c, query)
+}
+
+// expense_idに紐づくpurchase_ordersを取得
+func (er *expenseRepository) AllOrderAndReportInfo(c context.Context, expenseID string) (*sql.Rows, error) {
+	query := `
+		SELECT
+			*
+		FROM
+			purchase_reports pr
 		INNER JOIN
 			purchase_orders po
 		ON
-			pi.purchase_order_id = po.id
-		INNER JOIN
-			purchase_reports pr
-		ON
-			pi.purchase_order_id = pr.purchase_order_id
-		WHERE
-			po.expense_id =` + expenseID + `
-		AND
-			pi.finance_check IS true
-		AND
-			po.finance_check IS true
+			pr.purchase_order_id = po.id 
+		WHERE po.expense_id = ` + expenseID + `
 		AND
 			pr.finance_check IS true
-		ORDER BY
-			pi.price*pi.quantity
-		DESC LIMIT 3`
+		AND
+			po.finance_check IS true
+		`
 	return er.crud.Read(c, query)
 }

--- a/api/internals/domain/expense.go
+++ b/api/internals/domain/expense.go
@@ -14,11 +14,12 @@ type Expense struct {
 }
 
 type ExpenseDetails struct {
-	Expense       Expense            `json:"expense"`
-	PurchaseItems []PurchaseItemInfo `json:"purchaseItem"`
+	Expense         Expense          `json:"expense"`
+	PurchaseDetails []PurchaseDetail `json:"purchaseDetails"`
 }
 
-type PurchaseItemInfo struct {
-	ID   int    `json:"id"`
-	Item string `json:"item"`
+type PurchaseDetail struct {
+	PurchaseOrder  PurchaseOrder  `json:"purchaseOrder"`
+	PurchaseReport PurchaseReport `json:"purchaseReport"`
+	PurchaseItems  []PurchaseItem `json:"purchaseItems"`
 }

--- a/api/internals/usecase/expense_usecase.go
+++ b/api/internals/usecase/expense_usecase.go
@@ -124,8 +124,11 @@ func (e *expenseUseCase) UpdateExpenseTP(c context.Context) error {
 func (e *expenseUseCase) GetExpenseDetails(c context.Context) ([]domain.ExpenseDetails, error) {
 	expenseDetail := domain.ExpenseDetails{}
 	var expenseDetails []domain.ExpenseDetails
-	purchaseItem := domain.PurchaseItemInfo{}
-	var purchaseItems []domain.PurchaseItemInfo
+	purchaseDetail := domain.PurchaseDetail{}
+	var purchaseDetails []domain.PurchaseDetail
+	purchaseItem := domain.PurchaseItem{}
+	var purchaseItems []domain.PurchaseItem
+
 	rows, err := e.rep.All(c)
 	if err != nil {
 		return nil, err
@@ -142,28 +145,65 @@ func (e *expenseUseCase) GetExpenseDetails(c context.Context) ([]domain.ExpenseD
 		if err != nil {
 			return nil, err
 		}
-		rows, err := e.rep.AllItemInfo(c, strconv.Itoa(int(expenseDetail.Expense.ID)))
+		rows, err := e.rep.AllOrderAndReportInfo(c, strconv.Itoa(int(expenseDetail.Expense.ID)))
 		for rows.Next() {
 			err := rows.Scan(
-				&purchaseItem.ID,
-				&purchaseItem.Item,
+				&purchaseDetail.PurchaseReport.ID,
+				&purchaseDetail.PurchaseReport.UserID,
+				&purchaseDetail.PurchaseReport.Discount,
+				&purchaseDetail.PurchaseReport.Addition,
+				&purchaseDetail.PurchaseReport.FinanceCheck,
+				&purchaseDetail.PurchaseReport.PurchaseOrderID,
+				&purchaseDetail.PurchaseReport.Remark,
+				&purchaseDetail.PurchaseReport.CreatedAt,
+				&purchaseDetail.PurchaseReport.UpdatedAt,
+				&purchaseDetail.PurchaseOrder.ID,
+				&purchaseDetail.PurchaseOrder.DeadLine,
+				&purchaseDetail.PurchaseOrder.UserID,
+				&purchaseDetail.PurchaseOrder.ExpenseID,
+				&purchaseDetail.PurchaseOrder.FinanceCheck,
+				&purchaseDetail.PurchaseOrder.CreatedAt,
+				&purchaseDetail.PurchaseOrder.UpdatedAt,
 			)
 			if err != nil {
 				return nil, err
 			}
-			purchaseItems = append(purchaseItems, purchaseItem)
+			rows, err := e.rep.AllItemInfo(c, strconv.Itoa(int(purchaseDetail.PurchaseOrder.ID)))
+			for rows.Next() {
+				err := rows.Scan(
+					&purchaseItem.ID,
+					&purchaseItem.Item,
+					&purchaseItem.Price,
+					&purchaseItem.Quantity,
+					&purchaseItem.Detail,
+					&purchaseItem.Url,
+					&purchaseItem.ID,
+					&purchaseItem.FinanceCheck,
+					&purchaseItem.CreatedAt,
+					&purchaseItem.UpdatedAt,
+				)
+				if err != nil {
+					return nil, err
+				}
+				purchaseItems = append(purchaseItems, purchaseItem)
+			}
+			purchaseDetail.PurchaseItems = purchaseItems
+			purchaseItems = nil
+			purchaseDetails = append(purchaseDetails, purchaseDetail)
 		}
-		expenseDetail.PurchaseItems = purchaseItems
+		expenseDetail.PurchaseDetails = purchaseDetails
+		purchaseDetails = nil
 		expenseDetails = append(expenseDetails, expenseDetail)
-		purchaseItems = nil
 	}
 	return expenseDetails, nil
 }
 
 func (e *expenseUseCase) GetExpenseDetailByID(c context.Context, id string) (domain.ExpenseDetails, error) {
 	expenseDetail := domain.ExpenseDetails{}
-	purchaseItem := domain.PurchaseItemInfo{}
-	var purchaseItems []domain.PurchaseItemInfo
+	purchaseDetail := domain.PurchaseDetail{}
+	var purchaseDetails []domain.PurchaseDetail
+	purchaseItem := domain.PurchaseItem{}
+	var purchaseItems []domain.PurchaseItem
 	row, err := e.rep.Find(c, id)
 	err = row.Scan(
 		&expenseDetail.Expense.ID,
@@ -176,17 +216,52 @@ func (e *expenseUseCase) GetExpenseDetailByID(c context.Context, id string) (dom
 	if err != nil {
 		return expenseDetail, err
 	}
-	rows, err := e.rep.AllItemInfo(c, strconv.Itoa(int(expenseDetail.Expense.ID)))
+	rows, err := e.rep.AllOrderAndReportInfo(c, strconv.Itoa(int(expenseDetail.Expense.ID)))
 	for rows.Next() {
 		err := rows.Scan(
-			&purchaseItem.ID,
-			&purchaseItem.Item,
+			&purchaseDetail.PurchaseReport.ID,
+			&purchaseDetail.PurchaseReport.UserID,
+			&purchaseDetail.PurchaseReport.Discount,
+			&purchaseDetail.PurchaseReport.Addition,
+			&purchaseDetail.PurchaseReport.FinanceCheck,
+			&purchaseDetail.PurchaseReport.PurchaseOrderID,
+			&purchaseDetail.PurchaseReport.Remark,
+			&purchaseDetail.PurchaseReport.CreatedAt,
+			&purchaseDetail.PurchaseReport.UpdatedAt,
+			&purchaseDetail.PurchaseOrder.ID,
+			&purchaseDetail.PurchaseOrder.DeadLine,
+			&purchaseDetail.PurchaseOrder.UserID,
+			&purchaseDetail.PurchaseOrder.ExpenseID,
+			&purchaseDetail.PurchaseOrder.FinanceCheck,
+			&purchaseDetail.PurchaseOrder.CreatedAt,
+			&purchaseDetail.PurchaseOrder.UpdatedAt,
 		)
 		if err != nil {
 			return expenseDetail, err
 		}
-		purchaseItems = append(purchaseItems, purchaseItem)
+		rows, err := e.rep.AllItemInfo(c, strconv.Itoa(int(purchaseDetail.PurchaseOrder.ID)))
+		for rows.Next() {
+			err := rows.Scan(
+				&purchaseItem.ID,
+				&purchaseItem.Item,
+				&purchaseItem.Price,
+				&purchaseItem.Quantity,
+				&purchaseItem.Detail,
+				&purchaseItem.Url,
+				&purchaseItem.ID,
+				&purchaseItem.FinanceCheck,
+				&purchaseItem.CreatedAt,
+				&purchaseItem.UpdatedAt,
+			)
+			if err != nil {
+				return expenseDetail, err
+			}
+			purchaseItems = append(purchaseItems, purchaseItem)
+		}
+		purchaseDetail.PurchaseItems = purchaseItems
+		purchaseItems = nil
+		purchaseDetails = append(purchaseDetails, purchaseDetail)
 	}
-	expenseDetail.PurchaseItems = purchaseItems
+	expenseDetail.PurchaseDetails = purchaseDetails
 	return expenseDetail, nil
 }

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -194,12 +194,12 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.DELETE("/bureaus/:id", r.bureauController.DestroyBureau)
 
 	//expenseのRoute
-	e.GET("/expense", r.expenseController.IndexExpense)
-	e.GET("/expense/updateTP", r.expenseController.UpdateExpenseTP)
-	e.GET("/expense/details", r.expenseController.IndexExpenseDetails)
-	e.GET("/expense/:id", r.expenseController.ShowExpense)
-	e.GET("/expense/:id/details", r.expenseController.ShowExpenseDetail)
-	e.POST("/expense", r.expenseController.CreateExpense)
-	e.PUT("/expense/:id", r.expenseController.UpdateExpense)
-	e.DELETE("/expense/:id", r.expenseController.DestroyExpense)
+	e.GET("/expenses", r.expenseController.IndexExpense)
+	e.GET("/expenses/updateTP", r.expenseController.UpdateExpenseTP)
+	e.GET("/expenses/details", r.expenseController.IndexExpenseDetails)
+	e.GET("/expenses/:id", r.expenseController.ShowExpense)
+	e.GET("/expenses/:id/details", r.expenseController.ShowExpenseDetail)
+	e.POST("/expenses", r.expenseController.CreateExpense)
+	e.PUT("/expenses/:id", r.expenseController.UpdateExpense)
+	e.DELETE("/expenses/:id", r.expenseController.DestroyExpense)
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#472 
<!-- 対応したIssue番号を記載 -->
resolve #472

# 概要
<!-- 開発内容の概要を記載 -->
- 同じブランチのはずですがpushしたらPR別れちゃいました
- エンドポイントの変更 `/expenses`
- `expense/details`で支出に紐づく購入報告、購入申請、購入物品も返すようにした。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="319" alt="スクリーンショット 2023-03-19 1 52 31" src="https://user-images.githubusercontent.com/115447919/226121218-af31f1c9-3ea7-4e28-b60e-beb0e6997f69.png">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- swaggerで`/expenses`のAPIを叩き返ってくるデータを確認する
- 購入申請、購入報告、購入物品にデータを追加し、支出が適切か確認する。
-

# 備考
