### PR TITLE
制作局が使いやすくするための仕様追加

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2079,6 +2079,14 @@ const docTemplate = `{
                     "type": "string",
                     "example": "なし",
                 },
+                "design":{
+                    "type": "int",
+                    "example": 0,
+                },
+                "url":{
+                    "type": "string",
+                    "example": "",
+                },
             },
             "required":{
                     "sponsorID",

--- a/api/externals/controller/activity_controller.go
+++ b/api/externals/controller/activity_controller.go
@@ -53,7 +53,7 @@ func (a *activityController) CreateActivity(c echo.Context) error {
 		fmt.Println("err")
 		return err
 	}
-	latastActivity, err := a.u.CreateActivity(c.Request().Context() , strconv.Itoa(int(activities.UserID)), strconv.FormatBool(activities.IsDone), strconv.Itoa(int(activities.SponsorID)), activities.Feature, strconv.Itoa(int(activities.Expense)), activities.Remark)
+	latastActivity, err := a.u.CreateActivity(c.Request().Context() , strconv.Itoa(int(activities.UserID)), strconv.FormatBool(activities.IsDone), strconv.Itoa(int(activities.SponsorID)), activities.Feature, strconv.Itoa(int(activities.Expense)), activities.Remark, strconv.Itoa(int(activities.Design)) ,activities.Url)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func (a *activityController) UpdateActivity(c echo.Context) error {
 		fmt.Println("err")
 		return err
 	}
-	updatedActivity, err := a.u.UpdateActivity(c.Request().Context(), id , strconv.Itoa(int(activities.UserID)), strconv.FormatBool(activities.IsDone), strconv.Itoa(int(activities.SponsorID)), activities.Feature, strconv.Itoa(int(activities.Expense)), activities.Remark)
+	updatedActivity, err := a.u.UpdateActivity(c.Request().Context(), id , strconv.Itoa(int(activities.UserID)), strconv.FormatBool(activities.IsDone), strconv.Itoa(int(activities.SponsorID)), activities.Feature, strconv.Itoa(int(activities.Expense)), activities.Remark, strconv.Itoa(int(activities.Design)) ,activities.Url)
 	if err != nil {
 		return err
 	}

--- a/api/externals/repository/activity_repository.go
+++ b/api/externals/repository/activity_repository.go
@@ -16,8 +16,8 @@ type activityRepository struct {
 type ActivityRepository interface {
 	All(context.Context) (*sql.Rows, error)
 	Find(context.Context, string) (*sql.Row, error)
-	Create(context.Context, string, string, string, string, string, string) error
-	Update(context.Context, string, string, string, string, string,string, string) error
+	Create(context.Context, string, string, string, string, string, string, string, string) error
+	Update(context.Context, string, string, string, string, string,string, string, string, string) error
 	Destroy(context.Context, string) error
 	FindDetail(context.Context) (*sql.Rows, error)
 	FindLatestRecord(c context.Context) (*sql.Row, error)
@@ -48,13 +48,16 @@ func (ar *activityRepository) Create(
 	sponsorID string,
 	feature string,
 	expense string,
-	remark string) error {
+	remark string,
+	design string,
+	url string,
+	) error {
 
 	query := `
 	INSERT INTO	activities
-		(user_id, is_done, sponsor_id, feature, expense, remark)
+		(user_id, is_done, sponsor_id, feature, expense, remark, design, url)
 	VALUES
-		(` +userID + "," + isDone + "," + sponsorID + ",'" + feature + "'," + expense +",'" + remark +"')"
+		(` +userID + `,` + isDone + `,` + sponsorID +`,"` + feature + `",` + expense +`,"` + remark +`",` +design +`,"` +url +`")`
 
 	return ar.crud.UpdateDB(c, query)
 }
@@ -68,18 +71,23 @@ func (ar *activityRepository) Update(
 	sponsorID string,
 	feature string,
 	expense string,
-	remark string) error {
+	remark string,
+	design string,
+	url string,
+	) error {
 
 	query := `
 	UPDATE activities
 	SET
 		user_id = ` + userID +
-		", is_done = " + isDone +
-		", sponsor_id = " + sponsorID +
-		", feature = '" + feature +
-		"', expense = " + expense +
-		", remark = '" + remark +
-		"' where id = " + id
+		`, is_done = ` + isDone +
+		`, sponsor_id = ` + sponsorID +
+		`, feature = "` + feature +
+		`", expense = ` + expense +
+		`, remark = "` + remark +
+		`", design =` + design +
+		`, url ="` + url +
+		`" where id = ` + id
 
 	return ar.crud.UpdateDB(c, query)
 }

--- a/api/internals/domain/activity.go
+++ b/api/internals/domain/activity.go
@@ -12,6 +12,8 @@ type Activity struct {
 	Feature 		string		`json:"feature"`
 	Expense			uint		`json:"expense"`
 	Remark			string		`json:"remark"`
+	Design			int			`json:"design"`
+	Url				string		`json:"url"`
 	CreatedAt		time.Time	`json:"createdAt"`
 	UpdatedAt		time.Time	`json:"updatedAt"`
 }

--- a/api/internals/usecase/activity_usecase.go
+++ b/api/internals/usecase/activity_usecase.go
@@ -16,8 +16,8 @@ type activityUseCase struct {
 type ActivityUseCase interface {
 	GetActivity(context.Context) ([]domain.Activity, error)
 	GetActivityByID(context.Context, string) (domain.Activity, error)
-	CreateActivity(context.Context, string, string, string, string, string, string) (domain.Activity, error)
-	UpdateActivity(context.Context, string, string, string, string, string, string, string) (domain.Activity, error)
+	CreateActivity(context.Context, string, string, string, string, string, string, string, string) (domain.Activity, error)
+	UpdateActivity(context.Context, string, string, string, string, string, string, string, string, string) (domain.Activity, error)
 	DestroyActivity(context.Context, string) error
 	GetActivityDetail(context.Context) ([]domain.ActivityDetail, error)
 }
@@ -47,6 +47,8 @@ func (a *activityUseCase) GetActivity(c context.Context) ([]domain.Activity, err
 			&activity.Feature,
 			&activity.Expense,
 			&activity.Remark,
+			&activity.Design,
+			&activity.Url,
 			&activity.CreatedAt,
 			&activity.UpdatedAt,
 		)
@@ -72,6 +74,8 @@ func (a *activityUseCase) GetActivityByID(c context.Context, id string) (domain.
 		&activity.Feature,
 		&activity.Expense,
 		&activity.Remark,
+		&activity.Design,
+		&activity.Url,
 		&activity.CreatedAt,
 		&activity.UpdatedAt,
 	)
@@ -90,10 +94,12 @@ func (a *activityUseCase) CreateActivity(
 	sponsorID string,
 	feature string,
 	expense string,
-	remark string) (domain.Activity, error) {
+	remark string,
+	design string,
+	url string) (domain.Activity, error) {
 	latastActivity := domain.Activity{}
 
-	err := a.rep.Create(c, userID, isDone, sponsorID, feature, expense, remark)
+	err := a.rep.Create(c, userID, isDone, sponsorID, feature, expense, remark, design, url)
 	row, err := a.rep.FindLatestRecord(c)
 	err = row.Scan(
 		&latastActivity.ID,
@@ -103,6 +109,8 @@ func (a *activityUseCase) CreateActivity(
 		&latastActivity.Feature,
 		&latastActivity.Expense,
 		&latastActivity.Remark,
+		&latastActivity.Design,
+		&latastActivity.Url,
 		&latastActivity.CreatedAt,
 		&latastActivity.UpdatedAt,
 	)
@@ -121,9 +129,11 @@ func (a *activityUseCase) UpdateActivity(
 	sponsorID string,
 	feature string,
 	expense string,
-	remark string) (domain.Activity, error) {
+	remark string,
+	design string,
+	url string) (domain.Activity, error) {
 	updatedActivity := domain.Activity{}
-	err := a.rep.Update(c, id, userID, isDone, sponsorID, feature, expense, remark)
+	err := a.rep.Update(c, id, userID, isDone, sponsorID, feature, expense, remark, design, url)
 	row, err := a.rep.Find(c, id)
 	err = row.Scan(
 		&updatedActivity.ID,
@@ -132,7 +142,9 @@ func (a *activityUseCase) UpdateActivity(
 		&updatedActivity.SponsorID,
 		&updatedActivity.Feature,
 		&updatedActivity.Expense,
-		&updatedActivity.Remark,		
+		&updatedActivity.Remark,
+		&updatedActivity.Design,
+		&updatedActivity.Url,	
 		&updatedActivity.CreatedAt,
 		&updatedActivity.UpdatedAt,
 	)
@@ -169,6 +181,8 @@ func (a *activityUseCase) GetActivityDetail(c context.Context) ([]domain.Activit
 			&activity.Activity.Feature,
 			&activity.Activity.Expense,
 			&activity.Activity.Remark,
+			&activity.Activity.Design,
+			&activity.Activity.Url,
 			&activity.Activity.CreatedAt,
 			&activity.Activity.UpdatedAt,
 			&activity.Sponsor.ID,

--- a/mysql/db/activities.sql
+++ b/mysql/db/activities.sql
@@ -8,13 +8,15 @@ CREATE TABLE activities (
   feature varchar(255),
   expense int(10),
   remark varchar(255),
+  design int(10),
+  url varchar(255),
   created_at datetime not null default current_timestamp,
   updated_at datetime not null default current_timestamp on update current_timestamp,
   PRIMARY KEY (id)
 );
 
-INSERT into activities (user_id, is_done, sponsor_id, feature, expense, remark) values (1, false, 1, "なし", 11, "");
-INSERT into activities (user_id, is_done, sponsor_id, feature, expense, remark) values (2, false, 2, "クーポン", 22, "味玉or大盛無料");
+INSERT into activities (user_id, is_done, sponsor_id, feature, expense, remark, design, url) values (1, false, 1, "なし", 11, "" ,1 ,"");
+INSERT into activities (user_id, is_done, sponsor_id, feature, expense, remark, design, url) values (2, false, 2, "クーポン", 22, "味玉or大盛無料",1 ,"");
 
 CREATE TABLE activity_styles (
   id int(10) unsigned not null auto_increment,

--- a/view/next-project/src/components/sponsoractivities/DetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailModal.tsx
@@ -14,6 +14,8 @@ interface ModalProps {
   isDelete: boolean;
 }
 
+const designer=["学生が作成","企業が作成","去年のもの"];
+
 const DetailModal: FC<ModalProps> = (props) => {
   const onClose = () => {
     props.setIsOpen(false);
@@ -26,16 +28,16 @@ const DetailModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='mt-64 md:mt-0 md:w-1/2'>
+    <Modal className='mt-64 md:mt-5 md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto mr-5 w-fit'>
           <RiCloseCircleLine size={'23px'} color={'gray'} onClick={onClose} />
         </div>
       </div>
-      <p className='mx-auto mb-8 w-fit text-2xl font-thin leading-8 tracking-widest text-black-600'>
+      <p className='mx-auto mb-7 w-fit text-2xl font-thin leading-8 tracking-widest text-black-600'>
         協賛活動の詳細
       </p>
-      <div className='my-10 flex flex-wrap justify-center gap-8'>
+      <div className='my-7 flex flex-wrap justify-center gap-8'>
         <div className='flex gap-3'>
           <p className='text-black-600'>作成日</p>
           <p className='border-b border-primary-1'>
@@ -53,7 +55,7 @@ const DetailModal: FC<ModalProps> = (props) => {
           <p className='border-b border-primary-1'>{props.sponsorActivitiesViewItem.user.name}</p>
         </div>
       </div>
-      <div className='my-10 flex flex-wrap justify-center gap-8'>
+      <div className='my-7 flex flex-wrap justify-center gap-8'>
         <div className='flex gap-3'>
           <p className='text-black-600'>オプション</p>
           <p className='border-b border-primary-1'>
@@ -66,8 +68,38 @@ const DetailModal: FC<ModalProps> = (props) => {
             {props.sponsorActivitiesViewItem.sponsorActivity.expense}円
           </p>
         </div>
+        <div className='flex gap-3'>
+          <p className='text-black-600'>デザイン</p>
+          <p className='border-b border-primary-1'>
+            {designer[props.sponsorActivitiesViewItem.sponsorActivity.design]}
+          </p>
+        </div>
       </div>
-      <p className='mx-auto my-5 w-fit text-xl text-black-600'>備考</p>
+      <p className='mx-auto my-3 w-fit text-xl text-black-600'>広告データurl</p>
+      <table className='w-full table-fixed border-collapse'>
+        <thead>
+          <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'></tr>
+        </thead>
+        <tbody>
+          <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
+            <td className='py-3'>
+              <div>
+                <div
+                  className='border-primary-1 text-center text-black-600 '
+
+                >
+                  {props.sponsorActivitiesViewItem.sponsorActivity.url === '' && <p>なし</p>}
+                  {props.sponsorActivitiesViewItem.sponsorActivity.url !== '' &&
+                   <a href={props.sponsorActivitiesViewItem.sponsorActivity.url} className="hover:text-black-300 hover:underline">
+                    {props.sponsorActivitiesViewItem.sponsorActivity.url}
+                  </a>}
+                </div>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <p className='mx-auto mt-7 mb-2 w-fit text-xl text-black-600'>備考</p>
       <table className='w-full table-fixed border-collapse'>
         <thead>
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'></tr>
@@ -90,7 +122,7 @@ const DetailModal: FC<ModalProps> = (props) => {
           </tr>
         </tbody>
       </table>
-      <p className='mx-auto my-5 w-fit text-xl text-black-600'>協賛企業</p>
+      <p className='mx-auto mt-7 mb-2 w-fit text-xl text-black-600'>協賛企業</p>
       <table className='w-full table-fixed border-collapse'>
         <thead>
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
@@ -141,8 +173,8 @@ const DetailModal: FC<ModalProps> = (props) => {
           </tr>
         </tbody>
       </table>
-      <p className='mx-auto mb-5 mt-10 w-fit text-xl text-black-600'>協賛スタイル</p>
-      <table className='w-full table-fixed border-collapse'>
+      <p className='mx-auto mt-7 mb-2 w-fit text-xl text-black-600'>協賛スタイル</p>
+      <table className='mb-4 w-full table-fixed border-collapse'>
         <thead>
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
             <th className='w-1/4 px-6 pb-2'>

--- a/view/next-project/src/components/sponsoractivities/DetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailModal.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import { RiCloseCircleLine } from 'react-icons/ri';
 
 import { Modal } from '@components/common';
+import { DESIGNERS } from "@constants/designers";
 import { SponsorActivityView } from '@type/common';
 
 interface ModalProps {
@@ -13,7 +14,6 @@ interface ModalProps {
   sponsorActivitiesViewItem: SponsorActivityView;
   isDelete: boolean;
 }
-import { DESIGNERS } from "@constants/designers";
 
 const DetailModal: FC<ModalProps> = (props) => {
   const onClose = () => {

--- a/view/next-project/src/components/sponsoractivities/DetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailModal.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import { RiCloseCircleLine } from 'react-icons/ri';
 
 import { Modal } from '@components/common';
-import { DESIGNERS } from "@constants/designers";
+import { DESIGNERS } from '@constants/designers';
 import { SponsorActivityView } from '@type/common';
 
 interface ModalProps {
@@ -83,22 +83,23 @@ const DetailModal: FC<ModalProps> = (props) => {
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
             <td className='py-3'>
               <div>
-                <div
-                  className='border-primary-1 text-center text-black-600 '
-
-                >
+                <div className='border-primary-1 text-center text-black-600 '>
                   {props.sponsorActivitiesViewItem.sponsorActivity.url === '' && <p>なし</p>}
-                  {props.sponsorActivitiesViewItem.sponsorActivity.url !== '' &&
-                   <a href={props.sponsorActivitiesViewItem.sponsorActivity.url} className="hover:text-black-300 hover:underline">
-                    {props.sponsorActivitiesViewItem.sponsorActivity.url}
-                  </a>}
+                  {props.sponsorActivitiesViewItem.sponsorActivity.url !== '' && (
+                    <a
+                      href={props.sponsorActivitiesViewItem.sponsorActivity.url}
+                      className='hover:text-black-300 hover:underline'
+                    >
+                      {props.sponsorActivitiesViewItem.sponsorActivity.url}
+                    </a>
+                  )}
                 </div>
               </div>
             </td>
           </tr>
         </tbody>
       </table>
-      <p className='mx-auto mt-7 mb-2 w-fit text-xl text-black-600'>備考</p>
+      <p className='mx-auto mb-2 mt-7 w-fit text-xl text-black-600'>備考</p>
       <table className='w-full table-fixed border-collapse'>
         <thead>
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'></tr>
@@ -121,7 +122,7 @@ const DetailModal: FC<ModalProps> = (props) => {
           </tr>
         </tbody>
       </table>
-      <p className='mx-auto mt-7 mb-2 w-fit text-xl text-black-600'>協賛企業</p>
+      <p className='mx-auto mb-2 mt-7 w-fit text-xl text-black-600'>協賛企業</p>
       <table className='w-full table-fixed border-collapse'>
         <thead>
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
@@ -172,7 +173,7 @@ const DetailModal: FC<ModalProps> = (props) => {
           </tr>
         </tbody>
       </table>
-      <p className='mx-auto mt-7 mb-2 w-fit text-xl text-black-600'>協賛スタイル</p>
+      <p className='mx-auto mb-2 mt-7 w-fit text-xl text-black-600'>協賛スタイル</p>
       <table className='mb-4 w-full table-fixed border-collapse'>
         <thead>
           <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>

--- a/view/next-project/src/components/sponsoractivities/DetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailModal.tsx
@@ -13,8 +13,7 @@ interface ModalProps {
   sponsorActivitiesViewItem: SponsorActivityView;
   isDelete: boolean;
 }
-
-const designer=["学生が作成","企業が作成","去年のもの"];
+import { DESIGNERS } from "@constants/designers";
 
 const DetailModal: FC<ModalProps> = (props) => {
   const onClose = () => {
@@ -37,7 +36,7 @@ const DetailModal: FC<ModalProps> = (props) => {
       <p className='mx-auto mb-7 w-fit text-2xl font-thin leading-8 tracking-widest text-black-600'>
         協賛活動の詳細
       </p>
-      <div className='my-7 flex flex-wrap justify-center gap-8'>
+      <div className='my-7 flex flex-wrap justify-center gap-7'>
         <div className='flex gap-3'>
           <p className='text-black-600'>作成日</p>
           <p className='border-b border-primary-1'>
@@ -55,7 +54,7 @@ const DetailModal: FC<ModalProps> = (props) => {
           <p className='border-b border-primary-1'>{props.sponsorActivitiesViewItem.user.name}</p>
         </div>
       </div>
-      <div className='my-7 flex flex-wrap justify-center gap-8'>
+      <div className='my-7 flex flex-wrap justify-center gap-7'>
         <div className='flex gap-3'>
           <p className='text-black-600'>オプション</p>
           <p className='border-b border-primary-1'>
@@ -71,7 +70,7 @@ const DetailModal: FC<ModalProps> = (props) => {
         <div className='flex gap-3'>
           <p className='text-black-600'>デザイン</p>
           <p className='border-b border-primary-1'>
-            {designer[props.sponsorActivitiesViewItem.sponsorActivity.design]}
+            {DESIGNERS[props.sponsorActivitiesViewItem.sponsorActivity.design]}
           </p>
         </div>
       </div>

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -15,6 +15,7 @@ import {
 import { MultiSelect } from '@components/common';
 import { BUREAUS } from '@constants/bureaus';
 import { SponsorActivity, Sponsor, SponsorStyle, User, ActivityStyle } from '@type/common';
+import { DESIGNERS, DESIGNER_VALUES } from "@constants/designers";
 
 interface ModalProps {
   sponsorActivityId: number | string;
@@ -29,12 +30,7 @@ interface ModalProps {
 
 const REMARK_COUPON = `<クーポン> [詳細 :  ○○]\n`;
 const REMARK_PAMPHLET = `<パンフレット掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]\n`;
-const REMARK_PAMPHLET_SPONSOR = `<パンフレット掲載内容> 企業が作成\n`;
-const REMARK_PAMPHLET_OTHER = `<パンフレット掲載内容> 去年のものを使用\n`;
 const REMARK_POSTER = `<ポスター掲載内容> パンフレット広告拡大\n`;
-const REMARK_DESIGN_STUDENT = `<デザイン作成> 学生が作成\n`;
-const REMARK_DESIGN_SPONSOR = `<デザイン作成> 企業が作成\n`;
-const REMARK_DESIGN_OTHER = `<デザイン作成> 去年のものを使用\n`;
 
 export default function EditModal(props: ModalProps) {
   const { users, sponsors, sponsorStyles, sponsorStyleDetails, activityStyles } = props;
@@ -290,39 +286,19 @@ export default function EditModal(props: ModalProps) {
       </div>
       <p className='text-black-600'>デザイン作成</p>
       <div className='col-span-4 flex w-full justify-around'>
-        <div className='flex gap-3'>
-          <input
-            type='radio'
-            id='student'
-            name='design'
-            value='0'
-            checked={data.design === 0}
-            onChange={setDesign('design')}
-          />
-          <label htmlFor='student'>学生が作成</label>
-        </div>
-        <div className='flex gap-3'>
-          <input
-            type='radio'
-            id='company'
-            name='design'
-            value='1'
-            checked={data.design === 1}
-            onChange={setDesign('design')}
-          />
-          <label htmlFor='company'>企業が作成</label>
-        </div>
-        <div className='flex gap-3'>
-          <input
-            type='radio'
-            id='lastYear'
-            name='design'
-            value='2'
-            checked={data.design === 2}
-            onChange={setDesign('design')}
-          />
-          <label htmlFor='lastYear'>去年のものを使用</label>
-        </div>
+        {DESIGNER_VALUES.map((designer) => (
+          <div className='flex gap-3'>
+            <input
+              type='radio'
+              id={designer.id}
+              name='design'
+              value={designer.value}
+              checked={data.design === designer.value}
+              onChange={setDesign('design')}
+            />
+            <label htmlFor={designer.id}>{designer.label}</label>
+          </div>
+        ))}
       </div>
       <p className='text-black-600'>移動距離(km)</p>
       <div className='col-span-4 w-full'>

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -77,7 +77,7 @@ export default function EditModal(props: ModalProps) {
       ? REMARK_COUPON
       : '';
     const newRemarkDesign =
-      e.target.value === '0'
+      e.target.value === '1'
         ? REMARK_PAMPHLET
         :"";
     setFormData({ ...formData, design: Number(e.target.value), remark: remarkOption+newRemarkDesign});
@@ -94,7 +94,7 @@ export default function EditModal(props: ModalProps) {
         ? REMARK_COUPON
         : '';
     const remarkDesign =
-      formData.design === 0
+      formData.design === 1
         ? REMARK_PAMPHLET
         :"";
     setFormData({ ...formData, feature: e.target.value, remark: newRemarkFeature+remarkDesign});

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -67,12 +67,8 @@ export default function EditModal(props: ModalProps) {
   }, [sponsorStyles]);
 
   const setDesign =
-  (input: string) =>
   (
-    e:
-      | React.ChangeEvent<HTMLSelectElement>
-      | React.ChangeEvent<HTMLInputElement>
-      | React.ChangeEvent<HTMLTextAreaElement>,
+    e: React.ChangeEvent<HTMLInputElement>
   ) => {
     const remarkOption = 
       formData.feature === 'ポスター'
@@ -90,12 +86,8 @@ export default function EditModal(props: ModalProps) {
   };
 
   const setFeature =
-  (input: string) =>
   (
-    e:
-      | React.ChangeEvent<HTMLSelectElement>
-      | React.ChangeEvent<HTMLInputElement>
-      | React.ChangeEvent<HTMLTextAreaElement>,
+    e: React.ChangeEvent<HTMLSelectElement>
   ) => {
     const newRemarkFeature =
       e.target.value === 'ポスター'
@@ -107,7 +99,7 @@ export default function EditModal(props: ModalProps) {
       formData.design === 0
         ? REMARK_PAMPHLET
         :"";
-    setFormData({ ...formData, [input]: e.target.value, remark: newRemarkFeature+remarkDesign});
+    setFormData({ ...formData, feature: e.target.value, remark: newRemarkFeature+remarkDesign});
   };
 
   const isSelectSponsorBooth = useMemo(() => {
@@ -267,7 +259,7 @@ export default function EditModal(props: ModalProps) {
       <div className='col-span-4 w-full'>
         <Select
           value={data.feature}
-          onChange={setFeature('feature')}
+          onChange={setFeature}
         >
           <option value={'なし'} selected>
             なし
@@ -294,7 +286,7 @@ export default function EditModal(props: ModalProps) {
               name='design'
               value={designer.value}
               checked={data.design === designer.value}
-              onChange={setDesign('design')}
+              onChange={setDesign}
             />
             <label htmlFor={designer.id}>{designer.label}</label>
           </div>

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -45,6 +45,7 @@ export default function EditModal(props: ModalProps) {
     ...props.sponsorActivity,
     expense: Number((props.sponsorActivity.expense / 11).toFixed(1)),
   });
+
   const initStyleIds = sponsorStyleDetails
     ? sponsorStyleDetails.map((sponsorStyleDetail) => sponsorStyleDetail.sponsorStyleID)
     : [];
@@ -69,6 +70,50 @@ export default function EditModal(props: ModalProps) {
     return options;
   }, [sponsorStyles]);
 
+  const setDesign =
+  (input: string) =>
+  (
+    e:
+      | React.ChangeEvent<HTMLSelectElement>
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    const remarkOption = 
+      formData.feature === 'ポスター'
+      ? REMARK_POSTER
+      : formData.feature === 'クーポン'
+      ? REMARK_COUPON
+      : '';
+    const newRemarkDesign =
+      e.target.value === '0'
+        ? REMARK_PAMPHLET
+        :"";
+    console.log(formData.remark);
+    console.log(e.target.value);
+    setFormData({ ...formData, design: Number(e.target.value), remark: remarkOption+newRemarkDesign});
+  };
+
+  const setFeature =
+  (input: string) =>
+  (
+    e:
+      | React.ChangeEvent<HTMLSelectElement>
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    const newRemarkFeature =
+      e.target.value === 'ポスター'
+        ? REMARK_POSTER
+        : e.target.value === 'クーポン'
+        ? REMARK_COUPON
+        : '';
+    const remarkDesign =
+      formData.design === 0
+        ? REMARK_PAMPHLET
+        :"";
+    setFormData({ ...formData, [input]: e.target.value, remark: newRemarkFeature+remarkDesign});
+  };
+
   const isSelectSponsorBooth = useMemo(() => {
     if (!selectedStyleIds) return false;
     const isBoothOnly = selectedStyleIds.length === 1;
@@ -80,40 +125,13 @@ export default function EditModal(props: ModalProps) {
 
   useEffect(() => {
     if (isSelectSponsorBooth) {
-      const newRemark =
-        design === '学生が作成'
-          ? REMARK_DESIGN_STUDENT + REMARK_PAMPHLET
-          : design === '企業が作成'
-          ? REMARK_DESIGN_SPONSOR + REMARK_PAMPHLET_SPONSOR
-          : REMARK_DESIGN_OTHER + REMARK_PAMPHLET_OTHER;
       setFormData({
         ...formData,
         feature: 'なし',
-        remark: newRemark,
+        remark: "",
       });
     }
   }, [isSelectSponsorBooth]);
-
-  const [design, setDesign] = useState<string>('学生が作成');
-  const changeDesign = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setDesign(e.target.value);
-    const newRemark =
-      e.target.value === '学生が作成'
-        ? REMARK_DESIGN_STUDENT + REMARK_PAMPHLET
-        : e.target.value === '企業が作成'
-        ? REMARK_DESIGN_SPONSOR + REMARK_PAMPHLET_SPONSOR
-        : REMARK_DESIGN_OTHER + REMARK_PAMPHLET_OTHER;
-    const newRemarkFeature =
-      formData.feature === 'ポスター'
-        ? REMARK_POSTER
-        : formData.feature === 'クーポン'
-        ? REMARK_COUPON
-        : '';
-    setFormData({
-      ...formData,
-      remark: newRemark + newRemarkFeature,
-    });
-  };
 
   const handler =
     (input: string) =>
@@ -188,7 +206,7 @@ export default function EditModal(props: ModalProps) {
 
   // 協賛企業の情報
   const content = (data: SponsorActivity) => (
-    <div className='my-6 grid grid-cols-5 items-center justify-items-center gap-4'>
+    <div className='my-6 grid grid-cols-5 items-center justify-items-center gap-3'>
       <p className='text-black-600'>企業名</p>
       <div className='col-span-4 w-full'>
         <Select className='w-full' onChange={handler('sponsorID')}>
@@ -253,25 +271,7 @@ export default function EditModal(props: ModalProps) {
       <div className='col-span-4 w-full'>
         <Select
           value={data.feature}
-          onChange={(e) => {
-            const newRemark =
-              design === '学生が作成'
-                ? REMARK_DESIGN_STUDENT + REMARK_PAMPHLET
-                : design === '企業が作成'
-                ? REMARK_DESIGN_SPONSOR + REMARK_PAMPHLET_SPONSOR
-                : REMARK_DESIGN_OTHER + REMARK_PAMPHLET_OTHER;
-            const newRemarkFeature =
-              e.target.value === 'ポスター'
-                ? REMARK_POSTER
-                : e.target.value === 'クーポン'
-                ? REMARK_COUPON
-                : '';
-            setFormData({
-              ...formData,
-              remark: newRemark + newRemarkFeature,
-              feature: e.target.value,
-            });
-          }}
+          onChange={setFeature('feature')}
         >
           <option value={'なし'} selected>
             なし
@@ -284,6 +284,10 @@ export default function EditModal(props: ModalProps) {
           </option>
         </Select>
       </div>
+      <p className='text-black-600 text-center'>広告データurl</p>
+      <div className='col-span-4 grid w-full'>
+        <Input value={data.url} onChange={handler('url')} />
+      </div>
       <p className='text-black-600'>デザイン作成</p>
       <div className='col-span-4 flex w-full justify-around'>
         <div className='flex gap-3'>
@@ -291,9 +295,9 @@ export default function EditModal(props: ModalProps) {
             type='radio'
             id='student'
             name='design'
-            value='学生が作成'
-            checked={design === '学生が作成'}
-            onChange={changeDesign}
+            value='0'
+            checked={data.design === 0}
+            onChange={setDesign('design')}
           />
           <label htmlFor='student'>学生が作成</label>
         </div>
@@ -302,9 +306,9 @@ export default function EditModal(props: ModalProps) {
             type='radio'
             id='company'
             name='design'
-            value='企業が作成'
-            checked={design === '企業が作成'}
-            onChange={changeDesign}
+            value='1'
+            checked={data.design === 1}
+            onChange={setDesign('design')}
           />
           <label htmlFor='company'>企業が作成</label>
         </div>
@@ -313,9 +317,9 @@ export default function EditModal(props: ModalProps) {
             type='radio'
             id='lastYear'
             name='design'
-            value='去年のものを使用'
-            checked={design === '去年のものを使用'}
-            onChange={changeDesign}
+            value='2'
+            checked={data.design === 2}
+            onChange={setDesign('design')}
           />
           <label htmlFor='lastYear'>去年のものを使用</label>
         </div>

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -14,8 +14,8 @@ import {
 } from '@components/common';
 import { MultiSelect } from '@components/common';
 import { BUREAUS } from '@constants/bureaus';
+import { DESIGNER_VALUES } from '@constants/designers';
 import { SponsorActivity, Sponsor, SponsorStyle, User, ActivityStyle } from '@type/common';
-import { DESIGNERS, DESIGNER_VALUES } from "@constants/designers";
 
 interface ModalProps {
   sponsorActivityId: number | string;
@@ -66,38 +66,30 @@ export default function EditModal(props: ModalProps) {
     return options;
   }, [sponsorStyles]);
 
-  const setDesign =
-  (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const remarkOption = 
+  const setDesign = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const remarkOption =
       formData.feature === 'ポスター'
-      ? REMARK_POSTER
-      : formData.feature === 'クーポン'
-      ? REMARK_COUPON
-      : '';
-    const newRemarkDesign =
-      e.target.value === '1'
-        ? REMARK_PAMPHLET
-        :"";
-    setFormData({ ...formData, design: Number(e.target.value), remark: remarkOption+newRemarkDesign});
+        ? REMARK_POSTER
+        : formData.feature === 'クーポン'
+        ? REMARK_COUPON
+        : '';
+    const newRemarkDesign = e.target.value === '1' ? REMARK_PAMPHLET : '';
+    setFormData({
+      ...formData,
+      design: Number(e.target.value),
+      remark: remarkOption + newRemarkDesign,
+    });
   };
 
-  const setFeature =
-  (
-    e: React.ChangeEvent<HTMLSelectElement>
-  ) => {
+  const setFeature = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newRemarkFeature =
       e.target.value === 'ポスター'
         ? REMARK_POSTER
         : e.target.value === 'クーポン'
         ? REMARK_COUPON
         : '';
-    const remarkDesign =
-      formData.design === 1
-        ? REMARK_PAMPHLET
-        :"";
-    setFormData({ ...formData, feature: e.target.value, remark: newRemarkFeature+remarkDesign});
+    const remarkDesign = formData.design === 1 ? REMARK_PAMPHLET : '';
+    setFormData({ ...formData, feature: e.target.value, remark: newRemarkFeature + remarkDesign });
   };
 
   const isSelectSponsorBooth = useMemo(() => {
@@ -114,7 +106,7 @@ export default function EditModal(props: ModalProps) {
       setFormData({
         ...formData,
         feature: 'なし',
-        remark: "",
+        remark: '',
       });
     }
   }, [isSelectSponsorBooth]);
@@ -255,10 +247,7 @@ export default function EditModal(props: ModalProps) {
       </div>
       <p className='text-black-600'>オプション</p>
       <div className='col-span-4 w-full'>
-        <Select
-          value={data.feature}
-          onChange={setFeature}
-        >
+        <Select value={data.feature} onChange={setFeature}>
           <option value={'なし'} selected>
             なし
           </option>
@@ -270,14 +259,14 @@ export default function EditModal(props: ModalProps) {
           </option>
         </Select>
       </div>
-      <p className='text-black-600 text-center'>広告データurl</p>
+      <p className='text-center text-black-600'>広告データurl</p>
       <div className='col-span-4 grid w-full'>
         <Input value={data.url} onChange={handler('url')} />
       </div>
       <p className='text-black-600'>デザイン作成</p>
       <div className='col-span-4 flex w-full justify-around'>
         {DESIGNER_VALUES.map((designer) => (
-          <div className='flex gap-3'>
+          <div className='flex gap-3' key={designer.value}>
             <input
               type='radio'
               id={designer.id}

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -80,8 +80,6 @@ export default function EditModal(props: ModalProps) {
       e.target.value === '0'
         ? REMARK_PAMPHLET
         :"";
-    console.log(formData.remark);
-    console.log(e.target.value);
     setFormData({ ...formData, design: Number(e.target.value), remark: remarkOption+newRemarkDesign});
   };
 

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -65,14 +65,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
   });
 
 
-  const setDesign =
-  (input: string) =>
-  (
-    e:
-      | React.ChangeEvent<HTMLSelectElement>
-      | React.ChangeEvent<HTMLInputElement>
-      | React.ChangeEvent<HTMLTextAreaElement>,
-  ) => {
+  const setDesign = ( e: React.ChangeEvent<HTMLInputElement> ) => {
     const remarkOption = 
       formData.feature === 'ポスター'
       ? REMARK_POSTER
@@ -83,18 +76,15 @@ export default function SponsorActivitiesAddModal(props: Props) {
       e.target.value === '0'
         ? REMARK_PAMPHLET
         :"";
-    setFormData({ ...formData, design: Number(e.target.value), remark: remarkOption+newRemarkDesign});
+    setFormData({
+      ...formData,
+      design: Number(e.target.value),
+      remark: remarkOption+newRemarkDesign
+    });
   };
 
-  const setFeature =
-  (input: string) =>
-  (
-    e:
-      | React.ChangeEvent<HTMLSelectElement>
-      | React.ChangeEvent<HTMLInputElement>
-      | React.ChangeEvent<HTMLTextAreaElement>,
-  ) => {
-    const newRemarkFeature =
+  const setFeature =( e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newRemarkOption =
       e.target.value === 'ポスター'
         ? REMARK_POSTER
         : e.target.value === 'クーポン'
@@ -104,7 +94,11 @@ export default function SponsorActivitiesAddModal(props: Props) {
       formData.design === 0
         ? REMARK_PAMPHLET
         :"";
-    setFormData({ ...formData, [input]: e.target.value, remark: newRemarkFeature+remarkDesign});
+    setFormData({
+       ...formData,
+      feature: e.target.value,
+      remark: newRemarkOption+remarkDesign
+    });
   };
 
   const [selectedStyleIds, setSelectedStyleIds] = useState<number[]>([sponsorStyles[0].id || 0]);
@@ -260,7 +254,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
       <div className='col-span-4 w-full'>
         <Select
           value={data.feature}
-          onChange={setFeature('feature')}
+          onChange={setFeature}
         >
           <option value={'なし'} selected>
             なし
@@ -287,7 +281,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
                 name='design'
                 value={designer.value}
                 checked={data.design === designer.value}
-                onChange={setDesign('design')}
+                onChange={setDesign}
               />
               <label htmlFor={designer.id}>{designer.label}</label>
             </div>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -61,7 +61,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
     design:0,
     url:"",
     expense: 0,
-    remark: REMARK_PAMPHLET,
+    remark: "",
   });
 
 
@@ -73,7 +73,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
       ? REMARK_COUPON
       : '';
     const newRemarkDesign =
-      e.target.value === '0'
+      e.target.value === '1'
         ? REMARK_PAMPHLET
         :"";
     setFormData({
@@ -91,7 +91,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
         ? REMARK_COUPON
         : '';
     const remarkDesign =
-      formData.design === 0
+      formData.design === 1
         ? REMARK_PAMPHLET
         :"";
     setFormData({

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -15,6 +15,7 @@ import {
   Textarea,
 } from '@components/common';
 import { BUREAUS } from '@constants/bureaus';
+import { DESIGNERS, DESIGNER_VALUES } from "@constants/designers";
 import { SponsorActivity, Sponsor, SponsorStyle, User } from '@type/common';
 
 const TABLE_COLUMNS = [
@@ -41,7 +42,6 @@ interface Props {
 const REMARK_COUPON = `<クーポン> [詳細 :  ○○]\n`;
 const REMARK_PAMPHLET = `<パンフレット掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]\n`;
 const REMARK_POSTER = `<ポスター掲載内容> パンフレット広告拡大\n`;
-const designer = ["学生が作成","企業が作成","去年のもの"];
 
 export default function SponsorActivitiesAddModal(props: Props) {
   const router = useRouter();
@@ -83,8 +83,6 @@ export default function SponsorActivitiesAddModal(props: Props) {
       e.target.value === '0'
         ? REMARK_PAMPHLET
         :"";
-    console.log(formData.remark);
-    console.log(e.target.value);
     setFormData({ ...formData, design: Number(e.target.value), remark: remarkOption+newRemarkDesign});
   };
 
@@ -281,39 +279,19 @@ export default function SponsorActivitiesAddModal(props: Props) {
       </div>
       <p className='text-black-600'>デザイン作成</p>
       <div className='col-span-4 flex w-full justify-around'>
-        <div className='flex gap-3'>
-          <input
-            type='radio'
-            id='student'
-            name='design'
-            value='0'
-            checked={data.design === 0}
-            onChange={setDesign('design')}
-          />
-          <label htmlFor='student'>学生が作成</label>
-        </div>
-        <div className='flex gap-3'>
-          <input
-            type='radio'
-            id='company'
-            name='design'
-            value='1'
-            checked={data.design === 1}
-            onChange={setDesign('design')}
-          />
-          <label htmlFor='company'>企業が作成</label>
-        </div>
-        <div className='flex gap-3'>
-          <input
-            type='radio'
-            id='lastYear'
-            name='design'
-            value='2'
-            checked={data.design === 2}
-            onChange={setDesign('design')}
-          />
-          <label htmlFor='lastYear'>去年のものを使用</label>
-        </div>
+        {DESIGNER_VALUES.map((designer) => (
+            <div className='flex gap-3'>
+              <input
+                type='radio'
+                id={designer.id}
+                name='design'
+                value={designer.value}
+                checked={data.design === designer.value}
+                onChange={setDesign('design')}
+              />
+              <label htmlFor={designer.id}>{designer.label}</label>
+            </div>
+          ))}
       </div>
       <p className='text-black-600'>移動距離(km)</p>
       <div className='col-span-4 w-full'>
@@ -406,7 +384,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
               </td>
               <td className='py-3'>
                 <div className='text-center text-sm text-black-600'>
-                  {designer[sponsorActivities.design]}
+                  {DESIGNERS[sponsorActivities.design]}
                 </div>
               </td>
               <td className='py-3'>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -15,22 +15,12 @@ import {
   Textarea,
 } from '@components/common';
 import { BUREAUS } from '@constants/bureaus';
-import { DESIGNERS, DESIGNER_VALUES } from "@constants/designers";
+import { DESIGNERS, DESIGNER_VALUES } from '@constants/designers';
 import { SponsorActivity, Sponsor, SponsorStyle, User } from '@type/common';
 
-const TABLE_COLUMNS = [
-  '企業名',
-  '協賛スタイル',
-  '担当者名',
-  '回収状況',
-];
+const TABLE_COLUMNS = ['企業名', '協賛スタイル', '担当者名', '回収状況'];
 
-const TABLE_COLUMNS2 = [
-  'オプション',
-  'デザイン作成',
-  '移動距離(km)',
-  '交通費',
-];
+const TABLE_COLUMNS2 = ['オプション', 'デザイン作成', '移動距離(km)', '交通費'];
 
 interface Props {
   users: User[];
@@ -58,46 +48,39 @@ export default function SponsorActivitiesAddModal(props: Props) {
     userID: users[0].id || 0,
     isDone: false,
     feature: 'なし',
-    design:0,
-    url:"",
+    design: 0,
+    url: '',
     expense: 0,
-    remark: "",
+    remark: '',
   });
 
-
-  const setDesign = ( e: React.ChangeEvent<HTMLInputElement> ) => {
-    const remarkOption = 
+  const setDesign = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const remarkOption =
       formData.feature === 'ポスター'
-      ? REMARK_POSTER
-      : formData.feature === 'クーポン'
-      ? REMARK_COUPON
-      : '';
-    const newRemarkDesign =
-      e.target.value === '1'
-        ? REMARK_PAMPHLET
-        :"";
+        ? REMARK_POSTER
+        : formData.feature === 'クーポン'
+        ? REMARK_COUPON
+        : '';
+    const newRemarkDesign = e.target.value === '1' ? REMARK_PAMPHLET : '';
     setFormData({
       ...formData,
       design: Number(e.target.value),
-      remark: remarkOption+newRemarkDesign
+      remark: remarkOption + newRemarkDesign,
     });
   };
 
-  const setFeature =( e: React.ChangeEvent<HTMLSelectElement>) => {
+  const setFeature = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newRemarkOption =
       e.target.value === 'ポスター'
         ? REMARK_POSTER
         : e.target.value === 'クーポン'
         ? REMARK_COUPON
         : '';
-    const remarkDesign =
-      formData.design === 1
-        ? REMARK_PAMPHLET
-        :"";
+    const remarkDesign = formData.design === 1 ? REMARK_PAMPHLET : '';
     setFormData({
-       ...formData,
+      ...formData,
       feature: e.target.value,
-      remark: newRemarkOption+remarkDesign
+      remark: newRemarkOption + remarkDesign,
     });
   };
 
@@ -187,7 +170,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
       setFormData({
         ...formData,
         feature: 'なし',
-        remark: "",
+        remark: '',
       });
     }
   }, [isSelectSponsorBooth]);
@@ -252,10 +235,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
       </div>
       <p className='text-black-600'>オプション</p>
       <div className='col-span-4 w-full'>
-        <Select
-          value={data.feature}
-          onChange={setFeature}
-        >
+        <Select value={data.feature} onChange={setFeature}>
           <option value={'なし'} selected>
             なし
           </option>
@@ -267,25 +247,25 @@ export default function SponsorActivitiesAddModal(props: Props) {
           </option>
         </Select>
       </div>
-      <p className='text-black-600 text-center'>広告データurl</p>
+      <p className='text-center text-black-600'>広告データurl</p>
       <div className={clsx('col-span-4 grid w-full')}>
         <Input value={data.url} onChange={formDataHandler('url')} />
       </div>
       <p className='text-black-600'>デザイン作成</p>
       <div className='col-span-4 flex w-full justify-around'>
         {DESIGNER_VALUES.map((designer) => (
-            <div className='flex gap-3'>
-              <input
-                type='radio'
-                id={designer.id}
-                name='design'
-                value={designer.value}
-                checked={data.design === designer.value}
-                onChange={setDesign}
-              />
-              <label htmlFor={designer.id}>{designer.label}</label>
-            </div>
-          ))}
+          <div className='flex gap-3' key={designer.value}>
+            <input
+              type='radio'
+              id={designer.id}
+              name='design'
+              value={designer.value}
+              checked={data.design === designer.value}
+              onChange={setDesign}
+            />
+            <label htmlFor={designer.id}>{designer.label}</label>
+          </div>
+        ))}
       </div>
       <p className='text-black-600'>移動距離(km)</p>
       <div className='col-span-4 w-full'>
@@ -326,7 +306,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
 
     return (
       <div>
-        <table className='mt-10 mb-7 w-full table-fixed border-collapse'>
+        <table className='mb-7 mt-10 w-full table-fixed border-collapse'>
           <thead>
             <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
               {TABLE_COLUMNS.map((tableColumn: string) => (
@@ -406,9 +386,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
             <tr>
               <td>
                 <div className='py-3 text-sm text-black-600'>
-                  <p
-                    className='border-primary-1 text-center'
-                  >
+                  <p className='border-primary-1 text-center'>
                     {sponsorActivities.url === '' && <div>なし</div>}
                     {sponsorActivities.url}
                   </p>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -22,7 +22,11 @@ const TABLE_COLUMNS = [
   '協賛スタイル',
   '担当者名',
   '回収状況',
+];
+
+const TABLE_COLUMNS2 = [
   'オプション',
+  'デザイン作成',
   '移動距離(km)',
   '交通費',
 ];
@@ -36,12 +40,8 @@ interface Props {
 
 const REMARK_COUPON = `<クーポン> [詳細 :  ○○]\n`;
 const REMARK_PAMPHLET = `<パンフレット掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ]\n`;
-const REMARK_PAMPHLET_SPONSOR = `<パンフレット掲載内容> 企業が作成\n`;
-const REMARK_PAMPHLET_OTHER = `<パンフレット掲載内容> 去年のものを使用\n`;
 const REMARK_POSTER = `<ポスター掲載内容> パンフレット広告拡大\n`;
-const REMARK_DESIGN_STUDENT = `<デザイン作成> 学生が作成\n`;
-const REMARK_DESIGN_SPONSOR = `<デザイン作成> 企業が作成\n`;
-const REMARK_DESIGN_OTHER = `<デザイン作成> 去年のものを使用\n`;
+const designer = ["学生が作成","企業が作成","去年のもの"];
 
 export default function SponsorActivitiesAddModal(props: Props) {
   const router = useRouter();
@@ -58,26 +58,56 @@ export default function SponsorActivitiesAddModal(props: Props) {
     userID: users[0].id || 0,
     isDone: false,
     feature: 'なし',
+    design:0,
+    url:"",
     expense: 0,
-    remark: '',
+    remark: REMARK_PAMPHLET,
   });
 
-  const [design, setDesign] = useState<string>('学生が作成');
-  useEffect(() => {
-    const newRemark =
-      design === '学生が作成'
-        ? REMARK_DESIGN_STUDENT + REMARK_PAMPHLET
-        : design === '企業が作成'
-        ? REMARK_DESIGN_SPONSOR + REMARK_PAMPHLET_SPONSOR
-        : REMARK_DESIGN_OTHER + REMARK_PAMPHLET_OTHER;
-    const newRemarkFeature =
+
+  const setDesign =
+  (input: string) =>
+  (
+    e:
+      | React.ChangeEvent<HTMLSelectElement>
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    const remarkOption = 
       formData.feature === 'ポスター'
+      ? REMARK_POSTER
+      : formData.feature === 'クーポン'
+      ? REMARK_COUPON
+      : '';
+    const newRemarkDesign =
+      e.target.value === '0'
+        ? REMARK_PAMPHLET
+        :"";
+    console.log(formData.remark);
+    console.log(e.target.value);
+    setFormData({ ...formData, design: Number(e.target.value), remark: remarkOption+newRemarkDesign});
+  };
+
+  const setFeature =
+  (input: string) =>
+  (
+    e:
+      | React.ChangeEvent<HTMLSelectElement>
+      | React.ChangeEvent<HTMLInputElement>
+      | React.ChangeEvent<HTMLTextAreaElement>,
+  ) => {
+    const newRemarkFeature =
+      e.target.value === 'ポスター'
         ? REMARK_POSTER
-        : formData.feature === 'クーポン'
+        : e.target.value === 'クーポン'
         ? REMARK_COUPON
         : '';
-    setFormData({ ...formData, remark: newRemark + newRemarkFeature });
-  }, [design]);
+    const remarkDesign =
+      formData.design === 0
+        ? REMARK_PAMPHLET
+        :"";
+    setFormData({ ...formData, [input]: e.target.value, remark: newRemarkFeature+remarkDesign});
+  };
 
   const [selectedStyleIds, setSelectedStyleIds] = useState<number[]>([sponsorStyles[0].id || 0]);
   const [isStyleError, setIsStyleError] = useState(false);
@@ -162,23 +192,17 @@ export default function SponsorActivitiesAddModal(props: Props) {
 
   useEffect(() => {
     if (isSelectSponsorBooth) {
-      const newRemark =
-        design === '学生が作成'
-          ? REMARK_DESIGN_STUDENT + REMARK_PAMPHLET
-          : design === '企業が作成'
-          ? REMARK_DESIGN_SPONSOR + REMARK_PAMPHLET_SPONSOR
-          : REMARK_DESIGN_OTHER + REMARK_PAMPHLET_OTHER;
       setFormData({
         ...formData,
         feature: 'なし',
-        remark: newRemark,
+        remark: "",
       });
     }
   }, [isSelectSponsorBooth]);
 
   // 協賛活動の情報
   const content = (data: SponsorActivity) => (
-    <div className='mx-auto my-10 grid grid-cols-5 items-center justify-items-center gap-5'>
+    <div className='mx-auto my-10 grid grid-cols-5 items-center justify-items-center gap-3'>
       <p className='text-black-600'>協賛企業</p>
       <div className='col-span-4 w-full'>
         <Select value={data.sponsorID} onChange={formDataHandler('sponsorID')}>
@@ -238,9 +262,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
       <div className='col-span-4 w-full'>
         <Select
           value={data.feature}
-          onChange={(e) => {
-            setFormData({ ...formData, feature: e.target.value });
-          }}
+          onChange={setFeature('feature')}
         >
           <option value={'なし'} selected>
             なし
@@ -253,6 +275,10 @@ export default function SponsorActivitiesAddModal(props: Props) {
           </option>
         </Select>
       </div>
+      <p className='text-black-600 text-center'>広告データurl</p>
+      <div className={clsx('col-span-4 grid w-full')}>
+        <Input value={data.url} onChange={formDataHandler('url')} />
+      </div>
       <p className='text-black-600'>デザイン作成</p>
       <div className='col-span-4 flex w-full justify-around'>
         <div className='flex gap-3'>
@@ -260,9 +286,9 @@ export default function SponsorActivitiesAddModal(props: Props) {
             type='radio'
             id='student'
             name='design'
-            value='学生が作成'
-            checked={design === '学生が作成'}
-            onChange={(e) => setDesign(e.target.value)}
+            value='0'
+            checked={data.design === 0}
+            onChange={setDesign('design')}
           />
           <label htmlFor='student'>学生が作成</label>
         </div>
@@ -271,9 +297,9 @@ export default function SponsorActivitiesAddModal(props: Props) {
             type='radio'
             id='company'
             name='design'
-            value='企業が作成'
-            checked={design === '企業が作成'}
-            onChange={(e) => setDesign(e.target.value)}
+            value='1'
+            checked={data.design === 1}
+            onChange={setDesign('design')}
           />
           <label htmlFor='company'>企業が作成</label>
         </div>
@@ -282,9 +308,9 @@ export default function SponsorActivitiesAddModal(props: Props) {
             type='radio'
             id='lastYear'
             name='design'
-            value='去年のものを使用'
-            checked={design === '去年のものを使用'}
-            onChange={(e) => setDesign(e.target.value)}
+            value='2'
+            checked={data.design === 2}
+            onChange={setDesign('design')}
           />
           <label htmlFor='lastYear'>去年のものを使用</label>
         </div>
@@ -328,7 +354,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
 
     return (
       <div>
-        <table className='mb-10 w-full table-fixed border-collapse'>
+        <table className='mt-10 mb-7 w-full table-fixed border-collapse'>
           <thead>
             <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
               {TABLE_COLUMNS.map((tableColumn: string) => (
@@ -358,9 +384,29 @@ export default function SponsorActivitiesAddModal(props: Props) {
                   {sponsorActivities.isDone ? '回収済み' : '未回収'}
                 </div>
               </td>
+            </tr>
+          </tbody>
+        </table>
+        <table className='mb-7 w-full table-fixed border-collapse'>
+          <thead>
+            <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
+              {TABLE_COLUMNS2.map((tableColumn: string) => (
+                <th key={tableColumn} className='border-b-primary-1 px-6 pb-2'>
+                  <div className='text-center text-sm text-black-600'>{tableColumn}</div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
+            <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
               <td className='py-3'>
                 <div className='text-center text-sm text-black-600'>
                   {sponsorActivities.feature}
+                </div>
+              </td>
+              <td className='py-3'>
+                <div className='text-center text-sm text-black-600'>
+                  {designer[sponsorActivities.design]}
                 </div>
               </td>
               <td className='py-3'>
@@ -370,7 +416,30 @@ export default function SponsorActivitiesAddModal(props: Props) {
               </td>
               <td className='py-3'>
                 <div className='text-center text-sm text-black-600'>
-                  {Math.round(sponsorActivities.expense * 11)}
+                  {Math.round(sponsorActivities.expense * 11)}円
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table className='mb-7 w-full table-fixed border-collapse'>
+          <thead>
+            <tr className='border border-x-white-0 border-b-primary-1 border-t-white-0 py-3'>
+              <th className='border-b-primary-1 px-6 pb-2'>
+                <div className='text-center text-sm text-black-600'>広告データurl</div>
+              </th>
+            </tr>
+          </thead>
+          <tbody className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
+            <tr>
+              <td>
+                <div className='py-3 text-sm text-black-600'>
+                  <p
+                    className='border-primary-1 text-center'
+                  >
+                    {sponsorActivities.url === '' && <div>なし</div>}
+                    {sponsorActivities.url}
+                  </p>
                 </div>
               </td>
             </tr>

--- a/view/next-project/src/constants/designers.ts
+++ b/view/next-project/src/constants/designers.ts
@@ -1,0 +1,16 @@
+export const DESIGNERS = ["学生が作成","企業が作成","去年のもの"];
+
+export const DESIGNER_VALUES = [
+  {
+    value: 0,
+    label: '学生が作成'
+  },
+  {
+    value: 1,
+    label: '企業が作成'
+  },
+  {
+    value: 2,
+    label: '去年のものを使用'
+  },
+];

--- a/view/next-project/src/constants/designers.ts
+++ b/view/next-project/src/constants/designers.ts
@@ -1,18 +1,23 @@
-export const DESIGNERS = ["学生が作成","企業が作成","去年のもの"];
+export const DESIGNERS = ["なし","学生が作成","企業が作成","去年のもの"];
 
 export const DESIGNER_VALUES = [
   {
     value: 0,
+    label: 'なし',
+    id: "none"
+  },
+  {
+    value: 1,
     label: '学生が作成',
     id: "student"
   },
   {
-    value: 1,
+    value: 2,
     label: '企業が作成',
     id: "sponsor"
   },
   {
-    value: 2,
+    value: 3,
     label: '去年のものを使用',
     id: "lastYear"
   },

--- a/view/next-project/src/constants/designers.ts
+++ b/view/next-project/src/constants/designers.ts
@@ -3,14 +3,17 @@ export const DESIGNERS = ["学生が作成","企業が作成","去年のもの"]
 export const DESIGNER_VALUES = [
   {
     value: 0,
-    label: '学生が作成'
+    label: '学生が作成',
+    id: "student"
   },
   {
     value: 1,
-    label: '企業が作成'
+    label: '企業が作成',
+    id: "sponsor"
   },
   {
     value: 2,
-    label: '去年のものを使用'
+    label: '去年のものを使用',
+    id: "lastYear"
   },
 ];

--- a/view/next-project/src/constants/designers.ts
+++ b/view/next-project/src/constants/designers.ts
@@ -1,24 +1,24 @@
-export const DESIGNERS = ["なし","学生が作成","企業が作成","去年のもの"];
+export const DESIGNERS = ['なし', '学生が作成', '企業が作成', '去年のもの'];
 
 export const DESIGNER_VALUES = [
   {
     value: 0,
     label: 'なし',
-    id: "none"
+    id: 'none',
   },
   {
     value: 1,
     label: '学生が作成',
-    id: "student"
+    id: 'student',
   },
   {
     value: 2,
     label: '企業が作成',
-    id: "sponsor"
+    id: 'sponsor',
   },
   {
     value: 3,
     label: '去年のものを使用',
-    id: "lastYear"
+    id: 'lastYear',
   },
 ];

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -346,7 +346,9 @@ export default function SponsorActivities(props: Props) {
                       }}
                     >
                       <div className='text-sm text-black-600 flex justify-center'>
-                        {DESIGNERS[sponsorActivitiesItem.sponsorActivity.design]}
+                        {sponsorActivitiesItem.sponsorActivity.design !==0&&(
+                          DESIGNERS[sponsorActivitiesItem.sponsorActivity.design]
+                        )}
                         {sponsorActivitiesItem.sponsorActivity.url !=="" &&(
                           <a
                             className={clsx('mx-1')}

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -18,6 +18,7 @@ import {
   User,
   ActivityStyle,
 } from '@type/common';
+import { DESIGNERS } from "@constants/designers";
 
 interface Props {
   sponsorActivities: SponsorActivity[];
@@ -54,8 +55,6 @@ export async function getServerSideProps() {
     },
   };
 }
-
-const designer=["学生が作成","企業が作成","去年のもの"];
 
 export default function SponsorActivities(props: Props) {
   const [sponsorActivitiesID, setSponsorActivitiesID] = useState<number>(1);
@@ -190,7 +189,7 @@ export default function SponsorActivities(props: Props) {
                         </p>
                         <p>デザイン</p>
                         <div className='w-fit border-b border-primary-1 flex justify-center'>
-                          {designer[sponsorActivitiesItem.sponsorActivity.design]}
+                          {DESIGNERS[sponsorActivitiesItem.sponsorActivity.design]}
                           {sponsorActivitiesItem.sponsorActivity.url !==""&&(
                             <a
                             className={clsx('mx-1')}
@@ -347,7 +346,7 @@ export default function SponsorActivities(props: Props) {
                       }}
                     >
                       <div className='text-sm text-black-600 flex justify-center'>
-                        {designer[sponsorActivitiesItem.sponsorActivity.design]}
+                        {DESIGNERS[sponsorActivitiesItem.sponsorActivity.design]}
                         {sponsorActivitiesItem.sponsorActivity.url !=="" &&(
                           <a
                             className={clsx('mx-1')}

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -191,14 +191,16 @@ export default function SponsorActivities(props: Props) {
                         <p>デザイン</p>
                         <div className='w-fit border-b border-primary-1 flex justify-center'>
                           {designer[sponsorActivitiesItem.sponsorActivity.design]}
-                          <a
+                          {sponsorActivitiesItem.sponsorActivity.url !==""&&(
+                            <a
                             className={clsx('mx-1')}
                             href={sponsorActivitiesItem.sponsorActivity.url}
                             target='_blank'
                             rel='noopener noreferrer'
-                          >
-                            <RiExternalLinkLine size={'16px'} />
-                          </a>
+                            >
+                              <RiExternalLinkLine size={'16px'} />
+                            </a>
+                          )}
                         </div>
                         <p>交通費</p>
                         <p className='w-fit border-b border-primary-1'>
@@ -245,7 +247,7 @@ export default function SponsorActivities(props: Props) {
                 <th className='w-1/11 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>オプション</div>
                 </th>
-                <th className='w-1/11 border-b-primary-1 pb-2'>
+                <th className='w-1/10 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>デザイン</div>
                 </th>
                 <th className='w-1/11 border-b-primary-1 pb-2'>
@@ -346,14 +348,16 @@ export default function SponsorActivities(props: Props) {
                     >
                       <div className='text-sm text-black-600 flex justify-center'>
                         {designer[sponsorActivitiesItem.sponsorActivity.design]}
-                        <a
-                          className={clsx('mx-1')}
-                          href={sponsorActivitiesItem.sponsorActivity.url}
-                          target='_blank'
-                          rel='noopener noreferrer'
-                        >
-                        <RiExternalLinkLine size={'16px'} />
-                        </a>
+                        {sponsorActivitiesItem.sponsorActivity.url !=="" &&(
+                          <a
+                            className={clsx('mx-1')}
+                            href={sponsorActivitiesItem.sponsorActivity.url}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                          >
+                            <RiExternalLinkLine size={'16px'} />
+                          </a>
+                        )}
                       </div>
                     </td>
                     <td

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -5,6 +5,7 @@ import { useState, useMemo } from 'react';
 import OpenModalButton from '@/components/sponsoractivities/OpenAddModalButton';
 import { get } from '@api/api_methods';
 import { Card, Title } from '@components/common';
+import { RiExternalLinkLine } from 'react-icons/ri';
 import MainLayout from '@components/layout/MainLayout';
 import DetailModal from '@components/sponsoractivities/DetailModal';
 import OpenDeleteModalButton from '@components/sponsoractivities/OpenDeleteModalButton';
@@ -53,6 +54,8 @@ export async function getServerSideProps() {
     },
   };
 }
+
+const designer=["学生が作成","企業が作成","去年のもの"];
 
 export default function SponsorActivities(props: Props) {
   const [sponsorActivitiesID, setSponsorActivitiesID] = useState<number>(1);
@@ -185,6 +188,18 @@ export default function SponsorActivities(props: Props) {
                         <p className='w-fit border-b border-primary-1'>
                           {sponsorActivitiesItem.sponsorActivity.feature}
                         </p>
+                        <p>デザイン</p>
+                        <div className='w-fit border-b border-primary-1 flex justify-center'>
+                          {designer[sponsorActivitiesItem.sponsorActivity.design]}
+                          <a
+                            className={clsx('mx-1')}
+                            href={sponsorActivitiesItem.sponsorActivity.url}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                          >
+                            <RiExternalLinkLine size={'16px'} />
+                          </a>
+                        </div>
                         <p>交通費</p>
                         <p className='w-fit border-b border-primary-1'>
                           {sponsorActivitiesItem.sponsorActivity.expense}円
@@ -229,6 +244,9 @@ export default function SponsorActivities(props: Props) {
                 </th>
                 <th className='w-1/11 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>オプション</div>
+                </th>
+                <th className='w-1/11 border-b-primary-1 pb-2'>
+                  <div className='text-center text-sm text-black-600'>デザイン</div>
                 </th>
                 <th className='w-1/11 border-b-primary-1 pb-2'>
                   <div className='text-center text-sm text-black-600'>交通費</div>
@@ -326,6 +344,26 @@ export default function SponsorActivities(props: Props) {
                         );
                       }}
                     >
+                      <div className='text-sm text-black-600 flex justify-center'>
+                        {designer[sponsorActivitiesItem.sponsorActivity.design]}
+                        <a
+                          className={clsx('mx-1')}
+                          href={sponsorActivitiesItem.sponsorActivity.url}
+                          target='_blank'
+                          rel='noopener noreferrer'
+                        >
+                        <RiExternalLinkLine size={'16px'} />
+                        </a>
+                      </div>
+                    </td>
+                    <td
+                      onClick={() => {
+                        onOpen(
+                          sponsorActivitiesItem.sponsorActivity.id || 0,
+                          sponsorActivitiesItem,
+                        );
+                      }}
+                    >
                       <div className='text-center text-sm text-black-600'>
                         {sponsorActivitiesItem.sponsorActivity.expense}
                       </div>
@@ -377,7 +415,7 @@ export default function SponsorActivities(props: Props) {
                       {TotalActivityStyleFee}
                     </div>
                   </td>
-                  <td className='px-1 py-3' colSpan={3}>
+                  <td className='px-1 py-3' colSpan={4}>
                     <div className='flex justify-end'>
                       <div className='text-sm text-black-600'>合計</div>
                     </div>

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -2,14 +2,15 @@ import clsx from 'clsx';
 import Head from 'next/head';
 import { useState, useMemo } from 'react';
 
+import { RiExternalLinkLine } from 'react-icons/ri';
 import OpenModalButton from '@/components/sponsoractivities/OpenAddModalButton';
 import { get } from '@api/api_methods';
 import { Card, Title } from '@components/common';
-import { RiExternalLinkLine } from 'react-icons/ri';
 import MainLayout from '@components/layout/MainLayout';
 import DetailModal from '@components/sponsoractivities/DetailModal';
 import OpenDeleteModalButton from '@components/sponsoractivities/OpenDeleteModalButton';
 import OpenEditModalButton from '@components/sponsoractivities/OpenEditModalButton';
+import { DESIGNERS } from "@constants/designers";
 import {
   SponsorActivity,
   SponsorActivityView,
@@ -18,7 +19,6 @@ import {
   User,
   ActivityStyle,
 } from '@type/common';
-import { DESIGNERS } from "@constants/designers";
 
 interface Props {
   sponsorActivities: SponsorActivity[];

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -10,7 +10,7 @@ import MainLayout from '@components/layout/MainLayout';
 import DetailModal from '@components/sponsoractivities/DetailModal';
 import OpenDeleteModalButton from '@components/sponsoractivities/OpenDeleteModalButton';
 import OpenEditModalButton from '@components/sponsoractivities/OpenEditModalButton';
-import { DESIGNERS } from "@constants/designers";
+import { DESIGNERS } from '@constants/designers';
 import {
   SponsorActivity,
   SponsorActivityView,
@@ -188,14 +188,14 @@ export default function SponsorActivities(props: Props) {
                           {sponsorActivitiesItem.sponsorActivity.feature}
                         </p>
                         <p>デザイン</p>
-                        <div className='w-fit border-b border-primary-1 flex justify-center'>
+                        <div className='flex w-fit justify-center border-b border-primary-1'>
                           {DESIGNERS[sponsorActivitiesItem.sponsorActivity.design]}
-                          {sponsorActivitiesItem.sponsorActivity.url !==""&&(
+                          {sponsorActivitiesItem.sponsorActivity.url !== '' && (
                             <a
-                            className={clsx('mx-1')}
-                            href={sponsorActivitiesItem.sponsorActivity.url}
-                            target='_blank'
-                            rel='noopener noreferrer'
+                              className={clsx('mx-1')}
+                              href={sponsorActivitiesItem.sponsorActivity.url}
+                              target='_blank'
+                              rel='noopener noreferrer'
                             >
                               <RiExternalLinkLine size={'16px'} />
                             </a>
@@ -345,11 +345,10 @@ export default function SponsorActivities(props: Props) {
                         );
                       }}
                     >
-                      <div className='text-sm text-black-600 flex justify-center'>
-                        {sponsorActivitiesItem.sponsorActivity.design !==0&&(
-                          DESIGNERS[sponsorActivitiesItem.sponsorActivity.design]
-                        )}
-                        {sponsorActivitiesItem.sponsorActivity.url !=="" &&(
+                      <div className='flex justify-center text-sm text-black-600'>
+                        {sponsorActivitiesItem.sponsorActivity.design !== 0 &&
+                          DESIGNERS[sponsorActivitiesItem.sponsorActivity.design]}
+                        {sponsorActivitiesItem.sponsorActivity.url !== '' && (
                           <a
                             className={clsx('mx-1')}
                             href={sponsorActivitiesItem.sponsorActivity.url}

--- a/view/next-project/src/type/common.ts
+++ b/view/next-project/src/type/common.ts
@@ -124,6 +124,8 @@ export interface SponsorActivity {
   feature: string;
   expense: number;
   remark: string;
+  design: number;
+  url: string;
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#615 
<!-- 対応したIssue番号を記載 -->
resolve #615

# 概要
<!-- 開発内容の概要を記載 -->
- activityテーブルにカラム追加,
  - `design` :誰が作ったかを表す。int型　0:なし 1:学生 2:企業 3:去年
  - `url` :広告データのurl、string型
- カラムの追加に伴うAPIの修正
- 協賛活動ページの表にデザイン追加
  - 作成の矢印からgoogleドライブに遷移 
- 協賛活動ページの追加モーダルの修正
  - デザイン作成とリンクの入力フォーム追加
  - 備考の動的生成の修正
- 協賛活動ページの詳細モーダルの修正
  - デザイン作成とリンクの追加
- 協賛活動ページの修正モーダルの修正
  - デザイン作成とリンクの入力フォーム追加
  - 備考の動的生成の修正
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="1156" alt="スクリーンショット 2023-06-24 0 07 15" src="https://github.com/NUTFes/FinanSu/assets/115447919/ea2733fb-9139-4916-91ca-ec19dd5ffb88">
<img width="735" alt="スクリーンショット 2023-06-24 0 07 43" src="https://github.com/NUTFes/FinanSu/assets/115447919/0bb56982-d05c-48b1-8a35-780e8f1c23c0">
<img width="735" alt="スクリーンショット 2023-06-24 0 07 31" src="https://github.com/NUTFes/FinanSu/assets/115447919/1f896e83-1980-4643-9b4d-6ba01eae4b7c">


# テスト項目


<!-- テストしてほしい内容を記載 -->
- データベースのスキーマを変更しているため、DBコンテナのvolume削除
- `docker compose down -v`
- コンテナ立ち上げ　`docker compose up`
- テスト１　apiの確認
  - swaggerでactivityのapiの動作が適切であるか確認する
- テスト2　協賛活動ページの確認
  - 表にデザインが追加されている確認する
  - デザインのリンクの確認(urlは自分で追加してください)
  - スマホページの確認
- テスト3　追加モーダルの確認
  - 追加モーダルにデザインとurlを入力する欄があるか
  - 備考動的生成の動作の確認(あとで詳しく書きます)
  - レコードの追加ができるか
  - sp版でもできるか
- テスト4　修正モーダルの確認
  - 修正モーダルにデザインとurlを入力する欄があるか
  - 備考動的生成の動作の確認(あとで詳しく書きます)
  - レコードの修正ができるか
  - sp版でもできるか
- テスト4　詳細モーダルの確認
  - 詳細モーダルにデザインとurlがあるか
  - リンクからページに飛べるか、ホバーが効いているか

チェックリスト(適宜追加してください)
- [x] activityのapiの動作確認
- [x] 協賛活動ページの表にデザインが追加されているか
- [x] 表のデザインの矢印からページに飛ぶか
- [x] 協賛活動のレコードの追加ができるか
- [x] 協賛活動のレコードの修正ができるか
- [x] 詳細モーダルにデザインとurlがあるか
- [x] 備考の動的生成の動作が適切か
- [x] sp版対応しているか

# 備考

備考の動的生成は追加、修正モーダルでデータを入力する際に入力した内容に応じて備考にテキストのテンプレートを生成します。
今回広告の作成者のカラムが追加されたことにより処理を変更しました。

- オプション
 - クーポンが選択された場合、`<クーポン> [詳細 :  ○○]`が生成
 - ポスターが選択された場合、`<ポスター掲載内容> パンフレット広告拡大`が生成
- デザイン作成
 - 学生が作成が選択された場合、`<パンフレット掲載内容> [企業名 : x],[住所 : x],[HP : x],[ロゴ : x],[営業時間 : x],[電話番号 : x],[キャッチコピー : x],[地図 : x],[その他 :  ] `が生成
 
<img width="697" alt="スクリーンショット 2023-06-24 0 41 22" src="https://github.com/NUTFes/FinanSu/assets/115447919/4b5da413-c7ed-4a7f-a5b3-5edc16ae43c8">
