### PR TITLE
purchaseのdeleteの削除の修正

### DIFF
--- a/api/externals/repository/purchase_order_repository.go
+++ b/api/externals/repository/purchase_order_repository.go
@@ -23,6 +23,8 @@ type PurchaseOrderRepository interface {
 	FindUserInfo(context.Context, string) (*sql.Row, error)
 	FindPurchaseItem(context.Context, string) (*sql.Rows, error)
 	FindNewRecord(context.Context) (*sql.Row, error)
+	DeleteItems(context.Context, string) error
+	DeleteReport(context.Context, string) error
 }
 
 func NewPurchaseOrderRepository(c db.Client, ac abstract.Crud) PurchaseOrderRepository {
@@ -139,4 +141,22 @@ func (por *purchaseOrderRepository) FindNewRecord(c context.Context) (*sql.Row, 
 			id
 		DESC LIMIT 1`
 	return por.crud.ReadByID(c, query)
+}
+
+// 紐づいたitemの削除
+func (por *purchaseOrderRepository) DeleteItems(
+	c context.Context,
+	id string,
+) error {
+	query := `DELETE FROM purchase_items WHERE purchase_order_id =` + id
+	return por.crud.UpdateDB(c, query)
+}
+
+// 紐づいたreportの削除
+func (por *purchaseOrderRepository) DeleteReport(
+	c context.Context,
+	id string,
+) error {
+	query := `DELETE FROM purchase_reports WHERE purchase_order_id =` + id
+	return por.crud.UpdateDB(c, query)
 }

--- a/api/internals/usecase/purchase_order_usecase.go
+++ b/api/internals/usecase/purchase_order_usecase.go
@@ -130,6 +130,14 @@ func (p *purchaseOrderUseCase) DestroyPurchaseOrder(
 	id string,
 ) error {
 	err := p.rep.Delete(c, id)
+	if err != nil {
+		return err
+	}
+	err = p.rep.DeleteItems(c,id)
+	if err != nil {
+		return err
+	}
+	err = p.rep.DeleteReport(c,id)
 	return err
 }
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#600 
<!-- 対応したIssue番号を記載 -->
resolve #600

# 概要
<!-- 開発内容の概要を記載 -->
- 購入申請を削除するapi `DELETE` `/purchase_orders/{id}`を叩くと、それに紐づくitemsとreportも削除する。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- swaggerで`DELETE` `/purchase_orders/{id}`を叩く
- purchase_orderに紐づいたpurchase_items, purchase_reportsが削除されているか確認する。

# 備考
