### PR TITLE
協賛活動ページの協賛受取の絞り込みと並び替え機能の実装

### DIFF
--- a/view/next-project/src/components/common/Title.tsx
+++ b/view/next-project/src/components/common/Title.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default function Title(props: Props) {
   const className =
-    'text-2xl leading-8 font-thin tracking-widest gap-5 flex items-center justify-center' +
+    'text-xl leading-8 font-thin tracking-widest gap-5 flex items-center justify-center md:text-2xl' +
     (props.className ? ` ${props.className}` : '');
 
   return (

--- a/view/next-project/src/components/common/Title.tsx
+++ b/view/next-project/src/components/common/Title.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export default function Title(props: Props) {
   const className =
-    'text-xl leading-8 font-thin tracking-widest gap-5 flex items-center justify-center md:text-2xl' +
+    'text-2xl leading-8 font-thin tracking-widest gap-5 flex items-center justify-center' +
     (props.className ? ` ${props.className}` : '');
 
   return (

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -95,22 +95,18 @@ export default function SponsorActivities(props: Props) {
   }, [props, selectedYear]);
 
   const filteredIsDoneSponsorActivitiesViews = useMemo(() => {
-    let filteredActivities = filteredSponsorActivitiesViews;
     switch (selectedIsDone) {
       case 'false':
-        filteredActivities = filteredSponsorActivitiesViews.filter((sponsorActivitiesItem) => {
+        return filteredSponsorActivitiesViews.filter((sponsorActivitiesItem) => {
           return !sponsorActivitiesItem.sponsorActivity.isDone;
         });
-        break;
       case 'true':
-        filteredActivities = filteredSponsorActivitiesViews.filter((sponsorActivitiesItem) => {
+        return filteredSponsorActivitiesViews.filter((sponsorActivitiesItem) => {
           return sponsorActivitiesItem.sponsorActivity.isDone;
         });
-        break;
       default:
-        break;
+        return filteredSponsorActivitiesViews;
     }
-    return filteredActivities;
   }, [filteredSponsorActivitiesViews, selectedIsDone]);
 
   const sortedSponsorActivitiesViews = useMemo(() => {

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -88,31 +88,29 @@ export default function SponsorActivities(props: Props) {
   const [selectedIsDone, setSelectedIsDone] = useState<string>('all');
   const [selectedSort, setSelectedSort] = useState<string>('default');
 
-  const filteredSponsorActivitiesViews = useMemo(() => {
-    return props.sponsorActivitiesView.filter((sponsorActivitiesItem) => {
+  const sortedAndFilteredSponsorActivitiesViews = useMemo(() => {
+    let filteredActivities = props.sponsorActivitiesView.filter((sponsorActivitiesItem) => {
       return sponsorActivitiesItem.sponsorActivity.createdAt?.includes(selectedYear);
     });
-  }, [props, selectedYear]);
 
-  const filteredIsDoneSponsorActivitiesViews = useMemo(() => {
     switch (selectedIsDone) {
       case 'false':
-        return filteredSponsorActivitiesViews.filter((sponsorActivitiesItem) => {
+        filteredActivities = filteredActivities.filter((sponsorActivitiesItem) => {
           return !sponsorActivitiesItem.sponsorActivity.isDone;
         });
+        break;
       case 'true':
-        return filteredSponsorActivitiesViews.filter((sponsorActivitiesItem) => {
+        filteredActivities = filteredActivities.filter((sponsorActivitiesItem) => {
           return sponsorActivitiesItem.sponsorActivity.isDone;
         });
+        break;
       default:
-        return filteredSponsorActivitiesViews;
+        break;
     }
-  }, [filteredSponsorActivitiesViews, selectedIsDone]);
 
-  const sortedSponsorActivitiesViews = useMemo(() => {
     switch (selectedSort) {
       case 'createDesSort':
-        return [...filteredIsDoneSponsorActivitiesViews].sort(
+        return [...filteredActivities].sort(
           (firstObject: SponsorActivityView, secondObject: SponsorActivityView) =>
             new Date(firstObject.sponsorActivity.createdAt || 0).getTime() >
             new Date(secondObject.sponsorActivity.createdAt || 0).getTime()
@@ -120,7 +118,7 @@ export default function SponsorActivities(props: Props) {
               : 1,
         );
       case 'updateSort':
-        return [...filteredIsDoneSponsorActivitiesViews].sort(
+        return [...filteredActivities].sort(
           (firstObject: SponsorActivityView, secondObject: SponsorActivityView) =>
             new Date(firstObject.sponsorActivity.updatedAt || 0).getTime() >
             new Date(secondObject.sponsorActivity.updatedAt || 0).getTime()
@@ -128,7 +126,7 @@ export default function SponsorActivities(props: Props) {
               : -1,
         );
       case 'updateDesSort':
-        return [...filteredIsDoneSponsorActivitiesViews].sort(
+        return [...filteredActivities].sort(
           (firstObject: SponsorActivityView, secondObject: SponsorActivityView) =>
             new Date(firstObject.sponsorActivity.updatedAt || 0).getTime() >
             new Date(secondObject.sponsorActivity.updatedAt || 0).getTime()
@@ -136,7 +134,7 @@ export default function SponsorActivities(props: Props) {
               : 1,
         );
       case 'priceSort':
-        return [...filteredIsDoneSponsorActivitiesViews].sort(
+        return [...filteredActivities].sort(
           (firstObject: SponsorActivityView, secondObject: SponsorActivityView) =>
             firstObject.styleDetail.reduce((sum, style) => sum + style.sponsorStyle.price, 0) >
             secondObject.styleDetail.reduce((sum, style) => sum + style.sponsorStyle.price, 0)
@@ -144,7 +142,7 @@ export default function SponsorActivities(props: Props) {
               : -1,
         );
       case 'priceDesSort':
-        return [...filteredIsDoneSponsorActivitiesViews].sort(
+        return [...filteredActivities].sort(
           (firstObject: SponsorActivityView, secondObject: SponsorActivityView) =>
             firstObject.styleDetail.reduce((sum, style) => sum + style.sponsorStyle.price, 0) >
             secondObject.styleDetail.reduce((sum, style) => sum + style.sponsorStyle.price, 0)
@@ -152,24 +150,24 @@ export default function SponsorActivities(props: Props) {
               : 1,
         );
       default:
-        return filteredIsDoneSponsorActivitiesViews;
+        return filteredActivities;
     }
-  }, [filteredIsDoneSponsorActivitiesViews, selectedSort]);
+  }, [props, selectedYear, selectedIsDone, selectedSort]);
 
   const TotalTransportationFee = useMemo(() => {
     let totalFee = 0;
-    if (filteredIsDoneSponsorActivitiesViews) {
-      filteredIsDoneSponsorActivitiesViews?.map((sponsorActivityItem) => {
+    if (sortedAndFilteredSponsorActivitiesViews) {
+      sortedAndFilteredSponsorActivitiesViews?.map((sponsorActivityItem) => {
         totalFee += sponsorActivityItem.sponsorActivity.expense;
       });
     }
     return totalFee;
-  }, [filteredIsDoneSponsorActivitiesViews]);
+  }, [sortedAndFilteredSponsorActivitiesViews]);
 
   const TotalActivityStyleFee = useMemo(() => {
     let totalFee = 0;
-    if (filteredIsDoneSponsorActivitiesViews) {
-      filteredIsDoneSponsorActivitiesViews?.map((sponsorActivityItem) => {
+    if (sortedAndFilteredSponsorActivitiesViews) {
+      sortedAndFilteredSponsorActivitiesViews?.map((sponsorActivityItem) => {
         const sponsorActivitiesStylesPrice = sponsorActivityItem.styleDetail
           ? sponsorActivityItem.styleDetail.map((styleDetail) => {
               return styleDetail.sponsorStyle.price;
@@ -183,7 +181,7 @@ export default function SponsorActivities(props: Props) {
       });
     }
     return totalFee;
-  }, [filteredIsDoneSponsorActivitiesViews]);
+  }, [sortedAndFilteredSponsorActivitiesViews]);
 
   return (
     <MainLayout>
@@ -232,7 +230,9 @@ export default function SponsorActivities(props: Props) {
                 className='hidden md:block'
                 onClick={async () => {
                   downloadFile({
-                    downloadContent: await createPresentationCsv(sortedSponsorActivitiesViews),
+                    downloadContent: await createPresentationCsv(
+                      sortedAndFilteredSponsorActivitiesViews,
+                    ),
                     fileName: `協賛活動一覧_${formatYYYYMMDD(new Date())}.csv`,
                     isBomAdded: true,
                   });
@@ -253,8 +253,8 @@ export default function SponsorActivities(props: Props) {
           </div>
         </div>
         <div className='mb-7 md:hidden'>
-          {sortedSponsorActivitiesViews &&
-            sortedSponsorActivitiesViews.map((sponsorActivitiesItem) => (
+          {sortedAndFilteredSponsorActivitiesViews &&
+            sortedAndFilteredSponsorActivitiesViews.map((sponsorActivitiesItem) => (
               <Card key={sponsorActivitiesItem.sponsorActivity.id}>
                 <div className='flex flex-col gap-2 p-4'>
                   <div>
@@ -334,7 +334,7 @@ export default function SponsorActivities(props: Props) {
                 </div>
               </Card>
             ))}
-          {!filteredIsDoneSponsorActivitiesViews.length && (
+          {!sortedAndFilteredSponsorActivitiesViews.length && (
             <div className='my-5 text-center text-sm text-black-600'>データがありません</div>
           )}
         </div>
@@ -372,8 +372,8 @@ export default function SponsorActivities(props: Props) {
               </tr>
             </thead>
             <tbody className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
-              {sortedSponsorActivitiesViews &&
-                sortedSponsorActivitiesViews.map((sponsorActivitiesItem) => (
+              {sortedAndFilteredSponsorActivitiesViews &&
+                sortedAndFilteredSponsorActivitiesViews.map((sponsorActivitiesItem) => (
                   <tr className={clsx('border-b')} key={sponsorActivitiesItem.sponsorActivity.id}>
                     <td
                       onClick={() => {
@@ -518,7 +518,7 @@ export default function SponsorActivities(props: Props) {
                     </td>
                   </tr>
                 ))}
-              {filteredIsDoneSponsorActivitiesViews.length > 0 && (
+              {sortedAndFilteredSponsorActivitiesViews.length > 0 && (
                 <tr className='border-b border-primary-1'>
                   <td className='px-1 py-3' colSpan={1}>
                     <div className='flex justify-end'>
@@ -542,7 +542,7 @@ export default function SponsorActivities(props: Props) {
                   </td>
                 </tr>
               )}
-              {!filteredIsDoneSponsorActivitiesViews.length && (
+              {!sortedAndFilteredSponsorActivitiesViews.length && (
                 <tr>
                   <td colSpan={6} className='py-3'>
                     <div className='text-center text-sm text-black-600'>データがありません</div>

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -85,6 +85,7 @@ export default function SponsorActivities(props: Props) {
 
   const currentYear = new Date().getFullYear().toString();
   const [selectedYear, setSelectedYear] = useState<string>(currentYear);
+  const [selectedIsDone, setSelectedIsDone] = useState<string>('all');
 
   const filteredSponsorActivitiesViews = useMemo(() => {
     return props.sponsorActivitiesView.filter((sponsorActivitiesItem) => {
@@ -92,20 +93,40 @@ export default function SponsorActivities(props: Props) {
     });
   }, [props, selectedYear]);
 
+  const filteredIsDoneSponsorActivitiesViews = useMemo(() => {
+    let filteredActivities = filteredSponsorActivitiesViews;
+    switch (selectedIsDone) {
+      case 'false':
+        filteredActivities = filteredSponsorActivitiesViews.filter((sponsorActivitiesItem) => {
+          return !sponsorActivitiesItem.sponsorActivity.isDone;
+        });
+        break;
+      case 'true':
+        filteredActivities = filteredSponsorActivitiesViews.filter((sponsorActivitiesItem) => {
+          return sponsorActivitiesItem.sponsorActivity.isDone;
+        });
+        break;
+      default:
+        break;
+    }
+    console.log(filteredActivities);
+    return filteredActivities;
+  }, [filteredSponsorActivitiesViews, selectedIsDone]);
+
   const TotalTransportationFee = useMemo(() => {
     let totalFee = 0;
-    if (filteredSponsorActivitiesViews) {
-      filteredSponsorActivitiesViews?.map((sponsorActivityItem) => {
+    if (filteredIsDoneSponsorActivitiesViews) {
+      filteredIsDoneSponsorActivitiesViews?.map((sponsorActivityItem) => {
         totalFee += sponsorActivityItem.sponsorActivity.expense;
       });
     }
     return totalFee;
-  }, [filteredSponsorActivitiesViews]);
+  }, [filteredIsDoneSponsorActivitiesViews]);
 
   const TotalActivityStyleFee = useMemo(() => {
     let totalFee = 0;
-    if (filteredSponsorActivitiesViews) {
-      filteredSponsorActivitiesViews?.map((sponsorActivityItem) => {
+    if (filteredIsDoneSponsorActivitiesViews) {
+      filteredIsDoneSponsorActivitiesViews?.map((sponsorActivityItem) => {
         const sponsorActivitiesStylesPrice = sponsorActivityItem.styleDetail
           ? sponsorActivityItem.styleDetail.map((styleDetail) => {
               return styleDetail.sponsorStyle.price;
@@ -119,7 +140,7 @@ export default function SponsorActivities(props: Props) {
       });
     }
     return totalFee;
-  }, [filteredSponsorActivitiesViews]);
+  }, [filteredIsDoneSponsorActivitiesViews]);
 
   return (
     <MainLayout>
@@ -140,11 +161,22 @@ export default function SponsorActivities(props: Props) {
               <option value='2022'>2022</option>
               <option value='2023'>2023</option>
             </select>
+            <select
+              className={'w-100'}
+              defaultValue={'all'}
+              onChange={(e) => setSelectedIsDone(e.target.value)}
+            >
+              <option value='all'>すべて</option>
+              <option value='false'>未回収</option>
+              <option value='true'>回収済</option>
+            </select>
             <PrimaryButton
               className='hidden md:block'
               onClick={async () => {
                 downloadFile({
-                  downloadContent: await createPresentationCsv(filteredSponsorActivitiesViews),
+                  downloadContent: await createPresentationCsv(
+                    filteredIsDoneSponsorActivitiesViews,
+                  ),
                   fileName: `協賛活動一覧_${formatYYYYMMDD(new Date())}.csv`,
                   isBomAdded: true,
                 });
@@ -164,8 +196,8 @@ export default function SponsorActivities(props: Props) {
           </div>
         </div>
         <div className='mb-7 md:hidden'>
-          {filteredSponsorActivitiesViews &&
-            filteredSponsorActivitiesViews.map((sponsorActivitiesItem) => (
+          {filteredIsDoneSponsorActivitiesViews &&
+            filteredIsDoneSponsorActivitiesViews.map((sponsorActivitiesItem) => (
               <Card key={sponsorActivitiesItem.sponsorActivity.id}>
                 <div className='flex flex-col gap-2 p-4'>
                   <div>
@@ -245,7 +277,7 @@ export default function SponsorActivities(props: Props) {
                 </div>
               </Card>
             ))}
-          {!filteredSponsorActivitiesViews.length && (
+          {!filteredIsDoneSponsorActivitiesViews.length && (
             <div className='my-5 text-center text-sm text-black-600'>データがありません</div>
           )}
         </div>
@@ -283,8 +315,8 @@ export default function SponsorActivities(props: Props) {
               </tr>
             </thead>
             <tbody className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
-              {filteredSponsorActivitiesViews &&
-                filteredSponsorActivitiesViews.map((sponsorActivitiesItem, index) => (
+              {filteredIsDoneSponsorActivitiesViews &&
+                filteredIsDoneSponsorActivitiesViews.map((sponsorActivitiesItem) => (
                   <tr className={clsx('border-b')} key={sponsorActivitiesItem.sponsorActivity.id}>
                     <td
                       onClick={() => {
@@ -429,7 +461,7 @@ export default function SponsorActivities(props: Props) {
                     </td>
                   </tr>
                 ))}
-              {filteredSponsorActivitiesViews.length > 0 && (
+              {filteredIsDoneSponsorActivitiesViews.length > 0 && (
                 <tr className='border-b border-primary-1'>
                   <td className='px-1 py-3' colSpan={1}>
                     <div className='flex justify-end'>
@@ -453,7 +485,7 @@ export default function SponsorActivities(props: Props) {
                   </td>
                 </tr>
               )}
-              {!filteredSponsorActivitiesViews.length && (
+              {!filteredIsDoneSponsorActivitiesViews.length && (
                 <tr>
                   <td colSpan={6} className='py-3'>
                     <div className='text-center text-sm text-black-600'>データがありません</div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#639 

# 概要
<!-- 開発内容の概要を記載 -->
- 協賛金の回収済と未受取の絞り込み機能の実装 https://github.com/NUTFes/FinanSu/commit/699ed0e2f4d885bfa682664b78af35584a4b2ec2
- 協賛活動の並び替え機能の実装 https://github.com/NUTFes/FinanSu/commit/1d18a73ab229b0d8738f6c05f3a129b675424016
  - 作成日時昇順(デフォルト) 
  - 作成日時降順 : 作成日の新しい順 
  - 更新日時昇順 : 更新日の古い順 
  - 更新日時降順 : 更新日の新しい順
  - 協賛金昇順 : 協賛金額合計の少ない順
  - 協賛金降順 : 協賛金額合計の多い順


# 画面スクリーンショット等
<img width="700" alt="スクリーンショット 2023-08-15 14 30 00" src="https://github.com/NUTFes/FinanSu/assets/115447919/3865f587-db5e-45d9-8b80-37792f53e747">
<img width="700" alt="スクリーンショット 2023-08-15 14 30 04" src="https://github.com/NUTFes/FinanSu/assets/115447919/74fcf970-e194-4380-8da8-fbef4f1775df">
<img width="700" alt="スクリーンショット 2023-08-15 14 36 30" src="https://github.com/NUTFes/FinanSu/assets/115447919/be7de0b1-7045-49d6-863e-0b88c020400d">


# テスト項目
<!-- テストしてほしい内容を記載 -->

- [x] 協賛活動ページを開いた時、全てになっていて、未受取と回収済を選択することで絞り込みができているか
- [x] 並び替えのそれぞれ選択した際の並びが合っているか
- [x]  絞り込みによって、テーブルの下に表示される合計が正しいか
- [x] スマホページでも動作が問題ないか
- [x] 絞り込み、並び替えにあったcsvファイルが出力されるか
- [x] どの順番で絞り込みや並び替えを押しても表示結果に誤りがないか

# 備考
