### PR TITLE
企業ブース以外もある場合は選択可能に

### DIFF
--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -70,7 +70,7 @@ export default function EditModal(props: ModalProps) {
 
   const isSelectSponsorBooth = useMemo(() => {
     if (!selectedStyleIds) return false;
-    const isBoothOnly = (selectedStyleIds.length == 1);
+    const isBoothOnly = (selectedStyleIds.length === 1);
     const isBooth = selectedStyleIds.some((id) => {
       return sponsorStyles[id - 1]?.style === '企業ブース';
     });

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -70,10 +70,11 @@ export default function EditModal(props: ModalProps) {
 
   const isSelectSponsorBooth = useMemo(() => {
     if (!selectedStyleIds) return false;
+    const isBoothOnly = (selectedStyleIds.length == 1);
     const isBooth = selectedStyleIds.some((id) => {
       return sponsorStyles[id - 1]?.style === '企業ブース';
     });
-    return isBooth;
+    return isBooth && isBoothOnly;
   }, [selectedStyleIds, sponsorStyles]);
 
   useEffect(() => {

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -70,7 +70,7 @@ export default function EditModal(props: ModalProps) {
 
   const isSelectSponsorBooth = useMemo(() => {
     if (!selectedStyleIds) return false;
-    const isBoothOnly = (selectedStyleIds.length === 1);
+    const isBoothOnly = selectedStyleIds.length === 1;
     const isBooth = selectedStyleIds.some((id) => {
       return sponsorStyles[id - 1]?.style === '企業ブース';
     });

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -138,10 +138,11 @@ export default function SponsorActivitiesAddModal(props: Props) {
   }, [sponsorStyles]);
 
   const isSelectSponsorBooth = useMemo(() => {
+    const isBoothOnly = (selectedStyleIds.length == 1);
     const isBooth = selectedStyleIds.some((id) => {
       return sponsorStyles[id - 1]?.style === '企業ブース';
     });
-    return isBooth;
+    return isBooth && isBoothOnly;
   }, [selectedStyleIds, sponsorStyles]);
 
   useEffect(() => {

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -138,7 +138,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
   }, [sponsorStyles]);
 
   const isSelectSponsorBooth = useMemo(() => {
-    const isBoothOnly = (selectedStyleIds.length == 1);
+    const isBoothOnly = (selectedStyleIds.length === 1);
     const isBooth = selectedStyleIds.some((id) => {
       return sponsorStyles[id - 1]?.style === '企業ブース';
     });

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -138,7 +138,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
   }, [sponsorStyles]);
 
   const isSelectSponsorBooth = useMemo(() => {
-    const isBoothOnly = (selectedStyleIds.length === 1);
+    const isBoothOnly = selectedStyleIds.length === 1;
     const isBooth = selectedStyleIds.some((id) => {
       return sponsorStyles[id - 1]?.style === '企業ブース';
     });


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#594 
<!-- 対応したIssue番号を記載 -->
resolve #594 

# 概要
<!-- 開発内容の概要を記載 -->
企業ブースかつ協賛スタイルの配列サイズが1 の場合、オプションを選択不可にした。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="539" alt="スクリーンショット 2023-06-07 10 46 21" src="https://github.com/NUTFes/FinanSu/assets/115447919/00e86a1a-f68e-4591-b0e1-e26033e92418">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 協賛活動ページで追加、編集を行う
- スタイルが企業ブースのみの時、オプションが選択不可、企業ブース+他のスタイルの時オプションを選択できるか確認する。

# 備考
