### PR TITLE
協賛活動ページにcsvダウンロード機能を追加

### DIFF
--- a/view/next-project/src/components/common/Title.tsx
+++ b/view/next-project/src/components/common/Title.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default function Title(props: Props) {
   const className =
-    'text-2xl leading-8 font-thin tracking-widest mr-5' +
+    'text-2xl leading-8 font-thin tracking-widest gap-5 flex items-center justify-center' +
     (props.className ? ` ${props.className}` : '');
 
   return (

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -64,7 +64,7 @@ const formatYYYYMMDD = (date: Date) => {
   const mm = String(date.getMonth() + 1).padStart(2, '0');
   const dd = String(date.getDate()).padStart(2, '0');
   return `${yyyy}${mm}${dd}`;
-}
+};
 
 export default function SponsorActivities(props: Props) {
   const [sponsorActivitiesID, setSponsorActivitiesID] = useState<number>(1);

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -2,7 +2,10 @@ import clsx from 'clsx';
 import Head from 'next/head';
 import { useState, useMemo } from 'react';
 
+import PrimaryButton from '@/components/common/OutlinePrimaryButton/OutlinePrimaryButton';
 import OpenModalButton from '@/components/sponsoractivities/OpenAddModalButton';
+import { createPresentationCsv } from '@/utils/createActivityCsv';
+import { downloadFile } from '@/utils/downloadFile';
 import { get } from '@api/api_methods';
 import { Card, Title } from '@components/common';
 import MainLayout from '@components/layout/MainLayout';
@@ -52,6 +55,13 @@ export async function getServerSideProps() {
       activityStyles: activityStylesRes,
     },
   };
+}
+
+const formatYYYYMMDD = (date: Date) => {
+  const yyyy = String(date.getFullYear());
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}${mm}${dd}`;
 }
 
 export default function SponsorActivities(props: Props) {
@@ -117,7 +127,7 @@ export default function SponsorActivities(props: Props) {
       </Head>
       <Card w='w-full'>
         <div className='mx-6 mt-10 md:mx-5'>
-          <div className='flex'>
+          <div className='flex gap-4'>
             <Title title={'協賛活動一覧'} />
             <select
               className={'w-100'}
@@ -128,6 +138,17 @@ export default function SponsorActivities(props: Props) {
               <option value='2022'>2022</option>
               <option value='2023'>2023</option>
             </select>
+            <PrimaryButton
+              onClick={async () => {
+                downloadFile({
+                  downloadContent: await createPresentationCsv(filteredSponsorActivitiesViews),
+                  fileName: `協賛活動一覧_${formatYYYYMMDD(new Date())}.csv`,
+                  isBomAdded: true,
+                });
+              }}
+            >
+              CSVダウンロード
+            </PrimaryButton>
           </div>
           <div className='hidden justify-end md:flex '>
             <OpenModalButton

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -141,6 +141,7 @@ export default function SponsorActivities(props: Props) {
               <option value='2023'>2023</option>
             </select>
             <PrimaryButton
+              className='hidden md:block'
               onClick={async () => {
                 downloadFile({
                   downloadContent: await createPresentationCsv(filteredSponsorActivitiesViews),

--- a/view/next-project/src/utils/createActivityCsv.ts
+++ b/view/next-project/src/utils/createActivityCsv.ts
@@ -53,5 +53,9 @@ export const createPresentationCsv = async (activityViews: SponsorActivityView[]
         getCustomValue: (row) => row.sponsorActivity.updatedAt || '',
         label: '更新日時',
       },
+      {
+        getCustomValue: (row) => row.sponsorActivity.remark || '',
+        label: '備考',
+      },
     ]),
   );

--- a/view/next-project/src/utils/createActivityCsv.ts
+++ b/view/next-project/src/utils/createActivityCsv.ts
@@ -1,0 +1,57 @@
+import { SponsorActivityView } from '../type/common';
+import { createCsv, createCsvData } from './createCsv';
+import { BUREAUS } from '@/constants/bureaus';
+
+export const createPresentationCsv = async (activityViews: SponsorActivityView[]) =>
+  createCsv(
+    createCsvData(activityViews, [
+      {
+        getCustomValue: (row) => row.sponsor.name || '',
+        label: '企業名',
+      },
+      {
+        getCustomValue: (row) =>
+          row.styleDetail.reduce((sum, style) => sum + style.sponsorStyle.price, 0) || '',
+        label: '協賛合計金額',
+      },
+      {
+        getCustomValue: (row) =>
+          row.styleDetail
+            .map(
+              (style) =>
+                `${style.sponsorStyle.style} ${style.sponsorStyle.feature} ${style.sponsorStyle.price}`,
+            )
+            .join(' / ') || '',
+        label: '協賛内容【詳細】',
+      },
+      {
+        getCustomValue: (row) => row.user.name || '',
+        label: '担当者名',
+      },
+      {
+        getCustomValue: (row) =>
+          BUREAUS.find((bureau) => bureau.id === row.user.bureauID)?.name || '',
+        label: '所属局',
+      },
+      {
+        getCustomValue: (row) => (row.sponsorActivity.isDone ? '回収済み' : '未回収' || ''),
+        label: '回収状況',
+      },
+      {
+        getCustomValue: (row) => row.sponsorActivity.feature || '',
+        label: 'オプション',
+      },
+      {
+        getCustomValue: (row) => row.sponsorActivity.expense || '',
+        label: '交通費',
+      },
+      {
+        getCustomValue: (row) => row.sponsorActivity.createdAt || '',
+        label: '作成日時',
+      },
+      {
+        getCustomValue: (row) => row.sponsorActivity.updatedAt || '',
+        label: '更新日時',
+      },
+    ]),
+  );

--- a/view/next-project/src/utils/createActivityCsv.ts
+++ b/view/next-project/src/utils/createActivityCsv.ts
@@ -46,6 +46,27 @@ export const createPresentationCsv = async (activityViews: SponsorActivityView[]
         label: '交通費',
       },
       {
+        getCustomValue: (row) => {
+          switch (row.sponsorActivity.design) {
+            case 0:
+              return 'なし';
+            case 1:
+              return '学生が作成';
+            case 2:
+              return '企業が作成';
+            case 3:
+              return '去年のものを使用';
+            default:
+              return '';
+          }
+        },
+        label: 'デザイン作成者',
+      },
+      {
+        getCustomValue: (row) => row.sponsorActivity.url || '',
+        label: 'デザインURL',
+      },
+      {
         getCustomValue: (row) => row.sponsorActivity.createdAt || '',
         label: '作成日時',
       },

--- a/view/next-project/src/utils/createCsv.ts
+++ b/view/next-project/src/utils/createCsv.ts
@@ -1,0 +1,32 @@
+export type CsvColumn<T> = { label: string } & (
+  | { getCustomValue: (row: T) => string | number | null }
+  | { key: keyof T }
+);
+export function createHeader<T extends object>(columns: CsvColumn<T>[]) {
+  return columns.map(({ label }) => label);
+}
+export function createCsvData<T extends object>(rows: T[], columns: CsvColumn<T>[]) {
+  const header = createHeader(columns);
+  const body = rows.map((values) =>
+    columns.map((column) => {
+      if ('key' in column) {
+        return String(values[column.key] ?? '');
+      }
+
+      return column.getCustomValue(values);
+    }),
+  );
+  return [header, ...body];
+}
+
+export const createCsv = (csvData: (number | string | null)[][]) =>
+  csvData
+    .map((row) => {
+      const rowString = row.map((value) => {
+        if (value === null) return '';
+        if (typeof value === 'string') return value.replace(/,/g, '，').replace(/\n/g, ' ');
+        return String(value);
+      });
+      return rowString.join(',');
+    })
+    .join('\n');

--- a/view/next-project/src/utils/downloadFile.ts
+++ b/view/next-project/src/utils/downloadFile.ts
@@ -1,0 +1,39 @@
+export const downloadFile = async ({
+  downloadContent,
+  fileName,
+  isBomAdded,
+}: {
+  downloadContent: (() => Promise<string | File | Blob>) | string | File | Blob;
+  fileName?: string;
+  isBomAdded?: boolean;
+}) => {
+  if (!window) return;
+  let content: Blob | string;
+
+  if (typeof downloadContent === 'function') {
+    let response: string | File | Blob | Promise<string | File | Blob> = (
+      downloadContent as () => Promise<string | File | Blob>
+    )();
+
+    if (response instanceof Promise) {
+      const promiseResponse = await response.catch(console.error);
+      if (!promiseResponse) return;
+      response = promiseResponse;
+    }
+    content = response;
+  } else {
+    content = downloadContent;
+  }
+
+  if (typeof content === 'string')
+    content = new Blob(isBomAdded ? [new Uint8Array([0xef, 0xbb, 0xbf]), content] : [content]);
+
+  const url = URL.createObjectURL(content);
+  const anchor = document.createElement('a');
+  anchor.setAttribute('download', fileName || '');
+  anchor.setAttribute('href', url);
+
+  const mouseEvent = new MouseEvent('click');
+  anchor.dispatchEvent(mouseEvent);
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #616

# 概要
<!-- 開発内容の概要を記載 -->

- 協賛活動のデータをcsvでダウンロードできるようにした

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- https://nut-m-e-g.slack.com/archives/C020WQ3GY07/p1687530255938499

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 協賛活動ページに移動

- [x] csvダウンロードボタンを押してダウンロードされるか
- [x] 表示されてるデータが正常か

# 備考
