### PR TITLE
デザインを誰が作るのかの選択肢を増やす

### DIFF
--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -22,9 +22,14 @@ interface ModalProps {
   setIsOpen: (isOpen: boolean) => void;
 }
 
-const REMARK_COUPON = `<クーポン> [詳細 :  ○○],
-<広告掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
-const REMARK_POSTER = `<広告掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
+const REMARK_COUPON = `<クーポン> [詳細 :  ○○]\n`;
+const REMARK_PAMPHLET = `<パンフレット掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]\n`;
+const REMARK_PAMPHLET_SPONSOR = `<パンフレット掲載内容> 企業が作成\n`;
+const REMARK_PAMPHLET_OTHER = `<パンフレット掲載内容> 去年のものを使用\n`;
+const REMARK_POSTER = `<ポスター掲載内容> パンフレット広告拡大\n`;
+const REMARK_DESIGN_STUDENT = `<デザイン作成> 学生が作成\n`;
+const REMARK_DESIGN_SPONSOR = `<デザイン作成> 企業が作成\n`;
+const REMARK_DESIGN_OTHER = `<デザイン作成> 去年のものを使用\n`;
 
 export default function EditModal(props: ModalProps) {
   const router = useRouter();
@@ -34,6 +39,27 @@ export default function EditModal(props: ModalProps) {
     ...props.sponsorActivity,
     expense: Number((props.sponsorActivity.expense / 11).toFixed(1)),
   });
+
+  const [design, setDesign] = useState<string>('学生が作成');
+  const changeDesign = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDesign(e.target.value);
+    const newRemark =
+      e.target.value === '学生が作成'
+        ? REMARK_DESIGN_STUDENT + REMARK_PAMPHLET
+        : e.target.value === '企業が作成'
+        ? REMARK_DESIGN_SPONSOR + REMARK_PAMPHLET_SPONSOR
+        : REMARK_DESIGN_OTHER + REMARK_PAMPHLET_OTHER;
+    const newRemarkFeature =
+      formData.feature === 'ポスター'
+        ? REMARK_POSTER
+        : formData.feature === 'クーポン'
+        ? REMARK_COUPON
+        : '';
+    setFormData({
+      ...formData,
+      remark: newRemark + newRemarkFeature,
+    });
+  };
 
   const { users, sponsors, sponsorStyles } = props;
   const handler =
@@ -137,13 +163,23 @@ export default function EditModal(props: ModalProps) {
         <Select
           value={data.feature}
           onChange={(e) => {
-            if (e.target.value === 'クーポン') {
-              setFormData({ ...formData, feature: e.target.value, remark: REMARK_COUPON });
-            } else if (e.target.value === 'ポスター') {
-              setFormData({ ...formData, feature: e.target.value, remark: REMARK_POSTER });
-            } else {
-              setFormData({ ...formData, feature: e.target.value, remark: '' });
-            }
+            const newRemark =
+              design === '学生が作成'
+                ? REMARK_DESIGN_STUDENT + REMARK_PAMPHLET
+                : design === '企業が作成'
+                ? REMARK_DESIGN_SPONSOR + REMARK_PAMPHLET_SPONSOR
+                : REMARK_DESIGN_OTHER + REMARK_PAMPHLET_OTHER;
+            const newRemarkFeature =
+              e.target.value === 'ポスター'
+                ? REMARK_POSTER
+                : e.target.value === 'クーポン'
+                ? REMARK_COUPON
+                : '';
+            setFormData({
+              ...formData,
+              remark: newRemark + newRemarkFeature,
+              feature: e.target.value,
+            });
           }}
         >
           <option value={'なし'} selected>
@@ -162,6 +198,42 @@ export default function EditModal(props: ModalProps) {
             クーポン
           </option>
         </Select>
+      </div>
+      <p className='text-black-600'>デザイン作成</p>
+      <div className='col-span-4 flex w-full justify-around'>
+        <div className='flex gap-3'>
+          <input
+            type='radio'
+            id='student'
+            name='design'
+            value='学生が作成'
+            checked={design === '学生が作成'}
+            onChange={changeDesign}
+          />
+          <label htmlFor='student'>学生が作成</label>
+        </div>
+        <div className='flex gap-3'>
+          <input
+            type='radio'
+            id='company'
+            name='design'
+            value='企業が作成'
+            checked={design === '企業が作成'}
+            onChange={changeDesign}
+          />
+          <label htmlFor='company'>企業が作成</label>
+        </div>
+        <div className='flex gap-3'>
+          <input
+            type='radio'
+            id='lastYear'
+            name='design'
+            value='去年のものを使用'
+            checked={design === '去年のものを使用'}
+            onChange={changeDesign}
+          />
+          <label htmlFor='lastYear'>去年のものを使用</label>
+        </div>
       </div>
       <p className='text-black-600'>移動距離(km)</p>
       <div className='col-span-4 w-full'>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -32,9 +32,11 @@ interface Props {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const REMARK_COUPON = `<クーポン> [詳細 :  ○○],
-<広告掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
-const REMARK_POSTER = `<広告掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
+const REMARK_COUPON = `<クーポン> [詳細 :  ○○]\n`;
+const REMARK_PAMPHLET = `<パンフレット掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]\n`;
+const REMARK_PAMPHLET_SPONSOR = `<パンフレット掲載内容> 企業が作成\n`;
+const REMARK_PAMPHLET_OTHER = `<パンフレット掲載内容> 去年のものを使用\n`;
+const REMARK_POSTER = `<ポスター掲載内容> パンフレット広告拡大\n`;
 const REMARK_DESIGN_STUDENT = `<デザイン作成> 学生が作成\n`;
 const REMARK_DESIGN_SPONSOR = `<デザイン作成> 企業が作成\n`;
 const REMARK_DESIGN_OTHER = `<デザイン作成> 去年のものを使用\n`;
@@ -61,19 +63,19 @@ export default function SponsorActivitiesAddModal(props: Props) {
 
   const [design, setDesign] = useState<string>('学生が作成');
   useEffect(() => {
-    if (design === '学生が作成') {
-      if (formData.feature === 'ポスター') {
-        setFormData({ ...formData, remark: REMARK_DESIGN_STUDENT + REMARK_POSTER });
-      } else if (formData.feature === 'クーポン') {
-        setFormData({ ...formData, remark: REMARK_DESIGN_STUDENT + REMARK_COUPON });
-      } else {
-        setFormData({ ...formData, remark: REMARK_DESIGN_STUDENT });
-      }
-    } else if (design === '企業が作成') {
-      setFormData({ ...formData, remark: REMARK_DESIGN_SPONSOR });
-    } else if (design === '去年のものを使用') {
-      setFormData({ ...formData, remark: REMARK_DESIGN_OTHER });
-    }
+    const newRemark =
+      design === '学生が作成'
+        ? REMARK_DESIGN_STUDENT + REMARK_PAMPHLET
+        : design === '企業が作成'
+        ? REMARK_DESIGN_SPONSOR + REMARK_PAMPHLET_SPONSOR
+        : REMARK_DESIGN_OTHER + REMARK_PAMPHLET_OTHER;
+    const newRemarkFeature =
+      formData.feature === 'ポスター'
+        ? REMARK_POSTER
+        : formData.feature === 'クーポン'
+        ? REMARK_COUPON
+        : '';
+    setFormData({ ...formData, remark: newRemark + newRemarkFeature });
   }, [design, formData]);
 
   const formDataHandler =
@@ -174,13 +176,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
         <Select
           value={data.feature}
           onChange={(e) => {
-            if (e.target.value === 'クーポン') {
-              setFormData({ ...formData, feature: e.target.value, remark: REMARK_COUPON });
-            } else if (e.target.value === 'ポスター') {
-              setFormData({ ...formData, feature: e.target.value, remark: REMARK_POSTER });
-            } else {
-              setFormData({ ...formData, feature: e.target.value, remark: '' });
-            }
+            setFormData({ ...formData, feature: e.target.value });
           }}
         >
           <option value={'なし'} selected>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -1,6 +1,6 @@
 import { clsx } from 'clsx';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { RiArrowDropRightLine } from 'react-icons/ri';
 
 import { post } from '@/utils/api/sponsorActivities';
@@ -35,6 +35,9 @@ interface Props {
 const REMARK_COUPON = `<クーポン> [詳細 :  ○○],
 <広告掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
 const REMARK_POSTER = `<広告掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]`;
+const REMARK_DESIGN_STUDENT = `<デザイン作成> 学生が作成\n`;
+const REMARK_DESIGN_SPONSOR = `<デザイン作成> 企業が作成\n`;
+const REMARK_DESIGN_OTHER = `<デザイン作成> 去年のものを使用\n`;
 
 export default function SponsorActivitiesAddModal(props: Props) {
   const router = useRouter();
@@ -55,6 +58,23 @@ export default function SponsorActivitiesAddModal(props: Props) {
     expense: 0,
     remark: '',
   });
+
+  const [design, setDesign] = useState<string>('学生が作成');
+  useEffect(() => {
+    if (design === '学生が作成') {
+      if (formData.feature === 'ポスター') {
+        setFormData({ ...formData, remark: REMARK_DESIGN_STUDENT + REMARK_POSTER });
+      } else if (formData.feature === 'クーポン') {
+        setFormData({ ...formData, remark: REMARK_DESIGN_STUDENT + REMARK_COUPON });
+      } else {
+        setFormData({ ...formData, remark: REMARK_DESIGN_STUDENT });
+      }
+    } else if (design === '企業が作成') {
+      setFormData({ ...formData, remark: REMARK_DESIGN_SPONSOR });
+    } else if (design === '去年のものを使用') {
+      setFormData({ ...formData, remark: REMARK_DESIGN_OTHER });
+    }
+  }, [design, formData]);
 
   const formDataHandler =
     (input: string) =>
@@ -179,6 +199,42 @@ export default function SponsorActivitiesAddModal(props: Props) {
             クーポン
           </option>
         </Select>
+      </div>
+      <p className='text-black-600'>デザイン作成</p>
+      <div className='col-span-4 flex w-full justify-around'>
+        <div className='flex gap-3'>
+          <input
+            type='radio'
+            id='student'
+            name='design'
+            value='学生が作成'
+            checked={design === '学生が作成'}
+            onChange={(e) => setDesign(e.target.value)}
+          />
+          <label htmlFor='student'>学生が作成</label>
+        </div>
+        <div className='flex gap-3'>
+          <input
+            type='radio'
+            id='company'
+            name='design'
+            value='企業が作成'
+            checked={design === '企業が作成'}
+            onChange={(e) => setDesign(e.target.value)}
+          />
+          <label htmlFor='company'>企業が作成</label>
+        </div>
+        <div className='flex gap-3'>
+          <input
+            type='radio'
+            id='lastYear'
+            name='design'
+            value='去年のものを使用'
+            checked={design === '去年のものを使用'}
+            onChange={(e) => setDesign(e.target.value)}
+          />
+          <label htmlFor='lastYear'>去年のものを使用</label>
+        </div>
       </div>
       <p className='text-black-600'>移動距離(km)</p>
       <div className='col-span-4 w-full'>

--- a/view/next-project/src/pages/budgets/index.tsx
+++ b/view/next-project/src/pages/budgets/index.tsx
@@ -148,7 +148,7 @@ export default function BudgetList(props: Props) {
                     収入登録
                   </OpenAddModalButton>
                 </div>
-                <div className='mt-4 mb-2 overflow-scroll md:p-5'>
+                <div className='mb-2 mt-4 overflow-scroll md:p-5'>
                   <table className='mb-5 w-max table-auto border-collapse md:w-full'>
                     <thead>
                       <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 text-sm text-black-600'>
@@ -215,13 +215,13 @@ export default function BudgetList(props: Props) {
                     {filteredBudgets.length > 0 && (
                       <tfoot
                         className={clsx(
-                          'border border-x-white-0 border-t-primary-1 border-b-white-0',
+                          'border border-x-white-0 border-b-white-0 border-t-primary-1',
                         )}
                       >
                         <tr>
                           <th />
-                          <th className='py-3 pt-4 pb-3 text-center text-black-600'>合計金額</th>
-                          <th className='py-3 pt-4 pb-3 text-center text-black-600'>
+                          <th className='py-3 pb-3 pt-4 text-center text-black-600'>合計金額</th>
+                          <th className='py-3 pb-3 pt-4 text-center text-black-600'>
                             {budgetsTotalFee}
                           </th>
                           <th />
@@ -253,7 +253,7 @@ export default function BudgetList(props: Props) {
                     <option value='2023'>2023</option>
                   </select>
                 </div>
-                <div className='mt-4 mb-2 overflow-scroll md:p-5'>
+                <div className='mb-2 mt-4 overflow-scroll md:p-5'>
                   <table className='mb-5 w-max table-auto border-collapse md:w-full'>
                     <thead>
                       <tr
@@ -337,12 +337,12 @@ export default function BudgetList(props: Props) {
                     {filteredExpenses.length > 0 && (
                       <tfoot
                         className={clsx(
-                          'border border-x-white-0 border-t-primary-1 border-b-white-0',
+                          'border border-x-white-0 border-b-white-0 border-t-primary-1',
                         )}
                       >
                         <tr>
-                          <th className='py-3 pt-4 pb-3 text-center text-black-600'>合計金額</th>
-                          <th className='py-3 pt-4 pb-3 text-center text-black-600'>
+                          <th className='py-3 pb-3 pt-4 text-center text-black-600'>合計金額</th>
+                          <th className='py-3 pb-3 pt-4 text-center text-black-600'>
                             {expensesTotalFee}
                           </th>
                           <th />


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #573 

# 概要
<!-- 開発内容の概要を記載 -->

そのデザインを
- 学生が作るのか
- 企業が作るのか
- 去年のままなのか
を選べるようにする

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="718" alt="スクリーンショット 2023-05-12 11 23 18" src="https://github.com/NUTFes/FinanSu/assets/52590941/7e66a9b4-f15f-422f-9446-b87f1723af02">

# テスト項目
<!-- テストしてほしい内容を記載 -->

- [x] 以下の通り備考欄が生成されるか

- オプションが「なし」の場合の備考欄
  - デザイン作成者
  - 学生が作るならその掲載内容の入力
- オプションが「ポスター」の場合の備考欄
  - デザイン作成者
  - 学生が作るならその掲載内容の入力
  - ポスターはパンフレット内容を拡大したもの
- オプションが「クーポン」の場合
  - デザイン作成者
  - 学生が作るならその掲載内容の入力
  - クーポンの詳細を入力

# 備考
