### PR TITLE
[add]交通費と協賛スタイルの合計金額追加

### DIFF
--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -80,6 +80,27 @@ export default function SponsorActivities(props: Props) {
     });
   }, [props, selectedYear]);
 
+  const TotalTransportationFee = useMemo(() => {
+    let totalFee = 0;
+    filteredSponsorActivitiesViews?.map((sponsorActivityItem) => {
+      totalFee += sponsorActivityItem.sponsorActivity.expense;
+    });
+    return totalFee;
+  }, [filteredSponsorActivitiesViews]);
+
+  const TotalActivityStyleFee = useMemo(() => {
+    let totalFee = 0;
+    filteredSponsorActivitiesViews?.map((sponsorActivityItem) => {
+      const sponsorActivitiesStylesPrice = sponsorActivityItem.styleDetail.map((styleDetail) => {
+        return styleDetail.sponsorStyle.price;
+      });
+      totalFee += sponsorActivitiesStylesPrice.reduce((fee, price) => {
+        return fee + price;
+      })
+    });
+    return totalFee;
+  }, [filteredSponsorActivitiesViews]);
+
   return (
     <MainLayout>
       <Head>
@@ -216,7 +237,7 @@ export default function SponsorActivities(props: Props) {
               {filteredSponsorActivitiesViews &&
                 filteredSponsorActivitiesViews.map((sponsorActivitiesItem, index) => (
                   <tr
-                    className={clsx(props.sponsorActivitiesView.length - 1 !== index && 'border-b')}
+                    className={clsx('border-b')}
                     key={sponsorActivitiesItem.sponsorActivity.id}
                   >
                     <td
@@ -339,6 +360,30 @@ export default function SponsorActivities(props: Props) {
                     </td>
                   </tr>
                 ))}
+              {filteredSponsorActivitiesViews.length > 0 && (
+                <tr className='border-b border-primary-1'>
+                  <td className='px-1 py-3' colSpan={1}>
+                    <div className='flex justify-end'>
+                      <div className='text-sm text-black-600'>合計</div>
+                    </div>
+                  </td>
+                  <td className='px-1 py-3'>
+                    <div className='text-center text-sm text-black-600'>
+                      {TotalActivityStyleFee}
+                    </div>
+                  </td>
+                  <td className='px-1 py-3' colSpan={3}>
+                    <div className='flex justify-end'>
+                      <div className='text-sm text-black-600'>合計</div>
+                    </div>
+                  </td>
+                  <td className='px-1 py-3'>
+                    <div className='text-center text-sm text-black-600'>
+                      {TotalTransportationFee}
+                    </div>
+                  </td>
+                </tr>
+              )}
               {!filteredSponsorActivitiesViews.length && (
                 <tr>
                   <td colSpan={6} className='py-3'>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #598 

# 概要
<!-- 開発内容の概要を記載 -->
年度ごとの交通費と協賛スタイルの合計金額を表示させた．

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![スクリーンショット 2023-06-09 212308](https://github.com/NUTFes/FinanSu/assets/68796591/71004ba2-da35-4d93-a3ae-265974b4029e)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] 協賛活動ページの協賛スタイルと交通費の合計金額が表示されるか
- [ ] 年度ごとに切り替えられるか

# 備考
