### PR TITLE
api起動コマンド修正リリース

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,6 @@ services:
       dockerfile: prod.Dockerfile
     container_name: "nutfes-finansu-api"
     volumes: ["./api:/app"]
-    command: "./start.sh"
+    command: "go run main.go"
     env_file: ["./finansu.env"]
     ports: ["1323:1323"]

--- a/web/prod/config.yml
+++ b/web/prod/config.yml
@@ -4,7 +4,7 @@ protocol: http2
 
 ingress:
  - hostname: finansu.nutfes.net
-   service: http://localhost:3000
+   service: http://view:3000
  - hostname: finansu-api.nutfes.net
-   service: http://localhost:1323
+   service: http://api:1323
  - service: http_status:404


### PR DESCRIPTION
# 概要
<!-- 開発内容の概要を記載 -->
apiの起動コマンドにstart.shを使っていたが、不必要であるので、`go run`コマンドに置き換える