### PR TITLE
[fix] 協賛活動の登録時に備考が編集できない問題を解決(#583)

### DIFF
--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -76,7 +76,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
         ? REMARK_COUPON
         : '';
     setFormData({ ...formData, remark: newRemark + newRemarkFeature });
-  }, [design, formData]);
+  }, [design]);
 
   const [selectedStyleIds, setSelectedStyleIds] = useState<number[]>([sponsorStyles[0].id || 0]);
   const [isStyleError, setIsStyleError] = useState(false);


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #583 

# 概要
<!-- 開発内容の概要を記載 -->
協賛活動の登録時に備考欄が編集できなかったので解決しました。
`newRemark` を更新する `useEffect` に `formData` が入ってたから、 `formData` を編集した時に `newRemark` が更新されて変更できないようになってたっぽいです。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- http://localhost:3000/sponsoractivities

https://github.com/NUTFes/FinanSu/assets/71711872/a2b185ee-6cb7-4224-a74b-0cb7735822d1


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] 協賛活動の登録時に備考欄が編集できるか

# 備考
Slackでは「協賛活動の登録・編集時に備考欄が編集できない」とあったが、動作確認したところ編集モーダルでは備考欄の編集ができたので今回は触れてないです。
本番環境で動作確認したけど、編集モーダルの備考欄は編集できました。