### PR TITLE
safariテーブル調整

### DIFF
--- a/view/next-project/src/components/budgets/DetailModal.tsx
+++ b/view/next-project/src/components/budgets/DetailModal.tsx
@@ -30,7 +30,7 @@ const DetailModal: FC<ModalProps> = (props) => {
   }, [props.expenseView.purchaseDetails]);
 
   return (
-    <Modal className='w-1/2'>
+    <Modal className='w-fit'>
       <div className='w-full'>
         <div className='ml-auto mr-5 w-fit'>
           <RiCloseCircleLine size={'23px'} color={'gray'} onClick={onClose} />

--- a/view/next-project/src/pages/purchaseorders/index.tsx
+++ b/view/next-project/src/pages/purchaseorders/index.tsx
@@ -164,13 +164,13 @@ export default function PurchaseOrders(props: Props) {
           </div>
         </div>
         <div className='w-100 mb-2 overflow-scroll p-5'>
-          <table className='mb-5 w-max table-fixed border-collapse md:w-full'>
+          <table className='mb-5 w-max table-auto border-collapse md:w-full md:table-fixed'>
             <thead>
               <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
                 <th className='w-2/12 pb-2'>
                   <div className='text-center text-sm text-black-600'>財務局長チェック</div>
                 </th>
-                <th className='w-1/12 border-b-primary-1 pb-2'>
+                <th className='w-2/12 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>購入したい局</div>
                 </th>
                 <th className='w-2/12 border-b-primary-1 pb-2'>

--- a/view/next-project/src/pages/purchasereports/index.tsx
+++ b/view/next-project/src/pages/purchasereports/index.tsx
@@ -182,7 +182,7 @@ export default function PurchaseReports(props: Props) {
           </div>
         </div>
         <div className='w-100 mb-2 overflow-scroll p-5'>
-          <table className='mb-5 w-max table-fixed border-collapse md:w-full'>
+          <table className='mb-5 w-max table-auto border-collapse md:w-full md:table-fixed'>
             <thead>
               <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
                 <th className='w-1/12 pb-2'>

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -63,7 +63,7 @@ const sponsorship: NextPage<Props> = (props: Props) => {
           </div>
         </div>
         <div className='mb-2 overflow-scroll p-5'>
-          <table className='mb-5 w-max table-fixed border-collapse md:w-full'>
+          <table className='mb-5 w-max table-auto border-collapse md:w-full md:table-fixed'>
             <thead>
               <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
                 <th className='w-1/8 border-b-primary-1 pb-2'>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#587 
<!-- 対応したIssue番号を記載 -->
resolve #587 

# 概要
<!-- 開発内容の概要を記載 -->
- safariで開くと、テーブルが崩れている時があるため修正する。
- 原因
- tailwindでclassにw-max+table-fixedを当てるとwidthが1になってしまっていた。
- したがってsp版ではlassにw-max+table-autoを当てる
- 
# 画面スクリーンショット
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="411" alt="スクリーンショット 2023-05-29 17 29 30" src="https://github.com/NUTFes/FinanSu/assets/115447919/8869121b-8ce0-44fd-b9b3-37aa2495f831">
<img width="411" alt="スクリーンショット 2023-05-29 17 30 11" src="https://github.com/NUTFes/FinanSu/assets/115447919/a9fda19c-aca9-4515-a491-e2a850acd246">
<img width="411" alt="スクリーンショット 2023-05-29 17 30 29" src="https://github.com/NUTFes/FinanSu/assets/115447919/5662a02a-f97a-4506-917e-8df2e77f341c">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- safariで`localhost:3000`を開き、テーブルが崩れていないか確認する
-
-

# 備考
