### PR TITLE
expenseAPIの修正

### DIFF
--- a/api/internals/usecase/expense_usecase.go
+++ b/api/internals/usecase/expense_usecase.go
@@ -177,7 +177,7 @@ func (e *expenseUseCase) GetExpenseDetails(c context.Context) ([]domain.ExpenseD
 					&purchaseItem.Quantity,
 					&purchaseItem.Detail,
 					&purchaseItem.Url,
-					&purchaseItem.ID,
+					&purchaseItem.PurchaseOrderID,
 					&purchaseItem.FinanceCheck,
 					&purchaseItem.CreatedAt,
 					&purchaseItem.UpdatedAt,

--- a/mysql/db/expense.sql
+++ b/mysql/db/expense.sql
@@ -21,7 +21,15 @@ INSERT into expense (expense_name,yearID) values ("備品整備費",2);
 INSERT into expense (expense_name,yearID) values ("備品整備準備費",2);
 INSERT into expense (expense_name,yearID) values ("翌年度繰越金",2);
 
-CREATE TABLE tmp (
+
+-- 終端文字の変更
+DELIMITER //
+-- ストアドプロシージャ作成
+CREATE PROCEDURE updateExpense()
+BEGIN
+
+-- 1 テンポラリテーブル作成tmp,tmp
+CREATE TEMPORARY TABLE tmp (
   id int(10) NOT NULL,
   totalPrice int(10),
   purchase_reports_id int(10),
@@ -32,21 +40,11 @@ CREATE TABLE tmp (
   PRIMARY KEY (`id`)
 );
 
-CREATE TABLE tmp2 (
+CREATE TEMPORARY TABLE tmp2 (
   id int(10) NOT NULL,
   totalPrice int(10) NOT NULL,
   PRIMARY KEY (`id`)
 );
-
--- 終端文字の変更
-DELIMITER //
--- ストアドプロシージャ作成
-CREATE PROCEDURE updateExpense()
-BEGIN
-
--- 1 tmp,tmp2のテーブルデータを削除
-DELETE FROM tmp;
-DELETE FROM tmp2;
 
 -- 2 mpにpurchase_itemsのfinansu_checkがtrueのものをpurchase_orderごとに和を入れる
 INSERT INTO
@@ -111,6 +109,9 @@ ON
 	expense.id = tmp2.id
 SET
 	expense.totalPrice = tmp2.totalPrice;
+
+-- テンポラリテーブル削除
+DROP TEMPORARY TABLE tmp,tmp2;
 
 END;
 //


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#523
<!-- 対応したIssue番号を記載 -->
resolve #523

# 概要
<!-- 開発内容の概要を記載 -->
- `/expenses/details`のAPIの返すpurchase_itemsのpurchase_order_idが正しくなかったため修正した。
- expenseのtotalPriceを更新する際tmp,tmp2という2つのテーブルを使用していたが、計算に使うテーブルであるテンポラリテーブルにしてストアドプロシージャ内のみで定義、削除するようにした。
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- `/expenses`のAPIを叩き動作に問題がないか確認する。
-
-

# 備考
