### PR TITLE
Feature/kubosaka/551 fix activity

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -59,6 +59,24 @@ const docTemplate = `{
                         "in": "query",
                         "description": "sponsor_id",
                         "type": "integer"
+                    },
+                    {
+                        "name": "feature",
+                        "in": "query",
+                        "description": "feature",
+                        "type": "string"
+                    },
+                    {
+                        "name": "expense",
+                        "in": "query",
+                        "description": "expense",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "remark",
+                        "in": "query",
+                        "description": "remark",
+                        "type": "string"
                     }
                 ],
             },
@@ -134,6 +152,24 @@ const docTemplate = `{
                         "description": "sponsor_id",
                         "type": "integer"
                     },
+                    {
+                        "name": "feature",
+                        "in": "query",
+                        "description": "feature",
+                        "type": "string"
+                    },
+                    {
+                        "name": "expense",
+                        "in": "query",
+                        "description": "expense",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "remark",
+                        "in": "query",
+                        "description": "remark",
+                        "type": "string"
+                    }
                 ],
             },
             "delete": {

--- a/api/externals/controller/activity_controller.go
+++ b/api/externals/controller/activity_controller.go
@@ -49,7 +49,10 @@ func (a *activityController) CreateActivity(c echo.Context) error {
 	userID := c.QueryParam("user_id")
 	isDone := c.QueryParam("is_done")
 	sponsorID := c.QueryParam("sponsor_id")
-	latastActivity, err := a.u.CreateActivity(c.Request().Context(), sponsorStyleID, userID, isDone, sponsorID)
+	feature := c.QueryParam("feature")
+	expense := c.QueryParam("expense")
+	remark := c.QueryParam("remark")
+	latastActivity, err := a.u.CreateActivity(c.Request().Context(), sponsorStyleID, userID, isDone, sponsorID, feature, expense, remark)
 	if err != nil {
 		return err
 	}
@@ -63,7 +66,10 @@ func (a *activityController) UpdateActivity(c echo.Context) error {
 	userID := c.QueryParam("user_id")
 	isDone := c.QueryParam("is_done")
 	sponsorID := c.QueryParam("sponsor_id")
-	updatedActivity, err := a.u.UpdateActivity(c.Request().Context(), id, sponsorStyleID, userID, isDone, sponsorID)
+	feature := c.QueryParam("feature")
+	expense := c.QueryParam("expense")
+	remark := c.QueryParam("remark")
+	updatedActivity, err := a.u.UpdateActivity(c.Request().Context(), id, sponsorStyleID, userID, isDone, sponsorID, feature, expense, remark)
 	if err != nil {
 		return err
 	}

--- a/api/externals/repository/activity_repository.go
+++ b/api/externals/repository/activity_repository.go
@@ -16,8 +16,8 @@ type activityRepository struct {
 type ActivityRepository interface {
 	All(context.Context) (*sql.Rows, error)
 	Find(context.Context, string) (*sql.Row, error)
-	Create(context.Context, string, string, string, string) error
-	Update(context.Context, string, string, string, string, string) error
+	Create(context.Context, string, string, string, string, string, string, string) error
+	Update(context.Context, string, string, string, string, string,string, string, string) error
 	Destroy(context.Context, string) error
 	FindDetail(context.Context) (*sql.Rows, error)
 	FindLatestRecord(c context.Context) (*sql.Row, error)
@@ -45,13 +45,16 @@ func (ar *activityRepository) Create(
 	sponsorStyleID string,
 	userID string,
 	isDone string,
-	sponsorID string) error {
+	sponsorID string,
+	feature string,
+	expense string,
+	remark string) error {
 
 	query := `
 	INSERT INTO	activities
-		(sponsor_style_id, user_id, is_done, sponsor_id)
+		(sponsor_style_id, user_id, is_done, sponsor_id, feature, expense, remark)
 	VALUES
-		(` + sponsorStyleID + "," + userID + "," + isDone + "," + sponsorID + ")"
+		(` + sponsorStyleID + "," + userID + "," + isDone + "," + sponsorID + ",'" + feature + "'," + expense +",'" + remark +"')"
 
 	return ar.crud.UpdateDB(c, query)
 }
@@ -63,7 +66,10 @@ func (ar *activityRepository) Update(
 	sponsorStyleID string,
 	userID string,
 	isDone string,
-	sponsorID string) error {
+	sponsorID string,
+	feature string,
+	expense string,
+	remark string) error {
 
 	query := `
 	UPDATE activities
@@ -72,7 +78,10 @@ func (ar *activityRepository) Update(
 		", user_id = " + userID +
 		", is_done = " + isDone +
 		", sponsor_id = " + sponsorID +
-		" where id = " + id
+		", feature = '" + feature +
+		"', expense = " + expense +
+		", remark = '" + remark +
+		"' where id = " + id
 
 	return ar.crud.UpdateDB(c, query)
 }

--- a/api/internals/domain/activity.go
+++ b/api/internals/domain/activity.go
@@ -5,18 +5,21 @@ import (
 )
 
 type Activity struct {
-	ID             int       `json:"id"`
-	SponsorStyleID uint      `json:"sponsorStyleID"`
-	UserID         uint      `json:"userID"`
-	IsDone         bool      `json:"isDone"`
-	SponsorID      uint      `json:"sponsorID"`
-	CreatedAt      time.Time `json:"createdAt"`
-	UpdatedAt      time.Time `json:"updatedAt"`
+	ID				int			`json:"id"`
+	SponsorStyleID 	uint		`json:"sponsorStyleID"`
+	UserID			uint		`json:"userID"`
+	IsDone			bool		`json:"isDone"`
+	SponsorID		uint		`json:"sponsorID"`
+	Feature 		string		`json:"feature"`
+	Expense			uint		`json:"expense"`
+	Remark			string		`json:"remark"`
+	CreatedAt		time.Time	`json:"createdAt"`
+	UpdatedAt		time.Time	`json:"updatedAt"`
 }
 
 type ActivityDetail struct {
-	Activity     Activity     `json:"sponsorActivity"`
-	Sponsor      Sponsor      `json:"sponsor"`
-	SponsorStyle SponsorStyle `json:"sponsorStyle"`
-	User         User         `json:"user"`
+	Activity		Activity		`json:"sponsorActivity"`
+	Sponsor			Sponsor			`json:"sponsor"`
+	SponsorStyle	SponsorStyle	`json:"sponsorStyle"`
+	User			User			`json:"user"`
 }

--- a/api/internals/usecase/activity_usecase.go
+++ b/api/internals/usecase/activity_usecase.go
@@ -15,8 +15,8 @@ type activityUseCase struct {
 type ActivityUseCase interface {
 	GetActivity(context.Context) ([]domain.Activity, error)
 	GetActivityByID(context.Context, string) (domain.Activity, error)
-	CreateActivity(context.Context, string, string, string, string) (domain.Activity, error)
-	UpdateActivity(context.Context, string, string, string, string, string) (domain.Activity, error)
+	CreateActivity(context.Context, string, string, string, string, string, string, string) (domain.Activity, error)
+	UpdateActivity(context.Context, string, string, string, string, string, string, string, string) (domain.Activity, error)
 	DestroyActivity(context.Context, string) error
 	GetActivityDetail(context.Context) ([]domain.ActivityDetail, error)
 }
@@ -44,6 +44,9 @@ func (a *activityUseCase) GetActivity(c context.Context) ([]domain.Activity, err
 			&activity.UserID,
 			&activity.IsDone,
 			&activity.SponsorID,
+			&activity.Feature,
+			&activity.Expense,
+			&activity.Remark,
 			&activity.CreatedAt,
 			&activity.UpdatedAt,
 		)
@@ -67,6 +70,9 @@ func (a *activityUseCase) GetActivityByID(c context.Context, id string) (domain.
 		&activity.UserID,
 		&activity.IsDone,
 		&activity.SponsorID,
+		&activity.Feature,
+		&activity.Expense,
+		&activity.Remark,
 		&activity.CreatedAt,
 		&activity.UpdatedAt,
 	)
@@ -83,10 +89,13 @@ func (a *activityUseCase) CreateActivity(
 	sponsorStyleID string,
 	userID string,
 	isDone string,
-	sponsorID string) (domain.Activity, error) {
+	sponsorID string,
+	feature string,
+	expense string,
+	remark string) (domain.Activity, error) {
 	latastActivity := domain.Activity{}
 
-	err := a.rep.Create(c, sponsorStyleID, userID, isDone, sponsorID)
+	err := a.rep.Create(c, sponsorStyleID, userID, isDone, sponsorID, feature, expense, remark)
 	row, err := a.rep.FindLatestRecord(c)
 	err = row.Scan(
 		&latastActivity.ID,
@@ -94,6 +103,9 @@ func (a *activityUseCase) CreateActivity(
 		&latastActivity.UserID,
 		&latastActivity.IsDone,
 		&latastActivity.SponsorID,
+		&latastActivity.Feature,
+		&latastActivity.Expense,
+		&latastActivity.Remark,
 		&latastActivity.CreatedAt,
 		&latastActivity.UpdatedAt,
 	)
@@ -110,9 +122,12 @@ func (a *activityUseCase) UpdateActivity(
 	sponsorStyleID string,
 	userID string,
 	isDone string,
-	sponsorID string) (domain.Activity, error) {
+	sponsorID string,
+	feature string,
+	expense string,
+	remark string) (domain.Activity, error) {
 	updatedActivity := domain.Activity{}
-	err := a.rep.Update(c, id, sponsorStyleID, userID, isDone, sponsorID)
+	err := a.rep.Update(c, id, sponsorStyleID, userID, isDone, sponsorID, feature, expense, remark)
 	row, err := a.rep.Find(c, id)
 	err = row.Scan(
 		&updatedActivity.ID,
@@ -120,6 +135,9 @@ func (a *activityUseCase) UpdateActivity(
 		&updatedActivity.UserID,
 		&updatedActivity.IsDone,
 		&updatedActivity.SponsorID,
+		&updatedActivity.Feature,
+		&updatedActivity.Expense,
+		&updatedActivity.Remark,		
 		&updatedActivity.CreatedAt,
 		&updatedActivity.UpdatedAt,
 	)
@@ -153,6 +171,9 @@ func (a *activityUseCase) GetActivityDetail(c context.Context) ([]domain.Activit
 			&activity.Activity.UserID,
 			&activity.Activity.IsDone,
 			&activity.Activity.SponsorID,
+			&activity.Activity.Feature,
+			&activity.Activity.Expense,
+			&activity.Activity.Remark,
 			&activity.Activity.CreatedAt,
 			&activity.Activity.UpdatedAt,
 			&activity.Sponsor.ID,

--- a/mysql/db/activities.sql
+++ b/mysql/db/activities.sql
@@ -6,10 +6,13 @@ CREATE TABLE activities (
   user_id int(10),
   is_done boolean,
   sponsor_id int(10),
+  feature varchar(255),
+  expense int(10),
+  remark varchar(255),
   created_at datetime not null default current_timestamp,
   updated_at datetime not null default current_timestamp on update current_timestamp,
   PRIMARY KEY (id)
 );
 
-INSERT into activities (sponsor_style_id, user_id, is_done, sponsor_id) values (1, 1, false, 1);
-INSERT into activities (sponsor_style_id, user_id, is_done, sponsor_id) values (2, 2, false, 2);
+INSERT into activities (sponsor_style_id, user_id, is_done, sponsor_id, feature, expense, remark) values (1, 1, false, 1, "なし", 11, "");
+INSERT into activities (sponsor_style_id, user_id, is_done, sponsor_id, feature, expense, remark) values (2, 2, false, 2, "クーポン", 22, "味玉or大盛無料");

--- a/view/next-project/src/components/common/Textarea/Textarea.tsx
+++ b/view/next-project/src/components/common/Textarea/Textarea.tsx
@@ -6,11 +6,13 @@ import s from './Textarea.module.css';
 interface Props {
   className?: string;
   placeholder?: string;
+  id?: string;
   value?: string | number;
   onChange?: (
     e: React.ChangeEvent<HTMLTextAreaElement> | React.ChangeEvent<HTMLInputElement>,
   ) => void;
   children?: React.ReactNode;
+  type?: string;
 }
 
 function Textarea(props: Props): JSX.Element {

--- a/view/next-project/src/components/sponsoractivities/DetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailModal.tsx
@@ -56,6 +56,29 @@ const DetailModal: FC<ModalProps> = (props) => {
           <p className='border-b border-primary-1'>{props.sponsorActivitiesViewItem.user.name}</p>
         </div>
       </div>
+      <div  className='my-10 flex flex-wrap justify-center gap-8'>
+        <div className='flex gap-3'>
+          <p>オプション</p>
+          <p className='border-b border-primary-1'>
+            {props.sponsorActivitiesViewItem.sponsorActivity.feature}
+          </p>
+        </div>
+        <div className='flex gap-3'>
+          <p>交通費</p>
+          <p className='border-b border-primary-1'>
+            {props.sponsorActivitiesViewItem.sponsorActivity.expense}円
+          </p>
+        </div>
+        <div className='flex gap-3'>
+          <p>備考</p>
+          <p className='border-b border-primary-1'>
+            {props.sponsorActivitiesViewItem.sponsorActivity.remark == '' &&(
+                        <div>なし</div>
+            )}            
+            {props.sponsorActivitiesViewItem.sponsorActivity.remark}
+          </p>
+        </div>
+      </div>
       <p className='my-5 mx-auto w-fit text-xl text-black-600'>協賛企業</p>
       <table className='w-full table-fixed border-collapse'>
         <thead>

--- a/view/next-project/src/components/sponsoractivities/DetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailModal.tsx
@@ -28,6 +28,7 @@ const DetailModal: FC<ModalProps> = (props) => {
     return datetime2;
   };
 
+
   return (
     <Modal className='w-1/2'>
       <div className='w-full'>
@@ -46,39 +47,57 @@ const DetailModal: FC<ModalProps> = (props) => {
           </p>
         </div>
         <div className='flex gap-3'>
-          <p>回収状況</p>
+          <p className='text-black-600'>回収状況</p>
           <p className='border-b border-primary-1'>
             {props.sponsorActivitiesViewItem.sponsorActivity.isDone ? '回収済み' : '未回収'}
           </p>
         </div>
         <div className='flex gap-3'>
-          <p>担当者名</p>
+          <p className='text-black-600'>担当者名</p>
           <p className='border-b border-primary-1'>{props.sponsorActivitiesViewItem.user.name}</p>
         </div>
       </div>
       <div  className='my-10 flex flex-wrap justify-center gap-8'>
         <div className='flex gap-3'>
-          <p>オプション</p>
+          <p className='text-black-600'>オプション</p>
           <p className='border-b border-primary-1'>
             {props.sponsorActivitiesViewItem.sponsorActivity.feature}
           </p>
         </div>
         <div className='flex gap-3'>
-          <p>交通費</p>
+          <p className='text-black-600'>交通費</p>
           <p className='border-b border-primary-1'>
             {props.sponsorActivitiesViewItem.sponsorActivity.expense}円
           </p>
         </div>
-        <div className='flex gap-3'>
-          <p>備考</p>
-          <p className='border-b border-primary-1'>
-            {props.sponsorActivitiesViewItem.sponsorActivity.remark == '' &&(
-                        <div>なし</div>
-            )}            
-            {props.sponsorActivitiesViewItem.sponsorActivity.remark}
-          </p>
-        </div>
       </div>
+      <p className='my-5 mx-auto w-fit text-xl text-black-600'>備考</p>
+      <table className='w-full table-fixed border-collapse'>
+        <thead>
+          <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
+          </tr>
+        </thead>
+        <tbody>
+          <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
+            <td className='py-3'>
+              <div>
+                <p className='border-primary-1'>
+                  {props.sponsorActivitiesViewItem.sponsorActivity.remark.length<36 ?(
+                    <div className = 'text-center'>
+                      {props.sponsorActivitiesViewItem.sponsorActivity.remark ==="" &&(
+                        <div>なし</div>
+                      )}
+                      {props.sponsorActivitiesViewItem.sponsorActivity.remark}
+                    </div>
+                  ):(
+                    <div>{props.sponsorActivitiesViewItem.sponsorActivity.remark}</div>
+                  )}
+                </p>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
       <p className='my-5 mx-auto w-fit text-xl text-black-600'>協賛企業</p>
       <table className='w-full table-fixed border-collapse'>
         <thead>
@@ -103,27 +122,27 @@ const DetailModal: FC<ModalProps> = (props) => {
         <tbody>
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
             <td className='py-3'>
-              <div className='text-center text-sm text-black-600'>
+              <div className='text-center text-sm'>
                 {props.sponsorActivitiesViewItem.sponsor.name}
               </div>
             </td>
             <td className='py-3'>
-              <div className='text-center text-sm text-black-600'>
+              <div className='text-center text-sm'>
                 {props.sponsorActivitiesViewItem.sponsor.tel}
               </div>
             </td>
             <td className='py-3'>
-              <div className='text-center text-sm text-black-600'>
+              <div className='text-center text-sm'>
                 {props.sponsorActivitiesViewItem.sponsor.email}
               </div>
             </td>
             <td className='py-3'>
-              <div className='text-center text-sm text-black-600'>
+              <div className='text-center text-sm'>
                 {props.sponsorActivitiesViewItem.sponsor.address}
               </div>
             </td>
             <td className='py-3'>
-              <div className='text-center text-sm text-black-600'>
+              <div className='text-center text-sm'>
                 {props.sponsorActivitiesViewItem.sponsor.representative}
               </div>
             </td>
@@ -148,17 +167,17 @@ const DetailModal: FC<ModalProps> = (props) => {
         <tbody>
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
             <td className='py-3'>
-              <div className='text-center text-sm text-black-600'>
+              <div className='text-center text-sm'>
                 {props.sponsorActivitiesViewItem.sponsorStyle.style}
               </div>
             </td>
             <td className='py-3'>
-              <div className='text-center text-sm text-black-600'>
+              <div className='text-center text-sm'>
                 {props.sponsorActivitiesViewItem.sponsorStyle.feature}
               </div>
             </td>
             <td className='py-3'>
-              <div className='text-center text-sm text-black-600'>
+              <div className='text-center text-sm'>
                 {props.sponsorActivitiesViewItem.sponsorStyle.price}
               </div>
             </td>

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -8,6 +8,7 @@ import {
   CloseButton,
   Modal,
   Select,
+  Input,
 } from '@components/common';
 import { SponsorActivity, Sponsor, SponsorStyle, User } from '@type/common';
 
@@ -96,6 +97,37 @@ export default function EditModal(props: ModalProps) {
             回収完了
           </option>
         </Select>
+      </div>
+      <p className='text-black-600'>オプション</p>
+      <div className='col-span-4 w-full'>
+        <Select
+          value={data.feature}
+          onChange={handler('feature')}
+        >
+          <option value={'ポスター'}>
+            ポスター
+          </option>
+          <option value={'クーポン'}>クーポン</option>
+          <option value={'なし'}>なし</option>
+        </Select>
+      </div>
+      <p className='text-black-600'>交通費</p>
+      <div className='col-span-4 w-full'>
+        <Input
+          className='w-full'
+          id={String(data.id)}
+          value={data.expense}
+          onChange={handler('expense')}
+        />
+      </div>
+      <p className='text-black-600'>備考</p>
+      <div className='col-span-4 w-full'>
+        <Input
+          className='w-full'
+          id={String(data.id)}
+          value={data.remark}
+          onChange={handler('remark')}
+        />
       </div>
     </div>
   );

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -9,6 +9,7 @@ import {
   Modal,
   Select,
   Input,
+  Textarea,
 } from '@components/common';
 import { SponsorActivity, Sponsor, SponsorStyle, User } from '@type/common';
 
@@ -30,7 +31,7 @@ export default function EditModal(props: ModalProps) {
   const { users, sponsors, sponsorStyles } = props;
   const handler =
     (input: string) =>
-    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => {
       setFormData({ ...formData, [input]: e.target.value });
     };
 
@@ -51,6 +52,12 @@ export default function EditModal(props: ModalProps) {
     await put(updateSponsorStyleUrl, data);
   };
 
+  const remarkCoupon = 
+  `【クーポン】[詳細 :  ○○],
+  【広告掲載内容】[企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
+    const remarkElse =
+  `【広告掲載内容】[企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
+
   // 協賛企業の情報
   const content = (data: SponsorActivity) => (
     <div className='my-6 grid grid-cols-5 items-center justify-items-center gap-4'>
@@ -69,7 +76,7 @@ export default function EditModal(props: ModalProps) {
         <Select className='w-full' onChange={(e)=>{
           setFormData({ ...formData, sponsorStyleID: Number(e.target.value) });
           if(sponsorStyles[Number(e.target.value)-1]?.style === '企業ブース'){
-            setFormData({ ...formData, feature: "なし" ,sponsorStyleID: Number(e.target.value)});
+            setFormData({ ...formData, feature: "なし" ,sponsorStyleID: Number(e.target.value),remark: ''});
           }
         }}>
           {sponsorStyles.map((sponsorStyle) => (
@@ -112,8 +119,16 @@ export default function EditModal(props: ModalProps) {
       <p className='text-black-600'>オプション</p>
       <div className='col-span-4 w-full'>
         <Select
-          value={data.feature}
-          onChange={handler('feature')}
+            value={data.feature}
+            onChange={(e)=>{
+              if(e.target.value === 'クーポン'){
+                setFormData({ ...formData, feature: e.target.value ,remark: remarkCoupon});
+              }else if(e.target.value === 'ポスター'){
+                setFormData({ ...formData, feature: e.target.value ,remark: remarkElse});
+              }else{
+                setFormData({ ...formData, feature: e.target.value ,remark: ''});
+              }
+            }}
         >
           <option value={'なし'} selected>なし</option>
           <option value={'ポスター'} disabled={sponsorStyles[data.sponsorStyleID-1]?.style === '企業ブース'}>ポスター</option>
@@ -135,7 +150,7 @@ export default function EditModal(props: ModalProps) {
       </div>
       <p className='text-black-600'>備考</p>
       <div className='col-span-4 w-full'>
-        <Input
+        <Textarea
           className='w-full'
           id={String(data.id)}
           value={data.remark}

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -25,8 +25,9 @@ export default function EditModal(props: ModalProps) {
   const router = useRouter();
 
   // 協賛企業のリスト
-  const [formData, setFormData] = useState<SponsorActivity>(props.sponsorActivity);
+  const [formData, setFormData] = useState<SponsorActivity>({...props.sponsorActivity, expense:Number((props.sponsorActivity.expense/11).toFixed(1))});
 
+  const { users, sponsors, sponsorStyles } = props;
   const handler =
     (input: string) =>
     (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
@@ -35,7 +36,12 @@ export default function EditModal(props: ModalProps) {
 
   // 協賛企業の登録の更新を行い、ページをリロード
   const submit = (data: SponsorActivity) => {
-    updateSponsorStyle(data);
+    const {expense, ...rest} = data;
+    const submitData:SponsorActivity  = {
+      expense:Math.round(expense*11),
+      ...rest
+    }
+    updateSponsorStyle(submitData);
     router.reload();
   };
 
@@ -51,7 +57,7 @@ export default function EditModal(props: ModalProps) {
       <p className='text-black-600'>企業名</p>
       <div className='col-span-4 w-full'>
         <Select className='w-full' onChange={handler('sponsorID')}>
-          {props.sponsors.map((sponsor) => (
+          {sponsors.map((sponsor) => (
             <option key={sponsor.id} value={sponsor.id} selected={sponsor.id === data.sponsorID}>
               {sponsor.name}
             </option>
@@ -60,8 +66,13 @@ export default function EditModal(props: ModalProps) {
       </div>
       <p className='text-black-600'>協賛スタイル</p>
       <div className='col-span-4 w-full'>
-        <Select className='w-full' onChange={handler('sponsorStyleID')}>
-          {props.sponsorStyles.map((sponsorStyle) => (
+        <Select className='w-full' onChange={(e)=>{
+          setFormData({ ...formData, sponsorStyleID: Number(e.target.value) });
+          if(sponsorStyles[Number(e.target.value)-1]?.style === '企業ブース'){
+            setFormData({ ...formData, feature: "なし" ,sponsorStyleID: Number(e.target.value)});
+          }
+        }}>
+          {sponsorStyles.map((sponsorStyle) => (
             <option
               key={sponsorStyle.id}
               value={sponsorStyle.id}
@@ -75,7 +86,7 @@ export default function EditModal(props: ModalProps) {
       <p className='text-black-600'>担当者名</p>
       <div className='col-span-4 w-full'>
         <Select className='w-full' onChange={handler('userID')}>
-          {props.users.map((user) => (
+          {users.map((user) => (
             <option key={user.id} value={user.id} selected={user.id === data.userID}>
               {user.name}
             </option>
@@ -104,14 +115,12 @@ export default function EditModal(props: ModalProps) {
           value={data.feature}
           onChange={handler('feature')}
         >
-          <option value={'ポスター'}>
-            ポスター
-          </option>
-          <option value={'クーポン'}>クーポン</option>
-          <option value={'なし'}>なし</option>
+          <option value={'なし'} selected>なし</option>
+          <option value={'ポスター'} disabled={sponsorStyles[data.sponsorStyleID-1]?.style === '企業ブース'}>ポスター</option>
+          <option value={'クーポン'} disabled={sponsorStyles[data.sponsorStyleID-1]?.style === '企業ブース'}>クーポン</option>
         </Select>
       </div>
-      <p className='text-black-600'>交通費</p>
+      <p className='text-black-600'>移動距離(km)</p>
       <div className='col-span-4 w-full'>
         <Input
           className='w-full'
@@ -119,6 +128,10 @@ export default function EditModal(props: ModalProps) {
           value={data.expense}
           onChange={handler('expense')}
         />
+      </div>
+      <p className='text-black-600'>交通費</p>
+      <div className='col-span-4 w-full'>
+        <p className='w-full' >{Math.round(data.expense*11)}円</p>
       </div>
       <p className='text-black-600'>備考</p>
       <div className='col-span-4 w-full'>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -9,11 +9,12 @@ import {
   OutlinePrimaryButton,
   PrimaryButton,
   Select,
-  Input
+  Input,
 } from '@components/common';
 import { SponsorActivity, Sponsor, SponsorStyle, User } from '@type/common';
+import SponsorActivities from '@/pages/sponsoractivities';
 
-const TABLE_COLUMNS = ['企業名', '協賛スタイル', '担当者名', '回収状況', 'オプション', '交通費', '備考'];
+const TABLE_COLUMNS = ['企業名', '協賛スタイル', '担当者名', '回収状況', 'オプション', '移動距離(km)', '交通費', '備考'];
 
 interface Props {
   users: User[];
@@ -52,7 +53,12 @@ export default function SponsorActivitiesAddModal(props: Props) {
 
   // 協賛活動の登録と更新を行い、ページをリロード
   const submit = (data: SponsorActivity) => {
-    addSponsorActivities(data);
+    const {expense, ...rest} = data;
+    const submitData:SponsorActivity  = {
+      expense:Math.round(expense*11),
+      ...rest
+    }
+    addSponsorActivities(submitData);
     props.setIsOpen(false);
     router.reload();
   };
@@ -80,7 +86,12 @@ export default function SponsorActivitiesAddModal(props: Props) {
       </div>
       <p className='text-black-600'>協賛スタイル</p>
       <div className='col-span-4 w-full'>
-        <Select value={data.sponsorStyleID} onChange={formDataHandler('sponsorStyleID')}>
+        <Select value={data.sponsorStyleID} onChange={(e)=>{
+          setFormData({ ...formData, sponsorStyleID: Number(e.target.value) });
+          if(sponsorStyles[Number(e.target.value)-1]?.style === '企業ブース'){
+            setFormData({ ...formData, feature: "なし" ,sponsorStyleID: Number(e.target.value)});
+          }
+        }}>
           {sponsorStyles.map((sponsorStyle: SponsorStyle) => (
             <option key={sponsorStyle.id} value={sponsorStyle.id}>
               {`${sponsorStyle.style} / ${sponsorStyle.feature} / ${sponsorStyle.price} 円`}
@@ -118,22 +129,12 @@ export default function SponsorActivitiesAddModal(props: Props) {
             value={data.feature}
             onChange={formDataHandler('feature')}
         >
-          {sponsorStyles[data.sponsorStyleID-1]?.style !== '企業ブース' ?(
-            <>
-              <option value={'なし'} selected>なし</option>
-              <option value={'ポスター'} >ポスター</option>
-              <option value={'クーポン'} >クーポン</option>
-            </>
-          ):(
-            <>
-              <option value={'なし'} selected>なし</option>
-              <option value={'ポスター'} disabled>ポスター</option>
-              <option value={'クーポン'} disabled>クーポン</option>
-            </>
-          )}
+          <option value={'なし'} selected>なし</option>
+          <option value={'ポスター'} disabled={sponsorStyles[data.sponsorStyleID-1]?.style === '企業ブース'}>ポスター</option>
+          <option value={'クーポン'} disabled={sponsorStyles[data.sponsorStyleID-1]?.style === '企業ブース'}>クーポン</option>
         </Select>
       </div>
-      <p className='text-black-600'>交通費</p>
+      <p className='text-black-600'>移動距離(km)</p>
       <div className='col-span-4 w-full'>
         <Input
           type='number'
@@ -142,6 +143,10 @@ export default function SponsorActivitiesAddModal(props: Props) {
           value={data.expense}
           onChange={formDataHandler('expense')}
         />
+      </div>
+      <p className='text-black-600'>交通費</p>
+      <div className='col-span-4 w-full'>
+        <p className='w-full' >{Math.round(data.expense*11)}円</p>
       </div>
       <p className='text-black-600'>備考</p>
       <div className='col-span-4 w-full'>
@@ -202,6 +207,11 @@ export default function SponsorActivitiesAddModal(props: Props) {
             <td className='py-3'>
               <div className='text-center text-sm text-black-600'>
                 {sponsorActivities.expense}
+              </div>
+            </td>
+            <td className='py-3'>
+              <div className='text-center text-sm text-black-600'>
+                {Math.round(sponsorActivities.expense * 11)}
               </div>
             </td>
             <td className='py-3'>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -10,11 +10,13 @@ import {
   PrimaryButton,
   Select,
   Input,
+  Textarea,
 } from '@components/common';
 import { SponsorActivity, Sponsor, SponsorStyle, User } from '@type/common';
 import SponsorActivities from '@/pages/sponsoractivities';
+import { m } from 'framer-motion';
 
-const TABLE_COLUMNS = ['企業名', '協賛スタイル', '担当者名', '回収状況', 'オプション', '移動距離(km)', '交通費', '備考'];
+const TABLE_COLUMNS = ['企業名', '協賛スタイル', '担当者名', '回収状況', 'オプション', '移動距離(km)', '交通費'];
 
 interface Props {
   users: User[];
@@ -38,22 +40,22 @@ export default function SponsorActivitiesAddModal(props: Props) {
     sponsorStyleID: sponsorStyles[0].id || 0,
     userID: users[0].id || 0,
     isDone: false,
-    feature: '',
+    feature: 'なし',
     expense: 0,
-    remark: '',
+    remark:'',
     createdAt: '',
     updatedAt: '',
   });
 
   const formDataHandler =
     (input: string) =>
-    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
+    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>) => {
       setFormData({ ...formData, [input]: e.target.value });
     };
 
   // 協賛活動の登録と更新を行い、ページをリロード
   const submit = (data: SponsorActivity) => {
-    const {expense, ...rest} = data;
+  const {expense, ...rest} = data;
     const submitData:SponsorActivity  = {
       expense:Math.round(expense*11),
       ...rest
@@ -68,6 +70,12 @@ export default function SponsorActivitiesAddModal(props: Props) {
     const sponsorActivitiesUrl = process.env.CSR_API_URI + '/activities';
     await post(sponsorActivitiesUrl, data);
   };
+
+  const remarkCoupon = 
+`【クーポン】[詳細 :  ○○],
+【広告掲載内容】[企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
+  const remarkElse =
+`【広告掲載内容】[企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
 
   // 協賛活動の情報
   const content = (data: SponsorActivity) => (
@@ -89,7 +97,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
         <Select value={data.sponsorStyleID} onChange={(e)=>{
           setFormData({ ...formData, sponsorStyleID: Number(e.target.value) });
           if(sponsorStyles[Number(e.target.value)-1]?.style === '企業ブース'){
-            setFormData({ ...formData, feature: "なし" ,sponsorStyleID: Number(e.target.value)});
+            setFormData({ ...formData, feature: "なし" ,sponsorStyleID: Number(e.target.value), remark: ''});
           }
         }}>
           {sponsorStyles.map((sponsorStyle: SponsorStyle) => (
@@ -127,7 +135,15 @@ export default function SponsorActivitiesAddModal(props: Props) {
       <div className='col-span-4 w-full'>
         <Select
             value={data.feature}
-            onChange={formDataHandler('feature')}
+            onChange={(e)=>{
+              if(e.target.value === 'クーポン'){
+                setFormData({ ...formData, feature: e.target.value ,remark: remarkCoupon});
+              }else if(e.target.value === 'ポスター'){
+                setFormData({ ...formData, feature: e.target.value ,remark: remarkElse});
+              }else{
+                setFormData({ ...formData, feature: e.target.value ,remark: ''});
+              }
+            }}
         >
           <option value={'なし'} selected>なし</option>
           <option value={'ポスター'} disabled={sponsorStyles[data.sponsorStyleID-1]?.style === '企業ブース'}>ポスター</option>
@@ -150,13 +166,13 @@ export default function SponsorActivitiesAddModal(props: Props) {
       </div>
       <p className='text-black-600'>備考</p>
       <div className='col-span-4 w-full'>
-        <Input
+        <Textarea
           type='string'
           className='w-full'
           id={String(data.id)}
           value={data.remark}
           onChange={formDataHandler('remark')}
-        />
+        ></Textarea>
       </div>
     </div>
   );
@@ -169,8 +185,9 @@ export default function SponsorActivitiesAddModal(props: Props) {
       (sponsorStyle) => sponsorStyle.id === Number(sponsorActivities.sponsorStyleID),
     );
     const userView = users.find((user) => user.id === Number(sponsorActivities.userID));
-    
+
     return (
+      <div>
       <table className='mb-10 w-full table-fixed border-collapse'>
         <thead>
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
@@ -214,14 +231,36 @@ export default function SponsorActivitiesAddModal(props: Props) {
                 {Math.round(sponsorActivities.expense * 11)}
               </div>
             </td>
-            <td className='py-3'>
-              <div className='text-center text-sm text-black-600'>
-                {sponsorActivities.remark}
-              </div>
-            </td>
           </tr>
         </tbody>
       </table>
+      <table className='mb-10 w-full table-fixed border-collapse'>
+        <thead>
+          <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
+            <th className='border-b-primary-1 px-6 pb-2'>
+              <div className='text-center text-sm text-black-600'>備考</div>
+            </th>
+          </tr>
+        </thead>
+        <tr>
+          <td>
+            <div className='text-sm text-black-600'>
+              {sponsorActivities.remark.length<36 ?(
+                    <div className = 'text-center'>
+                      {sponsorActivities.remark ==="" &&(
+                        <div>なし</div>
+                      )}
+                      {sponsorActivities.remark}
+                    </div>
+                  ):(
+                    <div>{sponsorActivities.remark}</div>
+              )}
+            </div>
+          </td>
+        </tr>
+      </table>        
+      </div>
+
     );
   };
 

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -9,10 +9,11 @@ import {
   OutlinePrimaryButton,
   PrimaryButton,
   Select,
+  Input
 } from '@components/common';
 import { SponsorActivity, Sponsor, SponsorStyle, User } from '@type/common';
 
-const TABLE_COLUMNS = ['企業名', '協賛スタイル', '担当者名', '回収状況'];
+const TABLE_COLUMNS = ['企業名', '協賛スタイル', '担当者名', '回収状況', 'オプション', '交通費', '備考'];
 
 interface Props {
   users: User[];
@@ -36,6 +37,9 @@ export default function SponsorActivitiesAddModal(props: Props) {
     sponsorStyleID: sponsorStyles[0].id || 0,
     userID: users[0].id || 0,
     isDone: false,
+    feature: '',
+    expense: 0,
+    remark: '',
     createdAt: '',
     updatedAt: '',
   });
@@ -108,6 +112,39 @@ export default function SponsorActivitiesAddModal(props: Props) {
           <option value={'回収済み'}>回収済み</option>
         </Select>
       </div>
+      <p className='text-black-600'>オプション</p>
+      <div className='col-span-4 w-full'>
+        <Select
+          value={data.feature}
+          onChange={formDataHandler('feature')}
+        >
+          <option value={'ポスター'}>
+            ポスター
+          </option>
+          <option value={'クーポン'}>クーポン</option>
+          <option value={'なし'}>なし</option>
+        </Select>
+      </div>
+      <p className='text-black-600'>交通費</p>
+      <div className='col-span-4 w-full'>
+        <Input
+          type='number'
+          className='w-full'
+          id={String(formData.id)}
+          value={formData.expense}
+          onChange={formDataHandler('expense')}
+        />
+      </div>
+      <p className='text-black-600'>備考</p>
+      <div className='col-span-4 w-full'>
+        <Input
+          type='string'
+          className='w-full'
+          id={String(formData.id)}
+          value={formData.remark}
+          onChange={formDataHandler('remark')}
+        />
+      </div>
     </div>
   );
 
@@ -147,6 +184,21 @@ export default function SponsorActivitiesAddModal(props: Props) {
             <td className='py-3'>
               <div className='text-center text-sm text-black-600'>
                 {sponsorActivities.isDone ? '回収済み' : '未回収'}
+              </div>
+            </td>
+            <td className='py-3'>
+              <div className='text-center text-sm text-black-600'>
+                {sponsorActivities.feature}
+              </div>
+            </td>
+            <td className='py-3'>
+              <div className='text-center text-sm text-black-600'>
+                {sponsorActivities.expense}
+              </div>
+            </td>
+            <td className='py-3'>
+              <div className='text-center text-sm text-black-600'>
+                {sponsorActivities.remark}
               </div>
             </td>
           </tr>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -115,14 +115,22 @@ export default function SponsorActivitiesAddModal(props: Props) {
       <p className='text-black-600'>オプション</p>
       <div className='col-span-4 w-full'>
         <Select
-          value={data.feature}
-          onChange={formDataHandler('feature')}
+            value={data.feature}
+            onChange={formDataHandler('feature')}
         >
-          <option value={'ポスター'}>
-            ポスター
-          </option>
-          <option value={'クーポン'}>クーポン</option>
-          <option value={'なし'}>なし</option>
+          {sponsorStyles[data.sponsorStyleID-1]?.style !== '企業ブース' ?(
+            <>
+              <option value={'なし'} selected>なし</option>
+              <option value={'ポスター'} >ポスター</option>
+              <option value={'クーポン'} >クーポン</option>
+            </>
+          ):(
+            <>
+              <option value={'なし'} selected>なし</option>
+              <option value={'ポスター'} disabled>ポスター</option>
+              <option value={'クーポン'} disabled>クーポン</option>
+            </>
+          )}
         </Select>
       </div>
       <p className='text-black-600'>交通費</p>
@@ -130,8 +138,8 @@ export default function SponsorActivitiesAddModal(props: Props) {
         <Input
           type='number'
           className='w-full'
-          id={String(formData.id)}
-          value={formData.expense}
+          id={String(data.id)}
+          value={data.expense}
           onChange={formDataHandler('expense')}
         />
       </div>
@@ -140,8 +148,8 @@ export default function SponsorActivitiesAddModal(props: Props) {
         <Input
           type='string'
           className='w-full'
-          id={String(formData.id)}
-          value={formData.remark}
+          id={String(data.id)}
+          value={data.remark}
           onChange={formDataHandler('remark')}
         />
       </div>
@@ -156,7 +164,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
       (sponsorStyle) => sponsorStyle.id === Number(sponsorActivities.sponsorStyleID),
     );
     const userView = users.find((user) => user.id === Number(sponsorActivities.userID));
-
+    
     return (
       <table className='mb-10 w-full table-fixed border-collapse'>
         <thead>

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -101,14 +101,8 @@ export default function SponsorActivities(props: Props) {
                 <th className='w-1/11 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>担当者名</div>
                 </th>
-                <th className='w-1/11 border-b-primary-1 pb-2'>
+                <th className='w-2/11 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>回収状況</div>
-                </th>
-                <th className='w-1/11 border-b-primary-1 pb-2'>
-                  <div className='text-center text-sm text-black-600'>オプション</div>
-                </th>
-                <th className='w-1/11 border-b-primary-1 pb-2'>
-                  <div className='text-center text-sm text-black-600'>交通費</div>
                 </th>
                 <th className='w-2/11 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>作成日時</div>
@@ -178,30 +172,6 @@ export default function SponsorActivities(props: Props) {
                       {!sponsorActivitiesItem.sponsorActivity.isDone && (
                         <div className='text-center text-sm text-black-600'>未回収</div>
                       )}
-                    </td>
-                    <td
-                      onClick={() => {
-                        onOpen(
-                          sponsorActivitiesItem.sponsorActivity.id || 0,
-                          sponsorActivitiesItem,
-                        );
-                      }}
-                    >
-                      <div className='text-center text-sm text-black-600'>
-                        {sponsorActivitiesItem.sponsorActivity.feature}
-                      </div>
-                    </td>
-                    <td
-                      onClick={() => {
-                        onOpen(
-                          sponsorActivitiesItem.sponsorActivity.id || 0,
-                          sponsorActivitiesItem,
-                        );
-                      }}
-                    >
-                      <div className='text-center text-sm text-black-600'>
-                        {sponsorActivitiesItem.sponsorActivity.expense}
-                      </div>
                     </td>
                     <td
                       onClick={() => {

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -101,8 +101,14 @@ export default function SponsorActivities(props: Props) {
                 <th className='w-1/11 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>担当者名</div>
                 </th>
-                <th className='w-2/11 border-b-primary-1 pb-2'>
+                <th className='w-1/11 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>回収状況</div>
+                </th>
+                <th className='w-1/11 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>オプション</div>
+                </th>
+                <th className='w-1/11 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>交通費</div>
                 </th>
                 <th className='w-2/11 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>作成日時</div>
@@ -172,6 +178,30 @@ export default function SponsorActivities(props: Props) {
                       {!sponsorActivitiesItem.sponsorActivity.isDone && (
                         <div className='text-center text-sm text-black-600'>未回収</div>
                       )}
+                    </td>
+                    <td
+                      onClick={() => {
+                        onOpen(
+                          sponsorActivitiesItem.sponsorActivity.id || 0,
+                          sponsorActivitiesItem,
+                        );
+                      }}
+                    >
+                      <div className='text-center text-sm text-black-600'>
+                        {sponsorActivitiesItem.sponsorActivity.feature}
+                      </div>
+                    </td>
+                    <td
+                      onClick={() => {
+                        onOpen(
+                          sponsorActivitiesItem.sponsorActivity.id || 0,
+                          sponsorActivitiesItem,
+                        );
+                      }}
+                    >
+                      <div className='text-center text-sm text-black-600'>
+                        {sponsorActivitiesItem.sponsorActivity.expense}
+                      </div>
                     </td>
                     <td
                       onClick={() => {

--- a/view/next-project/src/type/common.ts
+++ b/view/next-project/src/type/common.ts
@@ -109,6 +109,9 @@ export interface SponsorActivity {
   sponsorStyleID: number;
   userID: number;
   isDone: boolean;
+  feature: string;
+  expense: number;
+  remark: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/view/next-project/src/type/common.ts
+++ b/view/next-project/src/type/common.ts
@@ -109,9 +109,6 @@ export interface SponsorActivity {
   sponsorStyleID: number;
   userID: number;
   isDone: boolean;
-  feature: string;
-  expense: number;
-  remark: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/view/next-project/src/utils/api/sponsorActivities.ts
+++ b/view/next-project/src/utils/api/sponsorActivities.ts
@@ -5,6 +5,9 @@ export const post = async (url: string, data: SponsorActivity) => {
   const sponsorStyleID = data.sponsorStyleID;
   const userID = data.userID;
   const isDone = data.isDone;
+  const feature = data.feature;
+  const expense = data.expense;
+  const remark = data.remark;
   const postUrl =
     url +
     '?sponsor_id=' +
@@ -14,7 +17,13 @@ export const post = async (url: string, data: SponsorActivity) => {
     '&user_id=' +
     userID +
     '&is_done=' +
-    isDone;
+    isDone +
+    '&feature=' +
+    feature +
+    '&expense=' +
+    expense +
+    '&remark=' +
+    remark;
   const res = await fetch(postUrl, {
     method: 'POST',
     mode: 'cors',
@@ -31,6 +40,9 @@ export const put = async (url: string, data: SponsorActivity) => {
   const sponsorStyleID = data.sponsorStyleID;
   const userID = data.userID;
   const isDone = data.isDone;
+  const feature = data.feature;
+  const expense = data.expense;
+  const remark = data.remark;
   const putUrl =
     url +
     '?sponsor_id=' +
@@ -40,7 +52,13 @@ export const put = async (url: string, data: SponsorActivity) => {
     '&user_id=' +
     userID +
     '&is_done=' +
-    isDone;
+    isDone +
+    '&feature=' +
+    feature +
+    '&expense=' +
+    expense +
+    '&remark=' +
+    remark;
 
   console.log('putUrl: ', putUrl);
   const res = await fetch(putUrl, {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#551
<!-- 対応したIssue番号を記載 -->
resolve #551

# 概要
<!-- 開発内容の概要を記載 -->
- activityにカラム(オプション:`feature`,交通費:`expense`,備考:`remark`)を追加し、APIの修正
- 協賛活動のページの表に、オプションと交通費の追加
- 協賛活動の登録の際にオプション、交通費、備考の入力フォーム追加
- 協賛活動の詳細にオプション、交通費、備考の表示
- 協賛活動のレコード修正にオプション、交通費、備考の追加
- フロント側の入力に伴う処理の変化
  - オプションはSelectを使って、なし・クーポン・ポスターから選択させる
    - 協賛内容が企業ブースの時はなしで確定
  - 交通費は距離(km)を入力させて値段を出す 11 yen/km
  - 備考欄はTextArea
    - テンプレートの動的生成

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- APIの動作確認(一応)
  - swagger で動作確認
-  協賛活動ページで動作に問題がないか確認する
- [ ] 協賛ページの表示できるか
- [ ] 協賛活動の登録ができるか
- [ ] 協賛活動の修正ができるか
- [ ] 協賛内容が企業ブースの時、オプションがなしになるか
- [ ] 交通費が距離を入力から算出できるか
- [ ] 交通費が距離を変更することで修正できるか
- [ ] オプションを変更することで、備考のテンプレートが変更されるか
- [ ] 備考のテンプレートが適切か

# 備考
