### PR TITLE
[feat] add validation  (#650)

### DIFF
--- a/view/next-project/src/components/purchaseorders/PurchaseOrderAddModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseOrderAddModal.tsx
@@ -52,15 +52,19 @@ export default function AddModal(props: ModalProps) {
     await del(deletePurchaseOrderUrl);
   };
 
+  const [itemName, setItemName] = useState('');
   const handler =
-    (stepNumber: number, input: string) =>
-    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
-      props.setFormDataList(
-        props.formDataList.map((formData: PurchaseItem) =>
-          formData.id === stepNumber ? { ...formData, [input]: e.target.value } : formData,
-        ),
-      );
-    };
+ (stepNumber: number, input: string) =>
+ (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
+   props.setFormDataList(
+     props.formDataList.map((formData: PurchaseItem) =>
+       formData.id === stepNumber ? { ...formData, [input]: e.target.value } : formData,
+     ),
+   );
+   if (input === 'item') {
+     setItemName(e.target.value);
+   }
+ };
 
   const addPurchaseItem = async (data: PurchaseItem[]) => {
     const addPurchaseItemUrl = process.env.CSR_API_URI + '/purchaseitems';
@@ -304,6 +308,7 @@ export default function AddModal(props: ModalProps) {
                             activeStep === steps.length ? setIsDone(true) : nextStep();
                           }
                         }}
+                        disabled={itemName.trim() === ''}
                       >
                         <div className={clsx('flex')}>
                           {activeStep === steps.length ? '申請の確認' : '次へ'}

--- a/view/next-project/src/components/purchaseorders/PurchaseOrderAddModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseOrderAddModal.tsx
@@ -54,17 +54,17 @@ export default function AddModal(props: ModalProps) {
 
   const [itemName, setItemName] = useState('');
   const handler =
- (stepNumber: number, input: string) =>
- (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
-   props.setFormDataList(
-     props.formDataList.map((formData: PurchaseItem) =>
-       formData.id === stepNumber ? { ...formData, [input]: e.target.value } : formData,
-     ),
-   );
-   if (input === 'item') {
-     setItemName(e.target.value);
-   }
- };
+    (stepNumber: number, input: string) =>
+    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
+      props.setFormDataList(
+        props.formDataList.map((formData: PurchaseItem) =>
+          formData.id === stepNumber ? { ...formData, [input]: e.target.value } : formData,
+        ),
+      );
+      if (input === 'item') {
+        setItemName(e.target.value);
+      }
+    };
 
   const addPurchaseItem = async (data: PurchaseItem[]) => {
     const addPurchaseItemUrl = process.env.CSR_API_URI + '/purchaseitems';

--- a/view/next-project/src/components/purchaseorders/PurchaseOrderAddModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseOrderAddModal.tsx
@@ -52,7 +52,6 @@ export default function AddModal(props: ModalProps) {
     await del(deletePurchaseOrderUrl);
   };
 
-  const [itemName, setItemName] = useState('');
   const handler =
     (stepNumber: number, input: string) =>
     (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
@@ -61,9 +60,6 @@ export default function AddModal(props: ModalProps) {
           formData.id === stepNumber ? { ...formData, [input]: e.target.value } : formData,
         ),
       );
-      if (input === 'item') {
-        setItemName(e.target.value);
-      }
     };
 
   const addPurchaseItem = async (data: PurchaseItem[]) => {
@@ -308,7 +304,7 @@ export default function AddModal(props: ModalProps) {
                             activeStep === steps.length ? setIsDone(true) : nextStep();
                           }
                         }}
-                        disabled={itemName.trim() === ''}
+                        disabled={props.formDataList[activeStep - 1].item.trim() === ''}
                       >
                         <div className={clsx('flex')}>
                           {activeStep === steps.length ? '申請の確認' : '次へ'}


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #650 

# 概要
<!-- 開発内容の概要を記載 -->
購入物品の登録の際に、物品名を入力せずに申請の確認へ進める仕様を改善。
物品名が未入力の場合には申請の確認ボタンがDisabledになるようにしました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
### **入力前**
![FireShot Capture 137 - 購入申請一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/4f7bd24e-9197-49cf-83ca-a66dc8373ae5)
###  **入力後**
![FireShot Capture 138 - 購入申請一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/6721cac8-d108-4adc-9fa7-25e4792be8c5)

# テスト項目


<!-- テストしてほしい内容を記載 -->

- [ ]  最初に購入物品の登録モーダルを開くと、「申請の確認」ボタンが押せない。
- [ ] 「物品名」のフォームになにかしら入力すると「申請の確認」ボタンが押せる。
