### PR TITLE
[add]ユーザの絞り込み機能追加

### DIFF
--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -46,12 +46,14 @@ const OpenAddModal: FC<ModalProps> = (props) => {
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsers = useMemo(() => {
-    const res = props.users.filter((user) => {
+    const res = props.users
+      .filter((user) => {
         return user.bureauID === bureauId;
-      }).filter((user, index, self) => {
+      })
+      .filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
-    if(res.length !== 0) setFormData({ ...formData, userID: res[0].id });
+    if (res.length !== 0) setFormData({ ...formData, userID: res[0].id });
     return res;
   }, [bureauId]);
 

--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -47,12 +47,14 @@ const OpenAddModal: FC<ModalProps> = (props) => {
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsersByBureau = useMemo(() => {
     return props.users.filter((user) => {
-      return (user.bureauID === bureauId);
+      return user.bureauID === bureauId;
     });
   }, [bureauId]);
   const filteredUsers = useMemo(() => {
     return filteredUsersByBureau.filter((user, index) => {
-      const usernames = filteredUsersByBureau.map((e) => { return e.name; })
+      const usernames = filteredUsersByBureau.map((e) => {
+        return e.name;
+      });
       return usernames.indexOf(user.name) === index;
     });
   }, [filteredUsersByBureau]);
@@ -105,13 +107,13 @@ const OpenAddModal: FC<ModalProps> = (props) => {
         </div>
         <p className='text-black-600'>所属している局</p>
         <div className='col-span-4 w-full'>
-        <Select value={bureauId} onChange={(e) => setBureauId(Number(e.target.value))}>
-          {BUREAUS.map((bureaus) => (
-            <option key={bureaus.id} value={bureaus.id}>
-              {bureaus.name}
-            </option>
-          ))}
-        </Select>
+          <Select value={bureauId} onChange={(e) => setBureauId(Number(e.target.value))}>
+            {BUREAUS.map((bureaus) => (
+              <option key={bureaus.id} value={bureaus.id}>
+                {bureaus.name}
+              </option>
+            ))}
+          </Select>
         </div>
         <p className='col-span-1 text-black-600'>担当者</p>
         <div className='col-span-4 w-full'>

--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -46,14 +46,13 @@ const OpenAddModal: FC<ModalProps> = (props) => {
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsers = useMemo(() => {
-    const filteredUsers = props.users
-      .filter((user) => {
+    const res = props.users.filter((user) => {
         return user.bureauID === bureauId;
-      })
-      .filter((user, index, self) => {
+      }).filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
-    return filteredUsers;
+    if(res.length !== 0) setFormData({ ...formData, userID: res[0].id });
+    return res;
   }, [bureauId]);
 
   const handler =

--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -45,19 +45,15 @@ const OpenAddModal: FC<ModalProps> = (props) => {
 
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
-  const filteredUsersByBureau = useMemo(() => {
-    return props.users.filter((user) => {
-      return user.bureauID === bureauId;
-    });
-  }, [bureauId]);
   const filteredUsers = useMemo(() => {
-    return filteredUsersByBureau.filter((user, index) => {
-      const usernames = filteredUsersByBureau.map((e) => {
-        return e.name;
+    const filteredUsers = props.users.filter((user) => {
+      return user.bureauID === bureauId;
+    })
+      .filter((user, index, self) => {
+        return self.findIndex((u) => u.name === user.name) === index;
       });
-      return usernames.indexOf(user.name) === index;
-    });
-  }, [filteredUsersByBureau]);
+    return filteredUsers;
+  }, [bureauId]);
 
   const handler =
     (input: string) =>

--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -1,10 +1,11 @@
 import { useRouter } from 'next/router';
-import React, { Dispatch, FC, SetStateAction, useEffect, useState } from 'react';
+import React, { Dispatch, FC, SetStateAction, useEffect, useState, useMemo } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { Modal, CloseButton, Input, Select, PrimaryButton } from '../common';
 import { userAtom } from '@/store/atoms';
 import { post } from '@api/fundInformations';
+import { BUREAUS } from '@constants/bureaus';
 import { Department, FundInformation, Teacher, User } from '@type/common';
 
 interface ModalProps {
@@ -41,6 +42,20 @@ const OpenAddModal: FC<ModalProps> = (props) => {
       setFormData(initFormData);
     }
   }, [user, router.isReady]);
+
+  // 担当者を局でフィルタを適用
+  const [bureauId, setBureauId] = useState<number>(1);
+  const filteredUsersByBureau = useMemo(() => {
+    return props.users.filter((user) => {
+      return (user.bureauID === bureauId);
+    });
+  }, [bureauId]);
+  const filteredUsers = useMemo(() => {
+    return filteredUsersByBureau.filter((user, index) => {
+      const usernames = filteredUsersByBureau.map((e) => { return e.name; })
+      return usernames.indexOf(user.name) === index;
+    });
+  }, [filteredUsersByBureau]);
 
   const handler =
     (input: string) =>
@@ -88,10 +103,20 @@ const OpenAddModal: FC<ModalProps> = (props) => {
               ))}
           </Select>
         </div>
+        <p className='text-black-600'>所属している局</p>
+        <div className='col-span-4 w-full'>
+        <Select value={bureauId} onChange={(e) => setBureauId(Number(e.target.value))}>
+          {BUREAUS.map((bureaus) => (
+            <option key={bureaus.id} value={bureaus.id}>
+              {bureaus.name}
+            </option>
+          ))}
+        </Select>
+        </div>
         <p className='col-span-1 text-black-600'>担当者</p>
         <div className='col-span-4 w-full'>
           <Select className='w-full' value={formData.userID} onChange={handler('userID')}>
-            {props.users.map((user) => (
+            {filteredUsers.map((user) => (
               <option key={user.id} value={user.id}>
                 {user.name}
               </option>

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -1,8 +1,9 @@
 import { useRouter } from 'next/router';
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState, useMemo } from 'react';
 
 import { Modal, Input, Select, CloseButton, PrimaryButton } from '../common';
 import { put } from '@api/fundInformations';
+import { BUREAUS } from '@constants/bureaus';
 import { FundInformation, Teacher, User, Department } from '@type/common';
 
 interface ModalProps {
@@ -52,6 +53,18 @@ export default function EditModal(props: ModalProps) {
     router.reload();
   };
 
+  // 担当者を局でフィルタを適用
+  const [bureauId, setBureauId] = useState<number>(1);
+  const filteredUsers = useMemo(() => {
+    const filteredUsers = props.users.filter((user) => {
+      return user.bureauID === bureauId;
+    })
+      .filter((user, index, self) => {
+        return self.findIndex((u) => u.name === user.name) === index;
+      });
+    return filteredUsers;
+  }, [bureauId]);
+
   return (
     <Modal className='md:w-1/2'>
       <div className='w-full'>
@@ -89,10 +102,20 @@ export default function EditModal(props: ModalProps) {
               ))}
           </Select>
         </div>
+        <p className='text-black-600'>所属している局</p>
+        <div className='col-span-4 w-full'>
+          <Select value={bureauId} onChange={(e) => setBureauId(Number(e.target.value))}>
+            {BUREAUS.map((bureaus) => (
+              <option key={bureaus.id} value={bureaus.id}>
+                {bureaus.name}
+              </option>
+            ))}
+          </Select>
+        </div>
         <p className='col-span-1 text-black-600'>担当者</p>
         <div className='col-span-4 w-full'>
           <Select className='w-full' value={formData.userID} onChange={handler('userID')}>
-            {props.users.map((user) => (
+            {filteredUsers.map((user) => (
               <option key={user.id} value={user.id}>
                 {user.name}
               </option>

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -56,14 +56,13 @@ export default function EditModal(props: ModalProps) {
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsers = useMemo(() => {
-    const filteredUsers = props.users
-      .filter((user) => {
+    const res = props.users.filter((user) => {
         return user.bureauID === bureauId;
-      })
-      .filter((user, index, self) => {
+      }).filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
-    return filteredUsers;
+    if(res.length !== 0) setFormData({ ...formData, userID: res[0].id });
+    return res;
   }, [bureauId]);
 
   return (

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -56,12 +56,14 @@ export default function EditModal(props: ModalProps) {
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsers = useMemo(() => {
-    const res = props.users.filter((user) => {
+    const res = props.users
+      .filter((user) => {
         return user.bureauID === bureauId;
-      }).filter((user, index, self) => {
+      })
+      .filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
-    if(res.length !== 0) setFormData({ ...formData, userID: res[0].id });
+    if (res.length !== 0) setFormData({ ...formData, userID: res[0].id });
     return res;
   }, [bureauId]);
 

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -339,7 +339,7 @@ export default function EditModal(props: ModalProps) {
   );
 
   return (
-    <Modal className='mt-64 md:mt-0 md:w-1/2'>
+    <Modal className='mt-64 md:mt-32 md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -171,12 +171,14 @@ export default function EditModal(props: ModalProps) {
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsers = useMemo(() => {
-    const res =  users.filter((user) => {
+    const res = users
+      .filter((user) => {
         return user.bureauID === bureauId;
-      }).filter((user, index, self) => {
+      })
+      .filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
-    if(res.length !== 0) setFormData({ ...formData, userID: res[0].id });
+    if (res.length !== 0) setFormData({ ...formData, userID: res[0].id });
     return res;
   }, [bureauId]);
 

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -13,6 +13,7 @@ import {
   Textarea,
 } from '@components/common';
 import { MultiSelect } from '@components/common';
+import { BUREAUS } from '@constants/bureaus';
 import { SponsorActivity, Sponsor, SponsorStyle, User, ActivityStyle } from '@type/common';
 
 interface ModalProps {
@@ -167,6 +168,16 @@ export default function EditModal(props: ModalProps) {
     });
   };
 
+  // 担当者を局でフィルタを適用
+  const [bureauId, setBureauId] = useState<number>(1);
+  const filteredUsers = useMemo(() => {
+    return users.filter((user) => {
+      return user.bureauID === bureauId;
+    }).filter((user, index, self) => {
+      return self.findIndex((u) => u.name === user.name) === index;
+    })
+  }, [bureauId]);
+
   // 協賛企業の情報
   const content = (data: SponsorActivity) => (
     <div className='my-6 grid grid-cols-5 items-center justify-items-center gap-4'>
@@ -194,10 +205,20 @@ export default function EditModal(props: ModalProps) {
           }}
         />
       </div>
+      <p className='text-black-600'>所属している局</p>
+      <div className='col-span-4 w-full'>
+        <Select value={bureauId} onChange={(e) => setBureauId(Number(e.target.value))}>
+          {BUREAUS.map((bureaus) => (
+            <option key={bureaus.id} value={bureaus.id}>
+              {bureaus.name}
+            </option>
+          ))}
+        </Select>
+      </div>
       <p className='text-black-600'>担当者名</p>
       <div className='col-span-4 w-full'>
         <Select className='w-full' onChange={handler('userID')}>
-          {users.map((user) => (
+          {filteredUsers.map((user) => (
             <option key={user.id} value={user.id} selected={user.id === data.userID}>
               {user.name}
             </option>

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -171,13 +171,13 @@ export default function EditModal(props: ModalProps) {
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsers = useMemo(() => {
-    return users
-      .filter((user) => {
+    const res =  users.filter((user) => {
         return user.bureauID === bureauId;
-      })
-      .filter((user, index, self) => {
+      }).filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
+    if(res.length !== 0) setFormData({ ...formData, userID: res[0].id });
+    return res;
   }, [bureauId]);
 
   // 協賛企業の情報

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -14,6 +14,7 @@ import {
   Input,
   Textarea,
 } from '@components/common';
+import { BUREAUS } from '@constants/bureaus';
 import { SponsorActivity, Sponsor, SponsorStyle, User } from '@type/common';
 
 const TABLE_COLUMNS = [
@@ -87,6 +88,11 @@ export default function SponsorActivitiesAddModal(props: Props) {
       setIsStyleError(false);
     }
   }, [selectedStyleIds]);
+
+  const [bureauId, setBureauId] = useState<number>(1);
+  const filteredUsers = useMemo(() => {
+    return users.filter((user) => { return (user.bureauID === bureauId); });
+  }, [bureauId])
 
   const formDataHandler =
     (input: string) =>
@@ -184,10 +190,20 @@ export default function SponsorActivitiesAddModal(props: Props) {
           }}
         />
       </div>
+      <p className='text-black-600'>所属している局</p>
+      <div className='col-span-4 w-full'>
+        <Select value={bureauId} onChange={(e) => setBureauId(Number(e.target.value))}>
+          {BUREAUS.map((bureaus) => (
+            <option key={bureaus.id} value={bureaus.id}>
+              {bureaus.name}
+            </option>
+          ))}
+        </Select>
+      </div>
       <p className='text-black-600'>担当者名</p>
       <div className='col-span-4 w-full'>
         <Select value={data.userID} onChange={formDataHandler('userID')}>
-          {users.map((user: User) => (
+          {filteredUsers.map((user: User) => (
             <option key={user.id} value={user.id}>
               {user.name}
             </option>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -89,10 +89,19 @@ export default function SponsorActivitiesAddModal(props: Props) {
     }
   }, [selectedStyleIds]);
 
+  // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
+  const filteredUsersByBureau = useMemo(() => {
+    return users.filter((user) => {
+      return (user.bureauID === bureauId);
+    });
+  }, [bureauId]);
   const filteredUsers = useMemo(() => {
-    return users.filter((user) => { return (user.bureauID === bureauId); });
-  }, [bureauId])
+    return filteredUsersByBureau.filter((user, index) => {
+      const usernames = filteredUsersByBureau.map((e) => { return e.name; })
+      return usernames.indexOf(user.name) === index;
+    });
+  }, [filteredUsersByBureau]);
 
   const formDataHandler =
     (input: string) =>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -92,13 +92,13 @@ export default function SponsorActivitiesAddModal(props: Props) {
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsers = useMemo(() => {
-    return users
-      .filter((user) => {
+    const res =  users.filter((user) => {
         return user.bureauID === bureauId;
-      })
-      .filter((user, index, self) => {
+      }).filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
+    if(res.length !== 0) setFormData({ ...formData, userID: res[0].id });
+    return res;
   }, [bureauId]);
 
   const formDataHandler =

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -91,19 +91,13 @@ export default function SponsorActivitiesAddModal(props: Props) {
 
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
-  const filteredUsersByBureau = useMemo(() => {
+  const filteredUsers = useMemo(() => {
     return users.filter((user) => {
       return user.bureauID === bureauId;
-    });
+    }).filter((user, index, self) => {
+      return self.findIndex((u) => u.name === user.name) === index;
+    })
   }, [bureauId]);
-  const filteredUsers = useMemo(() => {
-    return filteredUsersByBureau.filter((user, index) => {
-      const usernames = filteredUsersByBureau.map((e) => {
-        return e.name;
-      });
-      return usernames.indexOf(user.name) === index;
-    });
-  }, [filteredUsersByBureau]);
 
   const formDataHandler =
     (input: string) =>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -92,12 +92,14 @@ export default function SponsorActivitiesAddModal(props: Props) {
   // 担当者を局でフィルタを適用
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsers = useMemo(() => {
-    const res =  users.filter((user) => {
+    const res = users
+      .filter((user) => {
         return user.bureauID === bureauId;
-      }).filter((user, index, self) => {
+      })
+      .filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
-    if(res.length !== 0) setFormData({ ...formData, userID: res[0].id });
+    if (res.length !== 0) setFormData({ ...formData, userID: res[0].id });
     return res;
   }, [bureauId]);
 

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -93,12 +93,14 @@ export default function SponsorActivitiesAddModal(props: Props) {
   const [bureauId, setBureauId] = useState<number>(1);
   const filteredUsersByBureau = useMemo(() => {
     return users.filter((user) => {
-      return (user.bureauID === bureauId);
+      return user.bureauID === bureauId;
     });
   }, [bureauId]);
   const filteredUsers = useMemo(() => {
     return filteredUsersByBureau.filter((user, index) => {
-      const usernames = filteredUsersByBureau.map((e) => { return e.name; })
+      const usernames = filteredUsersByBureau.map((e) => {
+        return e.name;
+      });
       return usernames.indexOf(user.name) === index;
     });
   }, [filteredUsersByBureau]);


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #552 

# 概要
<!-- 開発内容の概要を記載 -->
募金ページと協賛活動の追加モーダルに担当者を局ごとに絞り込む機能を追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
![スクリーンショット 2023-06-09 170546](https://github.com/NUTFes/FinanSu/assets/68796591/f2a5a2b0-3868-41de-86a3-09462c2ca1b0)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 局・名前が一致するアカウントを作成する(2名以上)
- [x] 募金・協賛活動ページで追加モーダルを開き，絞り込みができるかテストする
-

# 備考
