### PR TITLE
購入報告ページのバグ修正

### DIFF
--- a/view/next-project/src/components/purchasereports/DetailModal.tsx
+++ b/view/next-project/src/components/purchasereports/DetailModal.tsx
@@ -66,10 +66,12 @@ const DetailModal: FC<ModalProps> = (props) => {
   // 購入報告の合計金額を計算
   const TotalFee = (purchaseReport: PurchaseReport, purchaseItems: PurchaseItem[]) => {
     let totalFee = 0;
-    purchaseItems.map((purchaseItem: PurchaseItem) => {
-      totalFee += purchaseItem.price * purchaseItem.quantity;
-    });
-    totalFee += purchaseReport.addition - purchaseReport.discount;
+    if (purchaseItems) {
+      purchaseItems.map((purchaseItem: PurchaseItem) => {
+        totalFee += purchaseItem.price * purchaseItem.quantity;
+      });
+      totalFee += purchaseReport.addition - purchaseReport.discount;
+    }
     return totalFee;
   };
 
@@ -161,7 +163,7 @@ const DetailModal: FC<ModalProps> = (props) => {
             </thead>
             <tbody className='w-full border border-x-white-0 border-b-primary-1 border-t-white-0'>
               {/* <div className='flex items-start'> */}
-              {props.purchaseReportViewItem?.purchaseItems.map((purchaseItem) => (
+              {props.purchaseReportViewItem?.purchaseItems?.map((purchaseItem) => (
                 <tr key={purchaseItem.id} className='w-full'>
                   <td className='border-b py-3'>
                     <div className='text-center text-sm text-black-300'>{purchaseItem.item}</div>

--- a/view/next-project/src/pages/purchasereports/index.tsx
+++ b/view/next-project/src/pages/purchasereports/index.tsx
@@ -93,13 +93,15 @@ export default function PurchaseReports(props: Props) {
 
   const TotalFee = useCallback((purchaseReport: PurchaseReport, purchaseItems: PurchaseItem[]) => {
     let totalFee = 0;
-    purchaseItems.map((purchaseItem: PurchaseItem) => {
-      if (purchaseItem.financeCheck) {
-        totalFee += purchaseItem.price * purchaseItem.quantity;
-      }
-    });
-    totalFee += purchaseReport.addition - purchaseReport.discount;
-    return totalFee;
+    if (purchaseItems) {
+      purchaseItems.map((purchaseItem: PurchaseItem) => {
+        if (purchaseItem.financeCheck) {
+          totalFee += purchaseItem.price * purchaseItem.quantity;
+        }
+      });
+      totalFee += purchaseReport.addition - purchaseReport.discount;
+      return totalFee;
+    }
   }, []);
 
   // すべてのpurchaseReportの合計金額
@@ -107,7 +109,8 @@ export default function PurchaseReports(props: Props) {
     if (filteredPurchaseReportViews) {
       let totalFee = 0;
       filteredPurchaseReportViews.map((purchaseReportView: PurchaseReportView) => {
-        totalFee += TotalFee(purchaseReportView.purchaseReport, purchaseReportView.purchaseItems);
+        totalFee +=
+          TotalFee(purchaseReportView.purchaseReport, purchaseReportView.purchaseItems) || 0;
       });
       return totalFee;
     }
@@ -333,7 +336,7 @@ export default function PurchaseReports(props: Props) {
                         )}
                       >
                         {/* name (個数/finasucheck) */}
-                        {purchaseReportViewItem.purchaseItems.map((purchaseItem, index) => (
+                        {purchaseReportViewItem.purchaseItems?.map((purchaseItem, index) => (
                           <div key={index}>
                             {`${purchaseItem.financeCheck ? '○' : 'x'} ${purchaseItem.item} (${
                               purchaseItem.quantity


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
#644 

# 概要
<!-- 開発内容の概要を記載 -->
本番環境で購入報告のレコードに購入物品が登録されていないものがあり、
それが原因で現在エラーが出ている。
購入物品が登録されているレコードのみ処理を行うことで修正した。
購入報告ページとその詳細モーダルを修正した。
<img width="1124" alt="スクリーンショット 2023-09-29 11 05 27" src="https://github.com/NUTFes/FinanSu/assets/115447919/9f9c7f8d-ae6e-4449-ac0e-7215ba522e6a">
<img width="756" alt="スクリーンショット 2023-09-29 11 05 43" src="https://github.com/NUTFes/FinanSu/assets/115447919/a36aafa9-c298-4091-a5ea-b5ae8e446930">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 本番環境のAPIを呼び出し、購入報告ページが表示できるか確認する
- `src/pages/purchasereports/index.tsx`の`getPurchaseReportViewUrl`を以下に変更することで、呼び出せる
- `const getPurchaseReportViewUrl = 'https://finansu-api.nutfes.net/purchasereports/details';`

# 備考
購入報告を追加する際、どこですり抜けているかは不明
おそらく購入申請にないものを報告する際の処理で何か問題が起きていると思われる
