### PR TITLE
activities/detailsに中間テーブルも紐付ける

### DIFF
--- a/api/externals/repository/activity_repository.go
+++ b/api/externals/repository/activity_repository.go
@@ -123,7 +123,7 @@ func (ar *activityRepository) FindLatestRecord(c context.Context) (*sql.Row, err
 func (ar *activityRepository) FindSponsorStyle(c context.Context, sponsorStyleID string) (*sql.Rows, error) {
 	query := `
 		SELECT
-			ss.*
+			*
 		FROM
 			activity_styles
 		INNER JOIN

--- a/api/internals/domain/activity.go
+++ b/api/internals/domain/activity.go
@@ -19,6 +19,11 @@ type Activity struct {
 type ActivityDetail struct {
 	Activity		Activity		`json:"sponsorActivity"`
 	Sponsor			Sponsor			`json:"sponsor"`
-	SponsorStyle	[]SponsorStyle	`json:"sponsorStyle"`
 	User			User			`json:"user"`
+	StyleDetail		[]StyleDetail	`json:"styleDetail"`
+}
+
+type StyleDetail struct {
+	ActivityStyle 	ActivityStyle	`json:"activityStyle"`
+	SponsorStyle 	SponsorStyle 	`json:"sponsorStyle"`
 }

--- a/api/internals/usecase/activity_usecase.go
+++ b/api/internals/usecase/activity_usecase.go
@@ -151,8 +151,8 @@ func (a *activityUseCase) GetActivityDetail(c context.Context) ([]domain.Activit
 
 	activity := domain.ActivityDetail{}
 	var activities []domain.ActivityDetail
-	sposorStyle := domain.SponsorStyle{}
-	var sponsorStyles []domain.SponsorStyle
+	styleDetail := domain.StyleDetail{}
+	var styleDetails []domain.StyleDetail
 	// クエリー実行
 	rows, err := a.rep.FindDetail(c)
 	if err != nil {
@@ -192,21 +192,26 @@ func (a *activityUseCase) GetActivityDetail(c context.Context) ([]domain.Activit
 		rows, err := a.rep.FindSponsorStyle(c,strconv.Itoa(int(activity.Activity.ID)))
 		for rows.Next(){
 			err := rows.Scan(
-				&sposorStyle.ID,
-				&sposorStyle.Style,
-				&sposorStyle.Feature,
-				&sposorStyle.Price,
-				&sposorStyle.CreatedAt,
-				&sposorStyle.UpdatedAt,
+				&styleDetail.ActivityStyle.ID,
+				&styleDetail.ActivityStyle.ActivityID,
+				&styleDetail.ActivityStyle.SponsoStyleID,
+				&styleDetail.ActivityStyle.CreatedAt,
+				&styleDetail.ActivityStyle.UpdatedAt,
+				&styleDetail.SponsorStyle.ID,
+				&styleDetail.SponsorStyle.Style,
+				&styleDetail.SponsorStyle.Feature,
+				&styleDetail.SponsorStyle.Price,
+				&styleDetail.SponsorStyle.CreatedAt,
+				&styleDetail.SponsorStyle.UpdatedAt,
 			)
 			if err != nil {
 				return nil, err
 			}
-			sponsorStyles = append(sponsorStyles, sposorStyle)
+			styleDetails = append(styleDetails, styleDetail)
 		}
-		activity.SponsorStyle = sponsorStyles
+		activity.StyleDetail = styleDetails
 		activities = append(activities, activity)
-		sponsorStyles = nil
+		styleDetails = nil
 	}
 	return activities, nil
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
<!-- 対応したIssue番号を記載 -->
resolve #0

# 概要
<!-- 開発内容の概要を記載 -->
- `/activities/details`で中間テーブルのデータも紐づけるようにした。(中間テーブルの修正を容易にするため）

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="1104" alt="スクリーンショット 2023-05-13 16 11 20" src="https://github.com/NUTFes/FinanSu/assets/115447919/cd9aab82-1291-437e-a4fa-58564a3eaedb">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- swaggerで`/activities/details`の動作を確認する
-
-

# 備考
