### PR TITLE
協賛企業登録のエスケープ処理

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1494,48 +1494,20 @@ const docTemplate = `{
             "post": {
                 tags: ["sponsor"],
                 "description": "sponsorの作成",
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "sponsor",
+                        "schema":{
+                            "$ref": "#/definitions/sponsor"
+                        },
+                    },
+                ],
                 responses: {
                     "200": {
                         "description": "作成されたsponsorが返ってくる",
-                    }
+                    },
                 },
-                "parameters": [
-                    {
-                        "name": "name",
-                        "in": "query",
-                        "description": "name",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "tel",
-                        "in": "query",
-                        "description": "tel",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "email",
-                        "in": "query",
-                        "description": "email",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "address",
-                        "in": "query",
-                        "description": "address",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "representative",
-                        "in": "query",
-                        "description": "representative",
-                        "required": true,
-                        "type": "string"
-                    }
-                ],
             },
         },
         "/sponsors/{id}": {
@@ -1574,40 +1546,12 @@ const docTemplate = `{
                         "type": "integer"
                     },
                     {
-                        "name": "name",
-                        "in": "query",
-                        "description": "name",
-                        "required": true,
-                        "type": "string"
+                        "in": "body",
+                        "name": "sponsor",
+                        "schema":{
+                            "$ref": "#/definitions/sponsor"
+                        },
                     },
-                    {
-                        "name": "tel",
-                        "in": "query",
-                        "description": "tel",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "email",
-                        "in": "query",
-                        "description": "email",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "address",
-                        "in": "query",
-                        "description": "address",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "representative",
-                        "in": "query",
-                        "description": "representative",
-                        "required": true,
-                        "type": "string"
-                    }
                 ],
             },
             "delete": {
@@ -2095,28 +2039,6 @@ const docTemplate = `{
         },
     },
     "definitions":{
-        "sponsorStyle":{
-            "properties":{
-                "style":{
-                    "type": "string",
-                    "example": "1分の1",
-
-                },
-                "feature":{
-                    "type": "string",
-                    "example": "カラー",
-                },
-                "price":{
-                    "type": "int",
-                    "example": 30000,
-                },
-            },
-            "required":{
-                    "style",
-                    "feature",
-                    "price",
-            },
-        },
         "activity":{
             "properties":{
                 "sponsorID":{
@@ -2170,6 +2092,60 @@ const docTemplate = `{
             "required":{
                     "activityID",
                     "sponsorStyleID",
+            },
+        },
+        "sponsorStyle":{
+            "properties":{
+                "style":{
+                    "type": "string",
+                    "example": "1分の1",
+
+                },
+                "feature":{
+                    "type": "string",
+                    "example": "カラー",
+                },
+                "price":{
+                    "type": "int",
+                    "example": 30000,
+                },
+            },
+            "required":{
+                    "style",
+                    "feature",
+                    "price",
+            },
+        },
+        "sponsor":{
+            "properties":{
+                "name":{
+                    "type": "string",
+                    "example": "企業1",
+
+                },
+                "tel":{
+                    "type": "string",
+                    "example": "09000000000",
+                },
+                "email":{
+                    "type": "string",
+                    "example": "test@example.com",
+                },
+                "address":{
+                    "type": "string",
+                    "example": "○○1-1",
+                },
+                "representative":{
+                    "type": "string",
+                    "example": "長岡太郎(社長)",
+                },
+            },
+            "required":{
+                    "name",
+                    "tel",
+                    "email",
+                    "address",
+                    "representative"
             },
         },
     },

--- a/api/externals/controller/sponsor_controller.go
+++ b/api/externals/controller/sponsor_controller.go
@@ -2,7 +2,9 @@ package controller
 
 import (
 	"net/http"
+	"strings"
 
+	"github.com/NUTFes/FinanSu/api/internals/domain"
 	"github.com/NUTFes/FinanSu/api/internals/usecase"
 	"github.com/labstack/echo/v4"
 )
@@ -41,11 +43,16 @@ func (s *sponsorController) ShowSponsor(c echo.Context) error {
 }
 
 func (s *sponsorController) CreateSponsor(c echo.Context) error {
-	Name := c.QueryParam("name")
-	Tel := c.QueryParam("tel")
-	Email := c.QueryParam("email")
-	Address := c.QueryParam("address")
-	Representative := c.QueryParam("representative")
+	sponsor := new(domain.Sponsor)
+	if err := c.Bind(sponsor); err != nil {
+		return err
+	}
+	//エスケープ処理
+	Name := strings.ReplaceAll(sponsor.Name, `"`, `\"`)
+	Tel := strings.ReplaceAll(sponsor.Tel, `"`, `\"`)
+	Email := strings.ReplaceAll(sponsor.Email, `"`, `\"`)
+	Address := strings.ReplaceAll(sponsor.Address, `"`, `\"`)
+	Representative := strings.ReplaceAll(sponsor.Representative, `"`, `\"`)
 
 	latastSponsor, err := s.u.CreateSponsor(c.Request().Context(), Name, Tel, Email, Address, Representative)
 	if err != nil {
@@ -56,11 +63,16 @@ func (s *sponsorController) CreateSponsor(c echo.Context) error {
 
 func (s *sponsorController) UpdateSponsor(c echo.Context) error {
 	id := c.Param("id")
-	Name := c.QueryParam("name")
-	Tel := c.QueryParam("tel")
-	Email := c.QueryParam("email")
-	Address := c.QueryParam("address")
-	Representative := c.QueryParam("representative")
+	sponsor := new(domain.Sponsor)
+	if err := c.Bind(sponsor); err != nil {
+		return err
+	}
+	//エスケープ処理
+	Name := strings.ReplaceAll(sponsor.Name, `"`, `\"`)
+	Tel := strings.ReplaceAll(sponsor.Tel, `"`, `\"`)
+	Email := strings.ReplaceAll(sponsor.Email, `"`, `\"`)
+	Address := strings.ReplaceAll(sponsor.Address, `"`, `\"`)
+	Representative := strings.ReplaceAll(sponsor.Representative, `"`, `\"`)
 
 	updatedSponsor, err := s.u.UpdateSponsor(c.Request().Context(), id, Name, Tel, Email, Address, Representative)
 	if err != nil {

--- a/api/externals/repository/sponsor_repository.go
+++ b/api/externals/repository/sponsor_repository.go
@@ -50,7 +50,7 @@ func (sr *sponsorRepository) Create(
 	query := `
 		INSERT  INTO
 			sponsors (name, tel, email, address, representative)
-		VALUES ('` + name + "','" + tel + "','" + email + "','" + address + "','" + representative + "')"
+		VALUES ("` + name + `","` + tel + `","` + email + `","` + address + `","` + representative + `")`
 	return sr.crud.UpdateDB(c, query)
 }
 
@@ -68,12 +68,12 @@ func (sr *sponsorRepository) Update(
 		UPDATE
 			sponsors
 		SET
-			name = '` + name +
-		"', tel='" + tel +
-		"', email = '" + email +
-		"', address = '" + address +
-		"', representative = '" + representative +
-		"' WHERE id = " + id
+			name = "` + name +
+		`", tel="` + tel +
+		`", email = "` + email +
+		`", address = "` + address +
+		`", representative = "` + representative +
+		`" WHERE id = ` + id
 	return sr.crud.UpdateDB(c, query)
 }
 

--- a/view/next-project/src/utils/api/sponsor.ts
+++ b/view/next-project/src/utils/api/sponsor.ts
@@ -1,25 +1,7 @@
 import { Sponsor } from '@type/common';
 
 export const post = async (url: string, data: Sponsor) => {
-  const name = data.name;
-  const tel = data.tel;
-  const email = data.email;
-  const address = data.address;
-  const representative = data.representative;
-  const postUrl =
-    url +
-    '?name=' +
-    name +
-    '&tel=' +
-    tel +
-    '&email=' +
-    email +
-    '&address=' +
-    address +
-    '&representative=' +
-    representative;
-
-  const res = await fetch(postUrl, {
+  const res = await fetch(url, {
     method: 'POST',
     mode: 'cors',
     headers: {
@@ -31,25 +13,7 @@ export const post = async (url: string, data: Sponsor) => {
 };
 
 export const put = async (url: string, data: Sponsor) => {
-  const name = data.name;
-  const tel = data.tel;
-  const email = data.email;
-  const address = data.address;
-  const representative = data.representative;
-  const postUrl =
-    url +
-    '?name=' +
-    name +
-    '&tel=' +
-    tel +
-    '&email=' +
-    email +
-    '&address=' +
-    address +
-    '&representative=' +
-    representative;
-
-  const res = await fetch(postUrl, {
+  const res = await fetch(url, {
     method: 'PUT',
     mode: 'cors',
     headers: {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#590 
<!-- 対応したIssue番号を記載 -->
resolve #590 

# 概要
<!-- 開発内容の概要を記載 -->
- フロントから受け取った文字列をエスケープして、'や"が含まれていても登録できるようにした
- 協賛企業の登録、修正の際データをクエリパラメータで送っていたのをbodyパラメータで送るようにした。
- 上に伴うswaggerの修正

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1104" alt="スクリーンショット 2023-06-01 14 40 45" src="https://github.com/NUTFes/FinanSu/assets/115447919/5afb6096-5f4b-4d4f-b8e9-23b2e39dfb9e">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 協賛企業ページで'や"を含む文字列を登録、修正して動作を確認する。
- swaggerで`/sponsor`のpost、putができるか確認する

# 備考
