### PR TITLE
activityのstyleがない場合にエラーが出ないようにする

### DIFF
--- a/view/next-project/src/components/sponsoractivities/DetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailModal.tsx
@@ -157,25 +157,33 @@ const DetailModal: FC<ModalProps> = (props) => {
           </tr>
         </thead>
         <tbody>
-          {props.sponsorActivitiesViewItem.styleDetail.map((styleDetail, index) => (
-            <tr
-              key={index}
-              className={clsx('border border-x-white-0 border-t-white-0', {
-                'border-b-primary-1':
-                  index === props.sponsorActivitiesViewItem.styleDetail.length - 1,
-              })}
-            >
-              <td className='py-3'>
-                <div className='text-center text-sm'>{styleDetail.sponsorStyle.style}</div>
-              </td>
-              <td className='py-3'>
-                <div className='text-center text-sm'>{styleDetail.sponsorStyle.feature}</div>
-              </td>
-              <td className='py-3'>
-                <div className='text-center text-sm'>{styleDetail.sponsorStyle.price} 円</div>
+          {props.sponsorActivitiesViewItem.styleDetail ? (
+            props.sponsorActivitiesViewItem.styleDetail.map((styleDetail, index) => (
+              <tr
+                key={index}
+                className={clsx('border border-x-white-0 border-t-white-0', {
+                  'border-b-primary-1':
+                    index === props.sponsorActivitiesViewItem.styleDetail.length - 1,
+                })}
+              >
+                <td className='py-3'>
+                  <div className='text-center text-sm'>{styleDetail.sponsorStyle.style}</div>
+                </td>
+                <td className='py-3'>
+                  <div className='text-center text-sm'>{styleDetail.sponsorStyle.feature}</div>
+                </td>
+                <td className='py-3'>
+                  <div className='text-center text-sm'>{styleDetail.sponsorStyle.price} 円</div>
+                </td>
+              </tr>
+            ))
+          ) : (
+            <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
+              <td colSpan={3} className='py-3'>
+                <div className='text-center text-sm text-red-500'>協賛スタイルを登録してください</div>
               </td>
             </tr>
-          ))}
+          )}
         </tbody>
       </table>
     </Modal>

--- a/view/next-project/src/components/sponsoractivities/DetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailModal.tsx
@@ -180,7 +180,9 @@ const DetailModal: FC<ModalProps> = (props) => {
           ) : (
             <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
               <td colSpan={3} className='py-3'>
-                <div className='text-center text-sm text-red-500'>協賛スタイルを登録してください</div>
+                <div className='text-center text-sm text-red-500'>
+                  協賛スタイルを登録してください
+                </div>
               </td>
             </tr>
           )}

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -46,10 +46,10 @@ export default function EditModal(props: ModalProps) {
   });
   const initStyleIds = sponsorStyleDetails
     ? sponsorStyleDetails.map((sponsorStyleDetail) => sponsorStyleDetail.sponsorStyleID)
-    : null;
-  const [selectedStyleIds, setSelectedStyleIds] = useState<number[] | null>(initStyleIds);
+    : [];
+  const [selectedStyleIds, setSelectedStyleIds] = useState<number[]>(initStyleIds);
 
-  const [isStyleError, setIsStyleError] = useState(false);
+  const [isStyleError, setIsStyleError] = useState(!sponsorStyleDetails);
   useEffect(() => {
     if (selectedStyleIds && selectedStyleIds.length === 0) {
       setIsStyleError(true);

--- a/view/next-project/src/components/sponsoractivities/OpenEditModalButton.tsx
+++ b/view/next-project/src/components/sponsoractivities/OpenEditModalButton.tsx
@@ -29,9 +29,11 @@ const OpenEditModalButton: React.FC<Props> = (props) => {
   const onOpen = () => {
     setIsOpen(true);
   };
-  const sponsorStyleDetails = props.sponsorStyleDetails.map((sponsorStyleDetail) => {
-    return sponsorStyleDetail.activityStyle;
-  });
+  const sponsorStyleDetails = props.sponsorStyleDetails
+    ? props.sponsorStyleDetails.map((sponsorStyleDetail) => {
+        return sponsorStyleDetail.activityStyle;
+      })
+    : null;
   return (
     <>
       <EditButton onClick={onOpen} isDisabled={props.isDisabled} />

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -136,13 +136,14 @@ export default function SponsorActivities(props: Props) {
                       <table className='my-1 w-full table-fixed border-collapse'>
                         <tbody>
                           <tr className='border border-b-primary-1'></tr>
-                          {sponsorActivitiesItem.styleDetail.map((styleDetail) => (
-                            <tr key={styleDetail.sponsorStyle.id}>
-                              <td className='text-center'>{styleDetail.sponsorStyle.style}</td>
-                              <td className='text-center'>{styleDetail.sponsorStyle.feature}</td>
-                              <td className='text-center'>{styleDetail.sponsorStyle.price}円</td>
-                            </tr>
-                          ))}
+                          {sponsorActivitiesItem.styleDetail &&
+                            sponsorActivitiesItem.styleDetail.map((styleDetail) => (
+                              <tr key={styleDetail.sponsorStyle.id}>
+                                <td className='text-center'>{styleDetail.sponsorStyle.style}</td>
+                                <td className='text-center'>{styleDetail.sponsorStyle.feature}</td>
+                                <td className='text-center'>{styleDetail.sponsorStyle.price}円</td>
+                              </tr>
+                            ))}
                           <tr className='border border-b-primary-1'></tr>
                         </tbody>
                       </table>
@@ -240,12 +241,16 @@ export default function SponsorActivities(props: Props) {
                       className='py-3'
                     >
                       <div className='text-center text-sm text-black-600'>
-                        {sponsorActivitiesItem.styleDetail.map((styleDetail) => (
-                          <div key={styleDetail.sponsorStyle.id}>
-                            <p>{`${styleDetail.sponsorStyle.style} / ${styleDetail.sponsorStyle.feature} / ${styleDetail.sponsorStyle.price} 円`}</p>
-                            <p></p>
-                          </div>
-                        ))}
+                        {sponsorActivitiesItem.styleDetail ? (
+                          sponsorActivitiesItem.styleDetail.map((styleDetail) => (
+                            <div key={styleDetail.sponsorStyle.id}>
+                              <p>{`${styleDetail.sponsorStyle.style} / ${styleDetail.sponsorStyle.feature} / ${styleDetail.sponsorStyle.price} 円`}</p>
+                              <p></p>
+                            </div>
+                          ))
+                        ) : (
+                          <div className='text-red-500'>協賛スタイルを登録してください</div>
+                        )}
                       </div>
                     </td>
                     <td


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve なし

# 概要
<!-- 開発内容の概要を記載 -->

- 紐づいてる協賛スタイルがない場合でも画面が表示できるようにした

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

<img width="1257" alt="スクリーンショット 2023-06-04 20 37 36" src="https://github.com/NUTFes/FinanSu/assets/52590941/3840db6d-abb3-48bd-87f4-6abc706d6414">
<img width="768" alt="スクリーンショット 2023-06-04 20 37 40" src="https://github.com/NUTFes/FinanSu/assets/52590941/810efc87-585e-41e0-85c1-a5e053796d51">
<img width="761" alt="スクリーンショット 2023-06-04 20 40 39" src="https://github.com/NUTFes/FinanSu/assets/52590941/dc875dc7-9953-453a-88ce-3e6b592632b1">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [swagger](http://localhost:1323/swagger/index.html#/)からactivitiesをpostする
  - 本来はactivity_styleもpostする必要があるが、今回はわざとしない
- FinanSuにログインし、協賛活動ページに移動する
  - ページと各モーダルが開くかどうか

# 備考
