### PR TITLE
購入報告のCSV出力

### DIFF
--- a/view/next-project/src/pages/purchasereports/index.tsx
+++ b/view/next-project/src/pages/purchasereports/index.tsx
@@ -2,9 +2,12 @@ import clsx from 'clsx';
 import Head from 'next/head';
 import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useRecoilValue } from 'recoil';
+import PrimaryButton from '@/components/common/OutlinePrimaryButton/OutlinePrimaryButton';
 
 import { authAtom } from '@/store/atoms';
 import { put } from '@/utils/api/purchaseReport';
+import { createPurchaseReportCsv } from '@/utils/createPurchaseReportCsv';
+import { downloadFile } from '@/utils/downloadFile';
 import { get } from '@api/api_methods';
 import { getCurrentUser } from '@api/currentUser';
 import { Card, Checkbox, Title, BureauLabel } from '@components/common';
@@ -46,6 +49,13 @@ export async function getServerSideProps() {
     },
   };
 }
+
+const formatYYYYMMDD = (date: Date) => {
+  const yyyy = String(date.getFullYear());
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}${mm}${dd}`;
+};
 
 export default function PurchaseReports(props: Props) {
   const auth = useRecoilValue(authAtom);
@@ -165,7 +175,7 @@ export default function PurchaseReports(props: Props) {
       </Head>
       <Card>
         <div className='mx-5 mt-10'>
-          <div className='flex'>
+          <div className='flex gap4'>
             <Title title={'購入報告一覧'} />
             <select
               className='w-100 '
@@ -176,6 +186,21 @@ export default function PurchaseReports(props: Props) {
               <option value='2022'>2022</option>
               <option value='2023'>2023</option>
             </select>
+            <PrimaryButton
+              className='hidden md:block'
+              onClick={async () => {
+                downloadFile({
+                  downloadContent: await createPurchaseReportCsv(
+                    filteredPurchaseReportViews,
+                    props.expenses,
+                  ),
+                  fileName: `購入申請一覧(${selectedYear})_${formatYYYYMMDD(new Date())}.csv`,
+                  isBomAdded: true,
+                });
+              }}
+            >
+              CSVダウンロード
+            </PrimaryButton>
           </div>
           <div className='hidden justify-end md:flex'>
             <OpenAddModalButton>報告登録</OpenAddModalButton>

--- a/view/next-project/src/utils/createPurchaseReportCsv.ts
+++ b/view/next-project/src/utils/createPurchaseReportCsv.ts
@@ -42,7 +42,7 @@ export const createPurchaseReportCsv = async (
                 (item.financeCheck ? '○' : '×'),
             )
             .join(' , ') || '',
-        label: '購入物品 (品名/値段/数量/財務局長チェック)',
+        label: '購入物品 (品名/値段/数量/購入の有無)',
       },
       {
         getCustomValue: (row) => row.purchaseReport.remark || '',

--- a/view/next-project/src/utils/createPurchaseReportCsv.ts
+++ b/view/next-project/src/utils/createPurchaseReportCsv.ts
@@ -1,0 +1,52 @@
+import { PurchaseReportView, Expense } from '../type/common';
+import { createCsv, createCsvData } from './createCsv';
+
+export const createPurchaseReportCsv = async (
+  purchaseReportsViews: PurchaseReportView[],
+  expenses: Expense[],
+) =>
+  createCsv(
+    createCsvData(purchaseReportsViews, [
+      {
+        getCustomValue: (row) => row.purchaseReport.id || '',
+        label: 'ID',
+      },
+      {
+        getCustomValue: (row) =>
+          expenses.find((expense) => expense.id === row.purchaseOrder.expenseID)?.name || '',
+        label: '報告した局',
+      },
+      {
+        getCustomValue: (row) => String(row.purchaseReport.createdAt).split('T')[0] || '',
+        label: '報告日',
+      },
+      {
+        getCustomValue: (row) => row.purchaseOrder.deadline || '',
+        label: '購入日',
+      },
+      {
+        getCustomValue: (row) =>
+          (row.purchaseItems.reduce((sum, item) => item.financeCheck ? (sum + item.price * item.quantity) : sum, 0) + row.purchaseReport.addition - row.purchaseReport.discount)|| '0',
+        label: '合計金額',
+      },
+      {
+        getCustomValue: (row) => (row.purchaseReport.financeCheck ? '○' : '' || ''),
+        label: '財務局長チェック',
+      },
+      {
+        getCustomValue: (row) =>
+          row.purchaseItems
+            .map(
+              (item) =>
+                `${item.item}/${item.price}円/${item.quantity}個/` +
+                (item.financeCheck ? '○' : '×'),
+            )
+            .join(' , ') || '',
+        label: '購入物品 (品名/値段/数量/財務局長チェック)',
+      },
+      {
+        getCustomValue: (row) => row.purchaseReport.remark || '',
+        label: '備考',
+      },
+    ]),
+  );


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->

# 概要
<!-- 開発内容の概要を記載 -->
購入報告の内容をSCV出力させる

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![スクリーンショット 2023-08-08 205409](https://github.com/NUTFes/FinanSu/assets/68796591/1908e326-332b-4e5f-9610-9a7e8e9c709b)

- 購入申請一覧(2022)_20230808.csv
```
ID,報告した局,報告日,購入日,合計金額,財務局長チェック,購入物品 (品名/値段/数量/財務局長チェック),備考
1,企画局,2023-06-19,2022-3-28,100100,○,ビンゴ用品/30000円/3個/○ ， マイク/10000円/1個/○,test-remark
2,企画局,2023-06-19,2022-2-22,10000,,ビンゴ景品/10000円/1個/○ ， ヒーロースーツ/20000円/2個/×,test-remark2
3,総務局,2023-06-19,2022-4-6,40400,○,机/20000円/2個/○ ， 椅子/30000円/3個/×,test-remark3
4,情報局,2023-06-19,2022-3-28,100400,○,酒/10000円/10個/○,test-remark3
5,制作局,2023-06-19,2022-4-6,400,○,封筒/100円/100個/×,test-remark3
6,渉外局,2023-06-19,2022-4-6,5400,○,領収書/100円/50個/○,test-remark3
```

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] csv出力ボタンが表示され，ダウンロードが実行されるか
- [ ] csv出力された内容が，画面で表示されている内容と一致しているか
-

# 備考
- 出力される合計金額は，画面と同じように，財務局長のチェックがついているアイテムと加算，割引の値で算出しています