### PR TITLE
スマホページのテーブルレイアウトの実装

### DIFF
--- a/view/next-project/src/components/auth/SignInView.tsx
+++ b/view/next-project/src/components/auth/SignInView.tsx
@@ -53,7 +53,7 @@ export default function SignInView() {
       <div className='my-16 flex w-full flex-col items-center'>
         <div className='mb-10 flex flex-col gap-3'>
           <div className='grid grid-cols-3 items-center justify-items-end gap-5'>
-            <p className='whitespace-nowrap text-black-300'>メールアドレス</p>
+            <p className='md:text-md whitespace-nowrap text-sm text-black-300'>メールアドレス</p>
             <input
               type='text'
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
@@ -66,7 +66,7 @@ export default function SignInView() {
                 },
               })}
             />
-            <p className='whitespace-nowrap text-black-300'>パスワード</p>
+            <p className='md:text-md whitespace-nowrap text-sm text-black-300'>パスワード</p>
             <input
               type='password'
               className='col-span-2 w-full border-b border-b-primary-1 p-1'

--- a/view/next-project/src/components/auth/SignUpView.tsx
+++ b/view/next-project/src/components/auth/SignUpView.tsx
@@ -82,14 +82,14 @@ export default function SignUpView() {
       <div className='my-16 flex w-full flex-col items-center'>
         <div className='mb-10 flex flex-col gap-3'>
           <div className='grid grid-cols-3 items-center justify-items-end gap-5'>
-            <p className='whitespace-nowrap text-black-300'>名前</p>
+            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>名前</p>
             <input
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               type='text'
               value={postUserData.name}
               onChange={userDataHandler('name')}
             />
-            <p className='whitespace-nowrap text-black-300'>学科</p>
+            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>学科</p>
             <select
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               value={postUserData.bureauID}
@@ -101,7 +101,7 @@ export default function SignUpView() {
                 </option>
               ))}
             </select>
-            <p className='whitespace-nowrap text-black-300'>メールアドレス</p>
+            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>メールアドレス</p>
             <input
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               type='text'
@@ -114,7 +114,7 @@ export default function SignUpView() {
                 },
               })}
             />
-            <p className='whitespace-nowrap text-black-300'>パスワード</p>
+            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>パスワード</p>
             <input
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               type='password'
@@ -126,7 +126,7 @@ export default function SignUpView() {
                 },
               })}
             />
-            <p className='whitespace-nowrap text-black-300'>パスワード確認</p>
+            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>パスワード確認</p>
             <input
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               type='password'

--- a/view/next-project/src/components/auth/SignUpView.tsx
+++ b/view/next-project/src/components/auth/SignUpView.tsx
@@ -82,14 +82,14 @@ export default function SignUpView() {
       <div className='my-16 flex w-full flex-col items-center'>
         <div className='mb-10 flex flex-col gap-3'>
           <div className='grid grid-cols-3 items-center justify-items-end gap-5'>
-            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>名前</p>
+            <p className='md:text-md whitespace-nowrap text-sm text-black-300'>名前</p>
             <input
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               type='text'
               value={postUserData.name}
               onChange={userDataHandler('name')}
             />
-            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>学科</p>
+            <p className='md:text-md whitespace-nowrap text-sm text-black-300'>学科</p>
             <select
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               value={postUserData.bureauID}
@@ -101,7 +101,7 @@ export default function SignUpView() {
                 </option>
               ))}
             </select>
-            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>メールアドレス</p>
+            <p className='md:text-md whitespace-nowrap text-sm text-black-300'>メールアドレス</p>
             <input
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               type='text'
@@ -114,7 +114,7 @@ export default function SignUpView() {
                 },
               })}
             />
-            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>パスワード</p>
+            <p className='md:text-md whitespace-nowrap text-sm text-black-300'>パスワード</p>
             <input
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               type='password'
@@ -126,7 +126,7 @@ export default function SignUpView() {
                 },
               })}
             />
-            <p className='whitespace-nowrap text-black-300 text-sm md:text-md'>パスワード確認</p>
+            <p className='md:text-md whitespace-nowrap text-sm text-black-300'>パスワード確認</p>
             <input
               className='col-span-2 w-full border-b border-b-primary-1 p-1'
               type='password'

--- a/view/next-project/src/components/budgets/ExpenseAddModal.tsx
+++ b/view/next-project/src/components/budgets/ExpenseAddModal.tsx
@@ -41,7 +41,7 @@ export default function ExpenseAddModal(props: ModalProps) {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='mr-5 ml-auto w-fit'>
           <CloseButton onClick={() => props.setIsOpen(false)} />

--- a/view/next-project/src/components/budgets/ExpenseDeleteModal.tsx
+++ b/view/next-project/src/components/budgets/ExpenseDeleteModal.tsx
@@ -24,7 +24,7 @@ const ExpenseDeleteModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={() => props.setShowModal(false)} />

--- a/view/next-project/src/components/budgets/ExpenseEditModal.tsx
+++ b/view/next-project/src/components/budgets/ExpenseEditModal.tsx
@@ -52,7 +52,7 @@ export default function ExpenseEditModal(props: ModalProps) {
   );
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton

--- a/view/next-project/src/components/budgets/OpenExpenseAddModalButton.tsx
+++ b/view/next-project/src/components/budgets/OpenExpenseAddModalButton.tsx
@@ -5,7 +5,7 @@ import { AddButton } from '@components/common';
 import { Year } from '@type/common';
 
 interface Props {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   years: Year[];
   disabled: boolean;
 }

--- a/view/next-project/src/components/purchaseorders/DeleteModal.tsx
+++ b/view/next-project/src/components/purchaseorders/DeleteModal.tsx
@@ -22,7 +22,7 @@ const DeleteModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={() => props.setShowModal(false)} />
@@ -30,7 +30,7 @@ const DeleteModal: FC<ModalProps> = (props) => {
       </div>
       <div className='mx-auto mb-5 w-fit text-xl text-black-600'>購入申請の削除</div>
       <div className='mx-auto my-5 w-fit text-xl'>削除しますか？</div>
-      <div className=''>
+      <div>
         <div className='flex flex-row justify-center gap-5'>
           <OutlinePrimaryButton onClick={closeModal}>戻る</OutlinePrimaryButton>
           <PrimaryButton

--- a/view/next-project/src/components/purchaseorders/DetailModal.tsx
+++ b/view/next-project/src/components/purchaseorders/DetailModal.tsx
@@ -47,7 +47,7 @@ const DetailModal: FC<ModalProps> = (props) => {
   }, [props.expenses, props.purchaseOrderViewItem]);
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className={clsx('w-full')}>
         <div className={clsx('mr-5 grid w-full justify-items-end')}>
           <RiCloseCircleLine size={'23px'} color={'gray'} onClick={onClose} />

--- a/view/next-project/src/components/purchaseorders/EditModal.tsx
+++ b/view/next-project/src/components/purchaseorders/EditModal.tsx
@@ -133,7 +133,7 @@ export default function EditModal(props: ModalProps) {
   return (
     <>
       {props.isOpen && (
-        <Modal className='w-1/2'>
+        <Modal className='md:w-1/2 w-full'>
           <div className='ml-auto w-fit'>
             <CloseButton
               onClick={() => {

--- a/view/next-project/src/components/purchaseorders/PurchaseOrderAddModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseOrderAddModal.tsx
@@ -130,7 +130,7 @@ export default function AddModal(props: ModalProps) {
   // 購入物品の確認用テーブル
   const PurchaseItemTable = (purchaseItems: PurchaseItem[]) => {
     return (
-      <table className={clsx('table-fixed border-collapse')}>
+      <table className={clsx('table-fixed border-collapse md:w-full w-max')}>
         <thead>
           <tr className={clsx('border border-x-white-0 border-b-primary-1 border-t-white-0 py-3')}>
             {tableColumns.map((tableColumn: string) => (
@@ -231,7 +231,7 @@ export default function AddModal(props: ModalProps) {
 
   return (
     <>
-      <Modal className='!w-1/2'>
+      <Modal className='mt-32 md:m-0 md:w-1/2'>
         <div className={clsx('w-full')}>
           <div className={clsx('mr-5 grid w-full justify-items-end')}>
             <CloseButton
@@ -261,7 +261,7 @@ export default function AddModal(props: ModalProps) {
                 >
                   購入物品
                 </div>
-                <div className={clsx('mb-2 grid w-full justify-items-center p-5')}>
+                <div className={clsx('mb-2 overflow-scroll grid w-full justify-items-center md:p-5')}>
                   {PurchaseItemTable(props.formDataList)}
                 </div>
                 <div className={clsx('my-10 grid grid-cols-12 gap-4')}>

--- a/view/next-project/src/components/purchasereports/AddModal.tsx
+++ b/view/next-project/src/components/purchasereports/AddModal.tsx
@@ -7,7 +7,7 @@ export default function PurchaseItemNumModal() {
   const { setModalView, openModal, closeModal } = useUI();
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='ml-auto w-fit'>
         <CloseButton onClick={closeModal} />
       </div>

--- a/view/next-project/src/components/purchasereports/DeleteModal.tsx
+++ b/view/next-project/src/components/purchasereports/DeleteModal.tsx
@@ -24,7 +24,7 @@ const PurchaseReportDeleteModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={() => props.setShowModal(false)} />

--- a/view/next-project/src/components/purchasereports/DetailModal.tsx
+++ b/view/next-project/src/components/purchasereports/DetailModal.tsx
@@ -57,7 +57,7 @@ const DetailModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='ml-auto w-fit'>
         <RiCloseCircleLine size={'23px'} color={'gray'} onClick={onClose} />
       </div>

--- a/view/next-project/src/components/purchasereports/EditModal.tsx
+++ b/view/next-project/src/components/purchasereports/EditModal.tsx
@@ -221,7 +221,7 @@ export default function EditModal(props: ModalProps) {
   return (
     <>
       {props.isOpen && (
-        <Modal className='w-1/2'>
+        <Modal className='md:w-1/2'>
           <div className='w-full'>
             <div className='ml-auto w-fit'>
               <CloseButton

--- a/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
@@ -76,7 +76,7 @@ export default function PurchaseItemNumModal() {
   };
 
   return (
-    <Modal>
+    <Modal className='md:m-0 mt-32'>
       <div className={clsx('w-full')}>
         <div className={clsx('mr-5 grid w-full justify-items-end')}>
           <CloseButton onClick={closeModal} />
@@ -88,8 +88,8 @@ export default function PurchaseItemNumModal() {
       <div className={clsx('mb-4 grid grid-cols-12 gap-4')}>
         <div className={clsx('col-span-1 grid')} />
         <div className={clsx('col-span-10 grid')}>
-          <div className={clsx('w-100 mb-2 p-5')}>
-            <table className={clsx('table-fixed border-collapse')}>
+          <div className={clsx('w-full overflow-scroll mb-2 p-5')}>
+            <table className={clsx('w-max md:w-full table-fixed border-collapse')}>
               <thead>
                 <tr
                   className={clsx(

--- a/view/next-project/src/components/purchasereports/PurchaseReportAddModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportAddModal.tsx
@@ -244,7 +244,7 @@ export default function PurchaseReportAddModal(props: ModalProps) {
   return (
     <>
       {props.isOpen && (
-        <Modal className='w-1/2'>
+        <Modal className='md:w-1/2'>
           <div className='ml-auto w-fit'>
             <CloseButton
               onClick={() => {

--- a/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
@@ -118,7 +118,7 @@ export default function PurchaseReportItemNumModal() {
 
   return (
     <>
-      <Modal className='w-1/2'>
+      <Modal className='md:w-1/2'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={closeModal} />
         </div>

--- a/view/next-project/src/components/sponsors/DeleteModal.tsx
+++ b/view/next-project/src/components/sponsors/DeleteModal.tsx
@@ -24,13 +24,13 @@ const SponsorDeleteModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={() => props.setShowModal(false)} />
         </div>
       </div>
-      <div className='mx-auto mb-5 w-fit text-xl text-black-600'>協賛企業の削除</div>
+      <div className='mx-auto mb-5 w-fit text-xl text-black-600'>企業情報の削除</div>
       <div className='mx-auto my-5 w-fit text-xl'>削除しますか？</div>
       <div className=''>
         <div className='flex flex-row justify-center gap-5'>

--- a/view/next-project/src/components/sponsors/SponsorAddModal.tsx
+++ b/view/next-project/src/components/sponsors/SponsorAddModal.tsx
@@ -36,7 +36,7 @@ export default function SponsorAddModal() {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='mr-5 ml-auto w-fit'>
           <CloseButton onClick={closeModal} />

--- a/view/next-project/src/components/sponsors/SponsorEditModal.tsx
+++ b/view/next-project/src/components/sponsors/SponsorEditModal.tsx
@@ -34,13 +34,13 @@ export default function SponsorEditModal(props: Props) {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='mr-5 ml-auto w-fit'>
           <CloseButton onClick={() => props.setIsOpen(false)} />
         </div>
       </div>
-      <h1 className='mx-auto mb-10 w-fit text-xl text-black-600'>企業登録</h1>
+      <h1 className='mx-auto mb-10 w-fit text-xl text-black-600'>企業情報編集</h1>
       <div className='my-6 grid grid-cols-5 items-center justify-items-center gap-4'>
         <p className='col-span-1 text-black-600'>企業名</p>
         <div className='col-span-4 w-full'>

--- a/view/next-project/src/components/sponsorstyles/DeleteModal.tsx
+++ b/view/next-project/src/components/sponsorstyles/DeleteModal.tsx
@@ -24,7 +24,7 @@ const SponsorStyleDeleteModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={() => props.setShowModal(false)} />

--- a/view/next-project/src/components/sponsorstyles/EditModal.tsx
+++ b/view/next-project/src/components/sponsorstyles/EditModal.tsx
@@ -74,7 +74,7 @@ export default function EditModal(props: ModalProps) {
   );
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton

--- a/view/next-project/src/components/sponsorstyles/OpenDeleteModalButton.tsx
+++ b/view/next-project/src/components/sponsorstyles/OpenDeleteModalButton.tsx
@@ -15,7 +15,7 @@ const OpenDeleteModalButton: React.FC<Props> = (props) => {
   };
   return (
     <>
-      <DeleteButton onClick={onOpen} isDisabled={true} />
+      <DeleteButton onClick={onOpen} />
       {isOpen && <DeleteModal id={props.id} setShowModal={setIsOpen} />}
     </>
   );

--- a/view/next-project/src/components/sponsorstyles/OpenEditModalButton.tsx
+++ b/view/next-project/src/components/sponsorstyles/OpenEditModalButton.tsx
@@ -18,7 +18,7 @@ const OpenEditModalButton: React.FC<Props> = (props) => {
   };
   return (
     <>
-      <EditButton onClick={onOpen} isDisabled={true} />
+      <EditButton onClick={onOpen}/>
       {isOpen && (
         <EditModal
           sponsorStyleId={props.id}

--- a/view/next-project/src/components/sponsorstyles/SponsorStyleAddModal.tsx
+++ b/view/next-project/src/components/sponsorstyles/SponsorStyleAddModal.tsx
@@ -40,7 +40,7 @@ export default function SponsorAddModal(props: ModalProps) {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='mr-5 ml-auto w-fit'>
           <CloseButton onClick={() => props.setIsOpen(false)} />

--- a/view/next-project/src/components/teacher/AddModal.tsx
+++ b/view/next-project/src/components/teacher/AddModal.tsx
@@ -47,7 +47,7 @@ const OpenAddModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='ml-auto w-fit'>
         <RiCloseCircleLine size={'23px'} color={'gray'} onClick={closeModal} />
       </div>

--- a/view/next-project/src/components/teacher/DeleteModal.tsx
+++ b/view/next-project/src/components/teacher/DeleteModal.tsx
@@ -22,7 +22,7 @@ export default function DeleteModal(props: ModalProps) {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={() => props.setShowModal(false)} />

--- a/view/next-project/src/components/teacher/EditModal.tsx
+++ b/view/next-project/src/components/teacher/EditModal.tsx
@@ -39,11 +39,11 @@ export default function FundInformationEditModal(props: ModalProps) {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='ml-auto w-fit'>
         <RiCloseCircleLine size={'23px'} color={'gray'} onClick={closeModal} />
       </div>
-      <div className='mx-auto w-fit text-xl'>教員の登録</div>
+      <div className='mx-auto w-fit text-xl'>教員情報の編集</div>
       <div className='my-10 grid grid-cols-5 items-center justify-items-center gap-5 text-black-600'>
         <p>教員名</p>
         <div className='col-span-4 w-full'>

--- a/view/next-project/src/components/users/EditModal.tsx
+++ b/view/next-project/src/components/users/EditModal.tsx
@@ -36,7 +36,7 @@ export default function FundInformationEditModal(props: ModalProps) {
   };
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='ml-auto w-fit'>
         <CloseButton
           onClick={() => {

--- a/view/next-project/src/pages/budgets/index.tsx
+++ b/view/next-project/src/pages/budgets/index.tsx
@@ -204,7 +204,6 @@ export default function BudgetList(props: Props) {
                           </td>
                         </tr>
                       ))}
-<<<<<<< HEAD
                       {!filteredBudgets.length && (
                         <tr>
                           <td colSpan={6} className='py-3 text-center text-sm text-black-600'>
@@ -327,7 +326,6 @@ export default function BudgetList(props: Props) {
                           </td>
                         </tr>
                       ))}
-<<<<<<< HEAD
                       {!filteredExpenses.length && (
                         <tr>
                           <td colSpan={6} className='py-3 text-center text-sm text-black-600'>

--- a/view/next-project/src/pages/budgets/index.tsx
+++ b/view/next-project/src/pages/budgets/index.tsx
@@ -75,6 +75,9 @@ export default function BudgetList(props: Props) {
 
   const currentYear: Year = { year: new Date().getFullYear() };
   const [selectedYear, setSelectedYear] = useState<Year>(currentYear);
+  const [selectedExpenseYear, setSelectedExpenseYear] = useState<string>(
+    currentYear.year.toString(),
+  );
   const handleSelectedYear = (selectedYear: number) => {
     const year: Year = { year: selectedYear };
     setSelectedYear(year);
@@ -88,9 +91,9 @@ export default function BudgetList(props: Props) {
 
   const filteredExpenses = useMemo(() => {
     return expenses.filter((expenseView) => {
-      expenseView.expense.createdAt?.includes(String(selectedYear.year));
+      return expenseView.expense.createdAt?.includes(selectedExpenseYear);
     });
-  }, [expenses, selectedYear]);
+  }, [expenses, selectedExpenseYear]);
 
   // 合計金額用の変数
   const budgetsTotalFee = filteredBudgets.reduce((prev, current) => {
@@ -114,7 +117,7 @@ export default function BudgetList(props: Props) {
         <meta name='viewport' content='initial-scale=1.0, width=device-width' />
       </Head>
       <Tabs variant='soft-rounded' className='primary-1'>
-        <TabList className='mx-20 mt-10'>
+        <TabList className='mx-5 mt-10 md:mx-20'>
           <Tab>収入</Tab>
           <Tab>支出</Tab>
         </TabList>
@@ -134,7 +137,7 @@ export default function BudgetList(props: Props) {
                     <option value='2023'>2023</option>
                   </select>
                 </div>
-                <div className='flex justify-end'>
+                <div className='hidden justify-end md:flex'>
                   <OpenAddModalButton sources={sources} years={years}>
                     <RiAddCircleLine
                       size={20}
@@ -145,8 +148,8 @@ export default function BudgetList(props: Props) {
                     収入登録
                   </OpenAddModalButton>
                 </div>
-                <div className='w-100 mb-2 p-5'>
-                  <table className='mb-5 w-full table-auto border-collapse'>
+                <div className='overflow-scroll mt-4 mb-2 md:p-5'>
+                  <table className='mb-5 w-max md:w-full table-auto border-collapse'>
                     <thead>
                       <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 text-sm text-black-600'>
                         <th className='pb-3'>
@@ -201,25 +204,39 @@ export default function BudgetList(props: Props) {
                           </td>
                         </tr>
                       ))}
-                    </tbody>
-                    <tfoot
-                      className={clsx(
-                        'border border-x-white-0 border-t-primary-1 border-b-white-0',
+                      {!filteredBudgets.length && (
+                        <tr>
+                          <td colSpan={6} className='py-3 text-center text-sm text-black-600'>
+                            データがありません
+                          </td>
+                        </tr>
                       )}
-                    >
-                      <tr>
-                        <th />
-                        <th className='py-3 pt-4 pb-3 text-center text-black-600'>合計金額</th>
-                        <th className='py-3 pt-4 pb-3 text-center text-black-600'>
-                          {budgetsTotalFee}
-                        </th>
-                        <th />
-                      </tr>
-                    </tfoot>
+                    </tbody>
+                    {filteredBudgets.length > 0 && (
+                      <tfoot
+                        className={clsx(
+                          'border border-x-white-0 border-t-primary-1 border-b-white-0',
+                        )}
+                      >
+                        <tr>
+                          <th />
+                          <th className='py-3 pt-4 pb-3 text-center text-black-600'>合計金額</th>
+                          <th className='py-3 pt-4 pb-3 text-center text-black-600'>
+                            {budgetsTotalFee}
+                          </th>
+                          <th />
+                        </tr>
+                      </tfoot>
+                    )}
                   </table>
                 </div>
               </div>
             </Card>
+            <div className='fixed bottom-4 right-4 md:hidden'>
+              <OpenAddModalButton sources={sources} years={years}>
+                <RiAddCircleLine size={20} />
+              </OpenAddModalButton>
+            </div>
           </TabPanel>
           <TabPanel>
             <Card>
@@ -229,20 +246,15 @@ export default function BudgetList(props: Props) {
                   <select
                     className='w-100 '
                     defaultValue={currentYear.year}
-                    onChange={(e) => handleSelectedYear(Number(e.target.value))}
+                    onChange={(e) => setSelectedExpenseYear(e.target.value)}
                   >
                     <option value='2021'>2021</option>
                     <option value='2022'>2022</option>
                     <option value='2023'>2023</option>
                   </select>
                 </div>
-                <div className='flex justify-end'>
-                  <OpenExpenseAddModalButton years={years} disabled={isDisabled}>
-                    支出元登録
-                  </OpenExpenseAddModalButton>
-                </div>
-                <div className='w-100 mb-2 p-5'>
-                  <table className='mb-5 w-full table-fixed border-collapse'>
+                <div className='overflow-scroll mt-4 mb-2 md:p-5'>
+                  <table className='mb-5 w-max md:w-full table-auto border-collapse'>
                     <thead>
                       <tr
                         className={clsx(
@@ -314,24 +326,36 @@ export default function BudgetList(props: Props) {
                           </td>
                         </tr>
                       ))}
-                    </tbody>
-                    <tfoot
-                      className={clsx(
-                        'border border-x-white-0 border-t-primary-1 border-b-white-0',
+                      {!filteredExpenses.length && (
+                        <tr>
+                          <td colSpan={6} className='py-3 text-center text-sm text-black-600'>
+                            データがありません
+                          </td>
+                        </tr>
                       )}
-                    >
-                      <tr>
-                        <th className='py-3 pt-4 pb-3 text-center text-black-600'>合計金額</th>
-                        <th className='py-3 pt-4 pb-3 text-center text-black-600'>
-                          {expensesTotalFee}
-                        </th>
-                        <th />
-                      </tr>
-                    </tfoot>
+                    </tbody>
+                    {filteredExpenses.length > 0 && (
+                      <tfoot
+                        className={clsx(
+                          'border border-x-white-0 border-t-primary-1 border-b-white-0',
+                        )}
+                      >
+                        <tr>
+                          <th className='py-3 pt-4 pb-3 text-center text-black-600'>合計金額</th>
+                          <th className='py-3 pt-4 pb-3 text-center text-black-600'>
+                            {expensesTotalFee}
+                          </th>
+                          <th />
+                        </tr>
+                      </tfoot>
+                    )}
                   </table>
                 </div>
               </div>
             </Card>
+            <div className='fixed bottom-4 right-4 md:hidden'>
+              <OpenExpenseAddModalButton years={years} disabled={isDisabled} />
+            </div>
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/view/next-project/src/pages/fund_informations/index.tsx
+++ b/view/next-project/src/pages/fund_informations/index.tsx
@@ -237,7 +237,7 @@ export default function FundInformations(props: Props) {
                       <div>金額 : {fundViewItem.fundInformation.price}円</div>
                     </div>
                   </div>
-                  <div className='flex gap-4 ml-auto'>
+                  <div className='ml-auto flex gap-4'>
                     <OpenEditModalButton
                       fundInformation={fundViewItem.fundInformation}
                       teachers={teachers}

--- a/view/next-project/src/pages/fund_informations/index.tsx
+++ b/view/next-project/src/pages/fund_informations/index.tsx
@@ -205,9 +205,9 @@ export default function FundInformations(props: Props) {
           {filteredFundInformationViews &&
             filteredFundInformationViews.map((fundViewItem: FundInformationView) => (
               <Card key={fundViewItem.fundInformation.id}>
-                <div className='flex items-end justify-between p-4'>
+                <div className='flex flex-col gap-2 p-4'>
                   <div>
-                    <div className='mt-2 text-sm'>
+                    <div className='mt-2'>
                       {fundViewItem.fundInformation.isLastCheck &&
                         fundViewItem.fundInformation.isFirstCheck && (
                           <div className='flex items-center gap-1'>
@@ -237,7 +237,7 @@ export default function FundInformations(props: Props) {
                       <div>金額 : {fundViewItem.fundInformation.price}円</div>
                     </div>
                   </div>
-                  <div className='flex gap-2'>
+                  <div className='flex gap-4 ml-auto'>
                     <OpenEditModalButton
                       fundInformation={fundViewItem.fundInformation}
                       teachers={teachers}

--- a/view/next-project/src/pages/index.tsx
+++ b/view/next-project/src/pages/index.tsx
@@ -40,9 +40,9 @@ export default function Home() {
               alt='logo'
               width={150}
               height={40}
-              className='h-fit md:w-48 w-40'
+              className='h-fit w-40 md:w-48'
             />
-            <p className='text-2xl md:text-3xl text-black-600'>新規登録</p>
+            <p className='text-2xl text-black-600 md:text-3xl'>新規登録</p>
           </div>
           <SignUpView />
           <hr className='border-black-300' />
@@ -56,7 +56,7 @@ export default function Home() {
   };
   return (
     <LoginLayout>
-      <div className='md:w-1/2 m-4 w-fit rounded-lg px-5 shadow-md md:m-8 md:px-10'>
+      <div className='m-4 w-fit rounded-lg px-5 shadow-md md:m-8 md:w-1/2 md:px-10'>
         {cardContent(isMember)}
       </div>
     </LoginLayout>

--- a/view/next-project/src/pages/index.tsx
+++ b/view/next-project/src/pages/index.tsx
@@ -40,9 +40,9 @@ export default function Home() {
               alt='logo'
               width={150}
               height={40}
-              className='h-fit w-48'
+              className='h-fit md:w-48 w-40'
             />
-            <p className='text-3xl text-black-600'>新規登録</p>
+            <p className='text-2xl md:text-3xl text-black-600'>新規登録</p>
           </div>
           <SignUpView />
           <hr className='border-black-300' />
@@ -56,7 +56,7 @@ export default function Home() {
   };
   return (
     <LoginLayout>
-      <div className='m-8 w-fit min-w-[500px] rounded-lg px-10 shadow-md'>
+      <div className='md:w-1/2 m-4 w-fit rounded-lg px-5 shadow-md md:m-8 md:px-10'>
         {cardContent(isMember)}
       </div>
     </LoginLayout>

--- a/view/next-project/src/pages/purchaseorders/index.tsx
+++ b/view/next-project/src/pages/purchaseorders/index.tsx
@@ -159,12 +159,12 @@ export default function PurchaseOrders(props: Props) {
               <option value='2023'>2023</option>
             </select>
           </div>
-          <div className='flex justify-end'>
+          <div className='hidden justify-end md:flex'>
             <OpenAddModalButton expenses={props.expenses}>申請登録</OpenAddModalButton>
           </div>
         </div>
-        <div className='w-100 mb-2 p-5'>
-          <table className='mb-5 w-full table-fixed border-collapse'>
+        <div className='w-100 mb-2 p-5 overflow-scroll'>
+          <table className='mb-5 w-max md:w-full table-fixed border-collapse'>
             <thead>
               <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
                 <th className='w-2/12 pb-2'>
@@ -337,6 +337,9 @@ export default function PurchaseOrders(props: Props) {
           isDelete={false}
         />
       )}
+      <div className='fixed bottom-4 right-4 md:hidden'>
+        <OpenAddModalButton expenses={props.expenses} />
+      </div>
     </MainLayout>
   );
 }

--- a/view/next-project/src/pages/purchasereports/index.tsx
+++ b/view/next-project/src/pages/purchasereports/index.tsx
@@ -177,12 +177,12 @@ export default function PurchaseReports(props: Props) {
               <option value='2023'>2023</option>
             </select>
           </div>
-          <div className='flex justify-end'>
+          <div className='hidden justify-end md:flex'>
             <OpenAddModalButton>報告登録</OpenAddModalButton>
           </div>
         </div>
-        <div className='w-100 mb-2 p-5'>
-          <table className='mb-5 w-full table-fixed border-collapse'>
+        <div className='overflow-scroll w-100 mb-2 p-5'>
+          <table className='mb-5 w-max md:w-full table-fixed border-collapse'>
             <thead>
               <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
                 <th className='w-1/12 pb-2'>
@@ -401,6 +401,9 @@ export default function PurchaseReports(props: Props) {
           isDelete={false}
         />
       )}
+      <div className='fixed bottom-4 right-4 md:hidden'>
+        <OpenAddModalButton />
+      </div>
     </MainLayout>
   );
 }

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -103,7 +103,7 @@ export default function SponsorActivities(props: Props) {
           {filteredSponsorActivitiesViews &&
             filteredSponsorActivitiesViews.map((sponsorActivitiesItem) => (
               <Card key={sponsorActivitiesItem.sponsorActivity.id}>
-                <div className='flex items-end justify-between p-4'>
+                <div className='flex flex-col gap-2 p-4'>
                   <div>
                     {sponsorActivitiesItem.sponsorActivity.isDone && (
                       <div className='flex items-center gap-1'>
@@ -155,7 +155,7 @@ export default function SponsorActivities(props: Props) {
                       </div>
                     </div>
                   </div>
-                  <div className='mx-50 right-10'>
+                  <div className='ml-auto flex flex-row gap-4'>
                     <OpenEditModalButton
                       id={sponsorActivitiesItem.sponsorActivity.id || '0'}
                       sponsorActivity={sponsorActivitiesItem.sponsorActivity}
@@ -163,8 +163,6 @@ export default function SponsorActivities(props: Props) {
                       sponsorStyles={props.sponsorStyles}
                       users={props.users}
                     />
-                  </div>
-                  <div className='mx-2'>
                     <OpenDeleteModalButton id={sponsorActivitiesItem.sponsorActivity.id || 0} />
                   </div>
                 </div>

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -58,14 +58,12 @@ const sponsorship: NextPage<Props> = (props: Props) => {
               <option value='2023'>2023</option>
             </select>
           </div>
-          <div className='flex justify-end'>
-            <div>
-              <OpenAddModalButton>協賛企業登録</OpenAddModalButton>
-            </div>
+          <div className='hidden justify-end md:flex'>
+            <OpenAddModalButton>協賛企業登録</OpenAddModalButton>
           </div>
         </div>
-        <div className='mb-2 p-5'>
-          <table className='mb-5 w-full table-fixed border-collapse'>
+        <div className='mb-2 p-5 overflow-scroll'>
+          <table className='mb-5 w-max md:w-full table-fixed border-collapse'>
             <thead>
               <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
                 <th className='w-1/8 border-b-primary-1 pb-2'>
@@ -129,6 +127,9 @@ const sponsorship: NextPage<Props> = (props: Props) => {
           </table>
         </div>
       </Card>
+      <div className='fixed bottom-4 right-4 md:hidden'>
+        <OpenAddModalButton />
+      </div>
     </MainLayout>
   );
 };

--- a/view/next-project/src/pages/sponsorstyles/index.tsx
+++ b/view/next-project/src/pages/sponsorstyles/index.tsx
@@ -37,10 +37,8 @@ export default function SponsorStyleList(props: Props) {
           <div className='flex'>
             <Title>協賛スタイル一覧</Title>
           </div>
-          <div className='flex justify-end'>
-            <div>
-              <OpenAddModalButton>協賛スタイル登録</OpenAddModalButton>
-            </div>
+          <div className='hidden justify-end md:flex'>
+            <OpenAddModalButton>協賛スタイル登録</OpenAddModalButton>
           </div>
         </div>
         <div className='mb-2 p-5'>
@@ -81,6 +79,7 @@ export default function SponsorStyleList(props: Props) {
                       <OpenEditModalButton
                         id={sponsorStyleItem.id || 0}
                         sponsorStyle={sponsorStyleItem}
+                        
                       />
                       <OpenDeleteModalButton id={sponsorStyleItem.id || 0} />
                     </div>
@@ -91,6 +90,9 @@ export default function SponsorStyleList(props: Props) {
           </table>
         </div>
       </Card>
+      <div className='md:hidden fixed bottom-4 right-4'>
+        <OpenAddModalButton />
+      </div>
     </MainLayout>
   );
 }

--- a/view/next-project/src/pages/teachers/index.tsx
+++ b/view/next-project/src/pages/teachers/index.tsx
@@ -33,9 +33,9 @@ export default function TeachersList(props: Props) {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const isDisabled = useMemo(() => {
     if (currentUser?.roleID === 2 || currentUser?.roleID === 3 || currentUser?.id === 4) {
-      return true;
-    } else {
       return false;
+    } else {
+      return true;
     }
   }, [currentUser?.roleID, currentUser?.id, currentUser]);
 
@@ -58,12 +58,12 @@ export default function TeachersList(props: Props) {
           <div className='flex'>
             <Title title={'教員一覧'} />
           </div>
-          <div className='flex justify-end'>
+          <div className='hidden justify-end md:flex'>
             <OpenAddModalButton>教員登録</OpenAddModalButton>
           </div>
         </div>
-        <div className='mb-2 p-5'>
-          <table className='mb-5 w-full table-auto border-collapse'>
+        <div className='mb-2 p-5 overflow-scroll'>
+          <table className='mb-5 w-max md:w-full table-auto border-collapse'>
             <thead className='text-sm text-black-600'>
               <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
                 <th>
@@ -130,6 +130,9 @@ export default function TeachersList(props: Props) {
           </table>
         </div>
       </Card>
+      <div className='md:hidden fixed bottom-4 right-4'>
+        <OpenAddModalButton />
+      </div>
     </MainLayout>
   );
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #558

# 概要
<!-- 開発内容の概要を記載 -->

- 募金・協賛活動以外のページでテーブルレイアウトを実装した
  - 追加ボタンを右下に移動し、表ははみ出した分を スクロールで表示できるようにする
  - できれば全てカードレイアウトにしたかったが、開発速度優先
- 各モーダルもスマホ対応
  - ただ文字の崩れがあるが、これは後々治していく

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

https://github.com/NUTFes/FinanSu/assets/52590941/1ddacd6d-6767-41b0-9ce7-6372c36b99e5

# テスト項目
<!-- テストしてほしい内容を記載 -->

- [x] 各ページが開けるか
- [x] 各モーダルが開けるか

# 備考
