### PR TITLE
協賛活動のAPIの修正

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2027,11 +2027,6 @@ const docTemplate = `{
         },
         "activity":{
             "properties":{
-                "sponsorStyleID":{
-                    "type": "int",
-                    "example": 1,
-
-                },
                 "sponsorID":{
                     "type": "int",
                     "example": 1,
@@ -2060,7 +2055,6 @@ const docTemplate = `{
                 },
             },
             "required":{
-                    "sponsorStyleID",
                     "sponsorID",
                     "userID",
                     "isDone",

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -119,6 +119,98 @@ const docTemplate = `{
                 },
             },
         },
+        "/activity_styles": {
+            "get": {
+                tags: ["activity_style"],
+                "description": "activity_styleの一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "activity_styleの一覧の取得",
+                    }
+                }
+            },
+            "post": {
+                tags: ["activity_style"],
+                "description": "activity_styleの作成",
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "activity_style",
+                        "schema":{
+                            "$ref": "#/definitions/activity_style"
+                        },
+                    },
+                ],
+                responses: {
+                    "200": {
+                        "description": "createされたactivity_styleが返ってくる",
+                    }
+                },
+            },
+        },
+        "/activity_styles/{id}": {
+            "get": {
+                tags: ["activity_style"],
+                "description": "IDで指定されたactivity_styleの取得",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "activity_styleの取得",
+                    }
+                }
+            },
+            "put": {
+                tags: ["activity_style"],
+                "description": "activity_styleの更新",
+                responses: {
+                    "200": {
+                        "description": "更新されたactivity_styleが返ってくる",
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    },
+                    {
+                        "in": "body",
+                        "name": "activity_style",
+                        "schema":{
+                            "$ref": "#/definitions/activity_style"
+                        },
+                    },
+                ],
+            },
+            "delete": {
+                tags: ["activity_style"],
+                "description": "IDを指定してactivity_styleの削除",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                responses: {
+                    "200": {
+                        "description": "activity_styleの削除完了",
+                    }
+                },
+            },
+        },
         "/budgets": {
             "get": {
                 tags: ["budget"],
@@ -2061,6 +2153,23 @@ const docTemplate = `{
                     "feature",
                     "expense",
                     "remark",
+            },
+        },
+        "activity_style":{
+            "properties":{
+                "activityID":{
+                    "type": "int",
+                    "example": 1,
+
+                },
+                "sponsorStyleID":{
+                    "type": "int",
+                    "example": 1,
+                },
+            },
+            "required":{
+                    "activityID",
+                    "sponsorStyleID",
             },
         },
     },

--- a/api/externals/controller/activity_controller.go
+++ b/api/externals/controller/activity_controller.go
@@ -53,7 +53,7 @@ func (a *activityController) CreateActivity(c echo.Context) error {
 		fmt.Println("err")
 		return err
 	}
-	latastActivity, err := a.u.CreateActivity(c.Request().Context(), strconv.Itoa(int(activities.SponsorStyleID)) , strconv.Itoa(int(activities.UserID)), strconv.FormatBool(activities.IsDone), strconv.Itoa(int(activities.SponsorID)), activities.Feature, strconv.Itoa(int(activities.Expense)), activities.Remark)
+	latastActivity, err := a.u.CreateActivity(c.Request().Context() , strconv.Itoa(int(activities.UserID)), strconv.FormatBool(activities.IsDone), strconv.Itoa(int(activities.SponsorID)), activities.Feature, strconv.Itoa(int(activities.Expense)), activities.Remark)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (a *activityController) UpdateActivity(c echo.Context) error {
 		fmt.Println("err")
 		return err
 	}
-	updatedActivity, err := a.u.UpdateActivity(c.Request().Context(), id, strconv.Itoa(int(activities.SponsorStyleID)) , strconv.Itoa(int(activities.UserID)), strconv.FormatBool(activities.IsDone), strconv.Itoa(int(activities.SponsorID)), activities.Feature, strconv.Itoa(int(activities.Expense)), activities.Remark)
+	updatedActivity, err := a.u.UpdateActivity(c.Request().Context(), id , strconv.Itoa(int(activities.UserID)), strconv.FormatBool(activities.IsDone), strconv.Itoa(int(activities.SponsorID)), activities.Feature, strconv.Itoa(int(activities.Expense)), activities.Remark)
 	if err != nil {
 		return err
 	}

--- a/api/externals/controller/activity_style_controller.go
+++ b/api/externals/controller/activity_style_controller.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/NUTFes/FinanSu/api/internals/domain"
+	"github.com/NUTFes/FinanSu/api/internals/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type activityStyleController struct {
+	u usecase.ActivityStyleUseCase
+}
+
+type ActivityStyleController interface {
+	IndexActivityStyle(echo.Context) error
+	ShowActivityStyle(echo.Context) error
+	CreateActivityStyle(echo.Context) error
+	UpdateActivityStyle(echo.Context) error
+	DestroyActivityStyle(echo.Context) error
+}
+
+func NewActivityStyleController(u usecase.ActivityStyleUseCase) ActivityStyleController {
+	return &activityStyleController{u}
+}
+
+// Index
+func (a *activityStyleController) IndexActivityStyle(c echo.Context) error {
+	activityStyles, err := a.u.GetActivityStyle(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, activityStyles)
+}
+
+// Show
+func (a *activityStyleController) ShowActivityStyle(c echo.Context) error {
+	id := c.Param("id")
+	activityStyle, err := a.u.GetActivityStyleByID(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, activityStyle)
+}
+
+// Create
+func (a *activityStyleController) CreateActivityStyle(c echo.Context) error {
+	activityStyle := new(domain.ActivityStyle)
+	if err := c.Bind(activityStyle); err != nil {
+		fmt.Println("err")
+		return err
+	}
+	latastActivityStyle, err := a.u.CreateActivityStyle(c.Request().Context() , strconv.Itoa(int(activityStyle.ActivityID)), strconv.Itoa(int(activityStyle.SponsoStyleID)))
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, latastActivityStyle)
+}
+
+// Update
+func (a *activityStyleController) UpdateActivityStyle(c echo.Context) error {
+	id := c.Param("id")
+	activityStyle := new(domain.ActivityStyle)
+	if err := c.Bind(activityStyle); err != nil {
+		fmt.Println("err")
+		return err
+	}
+	updatedActivityStyle, err := a.u.UpdateActivityStyle(c.Request().Context(), id , strconv.Itoa(int(activityStyle.ActivityID)), strconv.Itoa(int(activityStyle.SponsoStyleID)))
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, updatedActivityStyle)
+}
+
+// Destroy
+func (a *activityStyleController) DestroyActivityStyle(c echo.Context) error {
+	id := c.Param("id")
+	err := a.u.DestroyActivityStyle(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return c.String(http.StatusOK, "Destroy ActivityStyle")
+}

--- a/api/externals/repository/activity_repository.go
+++ b/api/externals/repository/activity_repository.go
@@ -16,8 +16,8 @@ type activityRepository struct {
 type ActivityRepository interface {
 	All(context.Context) (*sql.Rows, error)
 	Find(context.Context, string) (*sql.Row, error)
-	Create(context.Context, string, string, string, string, string, string, string) error
-	Update(context.Context, string, string, string, string, string,string, string, string) error
+	Create(context.Context, string, string, string, string, string, string) error
+	Update(context.Context, string, string, string, string, string,string, string) error
 	Destroy(context.Context, string) error
 	FindDetail(context.Context) (*sql.Rows, error)
 	FindLatestRecord(c context.Context) (*sql.Row, error)
@@ -42,7 +42,6 @@ func (ar *activityRepository) Find(c context.Context, id string) (*sql.Row, erro
 // 作成
 func (ar *activityRepository) Create(
 	c context.Context,
-	sponsorStyleID string,
 	userID string,
 	isDone string,
 	sponsorID string,
@@ -52,9 +51,9 @@ func (ar *activityRepository) Create(
 
 	query := `
 	INSERT INTO	activities
-		(sponsor_style_id, user_id, is_done, sponsor_id, feature, expense, remark)
+		(user_id, is_done, sponsor_id, feature, expense, remark)
 	VALUES
-		(` + sponsorStyleID + "," + userID + "," + isDone + "," + sponsorID + ",'" + feature + "'," + expense +",'" + remark +"')"
+		(` +userID + "," + isDone + "," + sponsorID + ",'" + feature + "'," + expense +",'" + remark +"')"
 
 	return ar.crud.UpdateDB(c, query)
 }
@@ -63,7 +62,6 @@ func (ar *activityRepository) Create(
 func (ar *activityRepository) Update(
 	c context.Context,
 	id string,
-	sponsorStyleID string,
 	userID string,
 	isDone string,
 	sponsorID string,
@@ -74,8 +72,7 @@ func (ar *activityRepository) Update(
 	query := `
 	UPDATE activities
 	SET
-		sponsor_style_id =` + sponsorStyleID +
-		", user_id = " + userID +
+		user_id = ` + userID +
 		", is_done = " + isDone +
 		", sponsor_id = " + sponsorID +
 		", feature = '" + feature +

--- a/api/externals/repository/activity_repository.go
+++ b/api/externals/repository/activity_repository.go
@@ -21,6 +21,7 @@ type ActivityRepository interface {
 	Destroy(context.Context, string) error
 	FindDetail(context.Context) (*sql.Rows, error)
 	FindLatestRecord(c context.Context) (*sql.Row, error)
+	FindSponsorStyle(context.Context, string) (*sql.Rows, error)
 }
 
 func NewActivityRepository(c db.Client, ac abstract.Crud) ActivityRepository {
@@ -98,10 +99,6 @@ func (ar *activityRepository) FindDetail(c context.Context) (*sql.Rows, error) {
 	ON
 		activities.sponsor_id = sponsors.id
 	INNER JOIN
-		sponsor_styles
-	ON
-		activities.sponsor_style_id = sponsor_styles.id
-	INNER JOIN
 		users
 	ON
 		activities.user_id = users.id`
@@ -120,4 +117,19 @@ func (ar *activityRepository) FindLatestRecord(c context.Context) (*sql.Row, err
 		DESC LIMIT 1
 	`
 	return ar.crud.ReadByID(c, query)
+}
+
+// 指定したorder_idのitemを取得する
+func (ar *activityRepository) FindSponsorStyle(c context.Context, sponsorStyleID string) (*sql.Rows, error) {
+	query := `
+		SELECT
+			ss.*
+		FROM
+			activity_styles
+		INNER JOIN
+			sponsor_styles AS ss
+		ON
+			activity_styles.sponsor_style_id = ss.id
+		WHERE activity_styles.activity_id = ` + sponsorStyleID
+	return ar.crud.Read(c, query)
 }

--- a/api/externals/repository/activity_style_repository.go
+++ b/api/externals/repository/activity_style_repository.go
@@ -1,0 +1,92 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/NUTFes/FinanSu/api/drivers/db"
+	"github.com/NUTFes/FinanSu/api/externals/repository/abstract"
+)
+
+type activityStyleRepository struct {
+	client db.Client
+	crud   abstract.Crud
+}
+
+type ActivityStyleRepository interface {
+	All(context.Context) (*sql.Rows, error)
+	Find(context.Context, string) (*sql.Row, error)
+	Create(context.Context, string, string) error
+	Update(context.Context, string, string, string) error
+	Destroy(context.Context, string) error
+	FindLatestRecord(context.Context) (*sql.Row, error)
+}
+
+func NewActivityStyleRepository(c db.Client, ac abstract.Crud) ActivityStyleRepository {
+	return &activityStyleRepository{c, ac}
+}
+
+// 全件取得
+func (ar *activityStyleRepository) All(c context.Context) (*sql.Rows, error) {
+	query := "SELECT * FROM activity_styles"
+	return ar.crud.Read(c, query)
+}
+
+// 1件取得
+func (ar *activityStyleRepository) Find(c context.Context, id string) (*sql.Row, error) {
+	query := "SELECT * FROM activity_styles WHERE id =" + id
+	return ar.crud.ReadByID(c, query)
+}
+
+// 作成
+func (ar *activityStyleRepository) Create(
+	c context.Context,
+	activityID string,
+	sponsorStyleID string,
+	) error {
+
+	query := `
+	INSERT INTO	activity_styles
+		(activity_id , sponsor_style_id)
+	VALUES
+		(` +activityID + "," + sponsorStyleID +")"
+
+	return ar.crud.UpdateDB(c, query)
+}
+
+// 編集
+func (ar *activityStyleRepository) Update(
+	c context.Context,
+	id string,
+	activityID string,
+	sponsorStyleID string,
+	) error {
+
+	query := `
+	UPDATE activity_styles
+	SET
+		activity_id = ` + activityID +
+		", sponsor_style_id = " + sponsorStyleID +
+		" where id = " + id
+
+	return ar.crud.UpdateDB(c, query)
+}
+
+// 削除
+func (ar *activityStyleRepository) Destroy(c context.Context, id string) error {
+	query := "DELETE FROM activity_styles WHERE id = " + id
+	return ar.crud.UpdateDB(c, query)
+}
+
+func (ar *activityStyleRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
+	query := `
+		SELECT
+			*
+		FROM
+			activity_styles
+		ORDER BY
+			id
+		DESC LIMIT 1
+	`
+	return ar.crud.ReadByID(c, query)
+}

--- a/api/internals/di/di.go
+++ b/api/internals/di/di.go
@@ -25,6 +25,7 @@ func InitializeServer() db.Client {
 
 	// Repository
 	activityRepository := repository.NewActivityRepository(client, crud)
+	activityStyleRepository := repository.NewActivityStyleRepository(client, crud)
 	budgetRepository := repository.NewBudgetRepository(client, crud)
 	bureauRepository := repository.NewBureauRepository(client, crud)
 	departmentRepository := repository.NewDepartmentRepository(client, crud)
@@ -45,6 +46,7 @@ func InitializeServer() db.Client {
 
 	// UseCase
 	activityUseCase := usecase.NewActivityUseCase(activityRepository)
+	activityStyleUseCase := usecase.NewActivityStyleUseCase(activityStyleRepository)
 	budgetUseCase := usecase.NewBudgetUseCase(budgetRepository)
 	bureauUseCase := usecase.NewBureauUseCase(bureauRepository)
 	departmentUseCase := usecase.NewDepartmentUseCase(departmentRepository)
@@ -64,6 +66,7 @@ func InitializeServer() db.Client {
 
 	// Controller
 	activityController := controller.NewActivityController(activityUseCase)
+	activityStyleController := controller.NewActivityStyleController(activityStyleUseCase)
 	budgetController := controller.NewBudgetController(budgetUseCase)
 	bureauController := controller.NewBureauController(bureauUseCase)
 	departmentController := controller.NewDepartmentController(departmentUseCase)
@@ -85,6 +88,7 @@ func InitializeServer() db.Client {
 	// router
 	router := router.NewRouter(
 		activityController,
+		activityStyleController,
 		budgetController,
 		bureauController,
 		departmentController,

--- a/api/internals/domain/activity.go
+++ b/api/internals/domain/activity.go
@@ -6,7 +6,6 @@ import (
 
 type Activity struct {
 	ID				int			`json:"id"`
-	SponsorStyleID 	uint		`json:"sponsorStyleID"`
 	UserID			uint		`json:"userID"`
 	IsDone			bool		`json:"isDone"`
 	SponsorID		uint		`json:"sponsorID"`

--- a/api/internals/domain/activity.go
+++ b/api/internals/domain/activity.go
@@ -19,6 +19,6 @@ type Activity struct {
 type ActivityDetail struct {
 	Activity		Activity		`json:"sponsorActivity"`
 	Sponsor			Sponsor			`json:"sponsor"`
-	SponsorStyle	SponsorStyle	`json:"sponsorStyle"`
+	SponsorStyle	[]SponsorStyle	`json:"sponsorStyle"`
 	User			User			`json:"user"`
 }

--- a/api/internals/domain/activity_style.go
+++ b/api/internals/domain/activity_style.go
@@ -1,0 +1,13 @@
+package domain
+
+import (
+	"time"
+)
+
+type ActivityStyle struct {
+	ID				int			`json:"id"`
+	ActivityID		uint		`json:"activityID"`
+	SponsoStyleID	uint		`json:"sponsorStyleID"`
+	CreatedAt		time.Time	`json:"createdAt"`
+	UpdatedAt		time.Time	`json:"updatedAt"`
+}

--- a/api/internals/usecase/activity_style_usecase.go
+++ b/api/internals/usecase/activity_style_usecase.go
@@ -1,0 +1,124 @@
+package usecase
+
+import (
+	"context"
+
+	rep "github.com/NUTFes/FinanSu/api/externals/repository"
+	"github.com/NUTFes/FinanSu/api/internals/domain"
+	"github.com/pkg/errors"
+)
+
+type activityStyleUseCase struct {
+	rep rep.ActivityStyleRepository
+}
+
+type ActivityStyleUseCase interface {
+	GetActivityStyle(context.Context) ([]domain.ActivityStyle, error)
+	GetActivityStyleByID(context.Context, string) (domain.ActivityStyle, error)
+	CreateActivityStyle(context.Context, string, string) (domain.ActivityStyle, error)
+	UpdateActivityStyle(context.Context, string, string, string) (domain.ActivityStyle, error)
+	DestroyActivityStyle(context.Context, string) error
+}
+
+func NewActivityStyleUseCase(rep rep.ActivityStyleRepository) ActivityStyleUseCase{
+	return &activityStyleUseCase{rep}
+}
+
+func (a *activityStyleUseCase) GetActivityStyle(c context.Context) ([]domain.ActivityStyle, error) {
+
+	activityStyle := domain.ActivityStyle{}
+	var activityStyles []domain.ActivityStyle
+
+	// クエリー実行
+	rows, err := a.rep.All(c)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		err := rows.Scan(
+			&activityStyle.ID,
+			&activityStyle.ActivityID,
+			&activityStyle.SponsoStyleID,
+			&activityStyle.CreatedAt,
+			&activityStyle.UpdatedAt,
+		)
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot connect SQL")
+		}
+
+		activityStyles = append(activityStyles, activityStyle)
+	}
+	return activityStyles, nil
+}
+
+func (a *activityStyleUseCase) GetActivityStyleByID(c context.Context, id string) (domain.ActivityStyle, error) {
+	var activityStyle domain.ActivityStyle
+
+	row, err := a.rep.Find(c, id)
+	err = row.Scan(
+		&activityStyle.ID,
+		&activityStyle.ActivityID,
+		&activityStyle.SponsoStyleID,
+		&activityStyle.CreatedAt,
+		&activityStyle.UpdatedAt,
+	)
+
+	if err != nil {
+		return activityStyle, err
+	}
+
+	return activityStyle, nil
+}
+
+func (a *activityStyleUseCase) CreateActivityStyle(
+	c context.Context,
+	activityID string,
+	sponsorStyleID string,
+	) (domain.ActivityStyle, error) {
+	latastActivityStyle := domain.ActivityStyle{}
+
+	err := a.rep.Create(c, activityID, sponsorStyleID)
+	row, err := a.rep.FindLatestRecord(c)
+	err = row.Scan(
+		&latastActivityStyle.ID,
+		&latastActivityStyle.ActivityID,
+		&latastActivityStyle.SponsoStyleID,
+		&latastActivityStyle.CreatedAt,
+		&latastActivityStyle.UpdatedAt,
+	)
+
+	if err != nil {
+		return latastActivityStyle, err
+	}
+	return latastActivityStyle, nil
+}
+
+func (a *activityStyleUseCase) UpdateActivityStyle(
+	c context.Context,
+	id string,
+	activityID string,
+	sponsorStyleID string,
+	) (domain.ActivityStyle, error) {
+	updatedActivityStyle := domain.ActivityStyle{}
+	err := a.rep.Update(c, id, activityID, sponsorStyleID)
+	row, err := a.rep.Find(c, id)
+	err = row.Scan(
+		&updatedActivityStyle.ID,
+		&updatedActivityStyle.ActivityID,
+		&updatedActivityStyle.SponsoStyleID,	
+		&updatedActivityStyle.CreatedAt,
+		&updatedActivityStyle.UpdatedAt,
+	)
+	if err != nil {
+		return updatedActivityStyle, err
+	}
+	return updatedActivityStyle, nil
+}
+
+func (a *activityStyleUseCase) DestroyActivityStyle(c context.Context, id string) error {
+	err := a.rep.Destroy(c, id)
+	return err
+}

--- a/api/internals/usecase/activity_usecase.go
+++ b/api/internals/usecase/activity_usecase.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"strconv"
 
 	rep "github.com/NUTFes/FinanSu/api/externals/repository"
 	"github.com/NUTFes/FinanSu/api/internals/domain"
@@ -150,7 +151,8 @@ func (a *activityUseCase) GetActivityDetail(c context.Context) ([]domain.Activit
 
 	activity := domain.ActivityDetail{}
 	var activities []domain.ActivityDetail
-
+	sposorStyle := domain.SponsorStyle{}
+	var sponsorStyles []domain.SponsorStyle
 	// クエリー実行
 	rows, err := a.rep.FindDetail(c)
 	if err != nil {
@@ -177,12 +179,6 @@ func (a *activityUseCase) GetActivityDetail(c context.Context) ([]domain.Activit
 			&activity.Sponsor.Representative,
 			&activity.Sponsor.CreatedAt,
 			&activity.Sponsor.UpdatedAt,
-			&activity.SponsorStyle.ID,
-			&activity.SponsorStyle.Style,
-			&activity.SponsorStyle.Feature,
-			&activity.SponsorStyle.Price,
-			&activity.SponsorStyle.CreatedAt,
-			&activity.SponsorStyle.UpdatedAt,
 			&activity.User.ID,
 			&activity.User.Name,
 			&activity.User.BureauID,
@@ -190,12 +186,27 @@ func (a *activityUseCase) GetActivityDetail(c context.Context) ([]domain.Activit
 			&activity.User.CreatedAt,
 			&activity.User.UpdatedAt,
 		)
-
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot connect SQL")
 		}
-
+		rows, err := a.rep.FindSponsorStyle(c,strconv.Itoa(int(activity.Activity.ID)))
+		for rows.Next(){
+			err := rows.Scan(
+				&sposorStyle.ID,
+				&sposorStyle.Style,
+				&sposorStyle.Feature,
+				&sposorStyle.Price,
+				&sposorStyle.CreatedAt,
+				&sposorStyle.UpdatedAt,
+			)
+			if err != nil {
+				return nil, err
+			}
+			sponsorStyles = append(sponsorStyles, sposorStyle)
+		}
+		activity.SponsorStyle = sponsorStyles
 		activities = append(activities, activity)
+		sponsorStyles = nil
 	}
 	return activities, nil
 }

--- a/api/internals/usecase/activity_usecase.go
+++ b/api/internals/usecase/activity_usecase.go
@@ -15,8 +15,8 @@ type activityUseCase struct {
 type ActivityUseCase interface {
 	GetActivity(context.Context) ([]domain.Activity, error)
 	GetActivityByID(context.Context, string) (domain.Activity, error)
-	CreateActivity(context.Context, string, string, string, string, string, string, string) (domain.Activity, error)
-	UpdateActivity(context.Context, string, string, string, string, string, string, string, string) (domain.Activity, error)
+	CreateActivity(context.Context, string, string, string, string, string, string) (domain.Activity, error)
+	UpdateActivity(context.Context, string, string, string, string, string, string, string) (domain.Activity, error)
 	DestroyActivity(context.Context, string) error
 	GetActivityDetail(context.Context) ([]domain.ActivityDetail, error)
 }
@@ -40,7 +40,6 @@ func (a *activityUseCase) GetActivity(c context.Context) ([]domain.Activity, err
 	for rows.Next() {
 		err := rows.Scan(
 			&activity.ID,
-			&activity.SponsorStyleID,
 			&activity.UserID,
 			&activity.IsDone,
 			&activity.SponsorID,
@@ -66,7 +65,6 @@ func (a *activityUseCase) GetActivityByID(c context.Context, id string) (domain.
 	row, err := a.rep.Find(c, id)
 	err = row.Scan(
 		&activity.ID,
-		&activity.SponsorStyleID,
 		&activity.UserID,
 		&activity.IsDone,
 		&activity.SponsorID,
@@ -86,7 +84,6 @@ func (a *activityUseCase) GetActivityByID(c context.Context, id string) (domain.
 
 func (a *activityUseCase) CreateActivity(
 	c context.Context,
-	sponsorStyleID string,
 	userID string,
 	isDone string,
 	sponsorID string,
@@ -95,11 +92,10 @@ func (a *activityUseCase) CreateActivity(
 	remark string) (domain.Activity, error) {
 	latastActivity := domain.Activity{}
 
-	err := a.rep.Create(c, sponsorStyleID, userID, isDone, sponsorID, feature, expense, remark)
+	err := a.rep.Create(c, userID, isDone, sponsorID, feature, expense, remark)
 	row, err := a.rep.FindLatestRecord(c)
 	err = row.Scan(
 		&latastActivity.ID,
-		&latastActivity.SponsorStyleID,
 		&latastActivity.UserID,
 		&latastActivity.IsDone,
 		&latastActivity.SponsorID,
@@ -119,7 +115,6 @@ func (a *activityUseCase) CreateActivity(
 func (a *activityUseCase) UpdateActivity(
 	c context.Context,
 	id string,
-	sponsorStyleID string,
 	userID string,
 	isDone string,
 	sponsorID string,
@@ -127,11 +122,10 @@ func (a *activityUseCase) UpdateActivity(
 	expense string,
 	remark string) (domain.Activity, error) {
 	updatedActivity := domain.Activity{}
-	err := a.rep.Update(c, id, sponsorStyleID, userID, isDone, sponsorID, feature, expense, remark)
+	err := a.rep.Update(c, id, userID, isDone, sponsorID, feature, expense, remark)
 	row, err := a.rep.Find(c, id)
 	err = row.Scan(
 		&updatedActivity.ID,
-		&updatedActivity.SponsorStyleID,
 		&updatedActivity.UserID,
 		&updatedActivity.IsDone,
 		&updatedActivity.SponsorID,
@@ -167,7 +161,6 @@ func (a *activityUseCase) GetActivityDetail(c context.Context) ([]domain.Activit
 	for rows.Next() {
 		err := rows.Scan(
 			&activity.Activity.ID,
-			&activity.Activity.SponsorStyleID,
 			&activity.Activity.UserID,
 			&activity.Activity.IsDone,
 			&activity.Activity.SponsorID,

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -7,6 +7,7 @@ import (
 
 type router struct {
 	activityController        controller.ActivityController
+	activityStyleController   controller.ActivityStyleController
 	budgetController          controller.BudgetController
 	bureauController          controller.BureauController
 	departmentController      controller.DepartmentController
@@ -31,6 +32,7 @@ type Router interface {
 
 func NewRouter(
 	activityController controller.ActivityController,
+	activitystyleController controller.ActivityStyleController,
 	budgetController controller.BudgetController,
 	bureauController controller.BureauController,
 	departmentController controller.DepartmentController,
@@ -50,6 +52,7 @@ func NewRouter(
 ) Router {
 	return router{
 		activityController,
+		activitystyleController,
 		budgetController,
 		bureauController,
 		departmentController,
@@ -80,6 +83,13 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.PUT("/activities/:id", r.activityController.UpdateActivity)
 	e.DELETE("/activities/:id", r.activityController.DestroyActivity)
 	e.GET("/activities/details", r.activityController.IndexActivityDetail)
+
+	// activityStyleのRoute
+	e.GET("/activity_styles", r.activityStyleController.IndexActivityStyle)
+	e.GET("/activity_styles/:id", r.activityStyleController.ShowActivityStyle)
+	e.POST("/activity_styles", r.activityStyleController.CreateActivityStyle)
+	e.PUT("/activity_styles/:id", r.activityStyleController.UpdateActivityStyle)
+	e.DELETE("/activity_styles/:id", r.activityStyleController.DestroyActivityStyle)
 
 	// budgetsのRoute
 	e.GET("/budgets", r.budgetController.IndexBudget)

--- a/mysql/db/activities.sql
+++ b/mysql/db/activities.sql
@@ -16,7 +16,7 @@ CREATE TABLE activities (
 INSERT into activities (user_id, is_done, sponsor_id, feature, expense, remark) values (1, false, 1, "なし", 11, "");
 INSERT into activities (user_id, is_done, sponsor_id, feature, expense, remark) values (2, false, 2, "クーポン", 22, "味玉or大盛無料");
 
-CREATE TABLE activitiy_styles (
+CREATE TABLE activity_styles (
   id int(10) unsigned not null auto_increment,
   activity_id int(10),
   sponsor_style_id int(10),
@@ -25,5 +25,5 @@ CREATE TABLE activitiy_styles (
   PRIMARY KEY (id)
 );
 
-INSERT into activitiy_styles (activity_id, sponsor_style_id) values (1, 1);
-INSERT into activitiy_styles (activity_id, sponsor_style_id) values (2, 2);
+INSERT into activity_styles (activity_id, sponsor_style_id) values (1, 1);
+INSERT into activity_styles (activity_id, sponsor_style_id) values (2, 2);

--- a/mysql/db/activities.sql
+++ b/mysql/db/activities.sql
@@ -27,3 +27,5 @@ CREATE TABLE activity_styles (
 
 INSERT into activity_styles (activity_id, sponsor_style_id) values (1, 1);
 INSERT into activity_styles (activity_id, sponsor_style_id) values (2, 2);
+INSERT into activity_styles (activity_id, sponsor_style_id) values (1, 2);
+INSERT into activity_styles (activity_id, sponsor_style_id) values (2, 1);

--- a/mysql/db/activities.sql
+++ b/mysql/db/activities.sql
@@ -2,7 +2,6 @@ use finansu_db;
 
 CREATE TABLE activities (
   id int(10) unsigned not null auto_increment,
-  sponsor_style_id int(10),
   user_id int(10),
   is_done boolean,
   sponsor_id int(10),
@@ -14,8 +13,8 @@ CREATE TABLE activities (
   PRIMARY KEY (id)
 );
 
-INSERT into activities (sponsor_style_id, user_id, is_done, sponsor_id, feature, expense, remark) values (1, 1, false, 1, "なし", 11, "");
-INSERT into activities (sponsor_style_id, user_id, is_done, sponsor_id, feature, expense, remark) values (2, 2, false, 2, "クーポン", 22, "味玉or大盛無料");
+INSERT into activities (user_id, is_done, sponsor_id, feature, expense, remark) values (1, false, 1, "なし", 11, "");
+INSERT into activities (user_id, is_done, sponsor_id, feature, expense, remark) values (2, false, 2, "クーポン", 22, "味玉or大盛無料");
 
 CREATE TABLE activitiy_styles (
   id int(10) unsigned not null auto_increment,

--- a/mysql/db/activities.sql
+++ b/mysql/db/activities.sql
@@ -16,3 +16,15 @@ CREATE TABLE activities (
 
 INSERT into activities (sponsor_style_id, user_id, is_done, sponsor_id, feature, expense, remark) values (1, 1, false, 1, "なし", 11, "");
 INSERT into activities (sponsor_style_id, user_id, is_done, sponsor_id, feature, expense, remark) values (2, 2, false, 2, "クーポン", 22, "味玉or大盛無料");
+
+CREATE TABLE activitiy_styles (
+  id int(10) unsigned not null auto_increment,
+  activity_id int(10),
+  sponsor_style_id int(10),
+  created_at datetime not null default current_timestamp,
+  updated_at datetime not null default current_timestamp on update current_timestamp,
+  PRIMARY KEY (id)
+);
+
+INSERT into activitiy_styles (activity_id, sponsor_style_id) values (1, 1);
+INSERT into activitiy_styles (activity_id, sponsor_style_id) values (2, 2);


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#572
<!-- 対応したIssue番号を記載 -->
resolve #572

# 概要
<!-- 開発内容の概要を記載 -->
協賛活動と協賛スタイルが多対多の関係になるように中間テーブルactivity_styleテーブルを作成した。
activity_styleに関するAPIの作成(CRUD)
activity_styleのswaggerへの追加
`/activity/details`を叩いた際、複数の協賛スタイルが結びつくようにした。

協賛活動の詳細
<img width="441" alt="スクリーンショット 2023-05-12 13 45 34" src="https://github.com/NUTFes/FinanSu/assets/115447919/5f9afd87-e9f9-46fb-9b2d-4d4e1de1b43c">
中間テーブル(活動とスタイルを結びつけるためには、このレコードを追加する必要がある)
<img width="593" alt="スクリーンショット 2023-05-12 13 48 42" src="https://github.com/NUTFes/FinanSu/assets/115447919/a8448a85-a7b8-4cb2-a352-fbabe8dfb391">

中間テーブルのAPIについて
 GET `/activity_styles`
中間テーブルの一覧を取得

POST  `/activity_styles`
中間テーブルにレコードの追加

GET `/activity_styles/:id`
idで指定されたレコードを取得

PUT `/activity_styles/:id`
idで指定されたレコードを修正

DELETE `/activity_styles/:id`
idで指定されたレコードを削除

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![スクリーンショット 2023-05-12 13 52 11](https://github.com/NUTFes/FinanSu/assets/115447919/6ee88499-bb2f-4092-b4e0-7edb37c47f77)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- `docker compose down -v` → `docker compose up`の順でコンテナ起動
- swaggerで以下を確認する
   - 中間テーブル`/activity_styles`の操作ができるか
   - `/activities/details`で複数の協賛スタイルが取得できているか
-

# 備考
