### PR TITLE
募金登録の金額入力フォームにプルダウンを追加する

### DIFF
--- a/view/next-project/src/components/common/Input/Input.tsx
+++ b/view/next-project/src/components/common/Input/Input.tsx
@@ -13,8 +13,8 @@ interface Props {
   type?: string;
   datalist?: {
     key: string;
-    data: { id:number; name: string}[];
-  }
+    data: { id: number; name: string }[];
+  };
 }
 
 function Input(props: Props): JSX.Element {
@@ -36,10 +36,10 @@ function Input(props: Props): JSX.Element {
       </input>
       {props.datalist?.key && props.datalist?.data && (
         <datalist id={props.datalist.key}>
-         {props.datalist.data.map((option) => (
-           <option key={option.id} value={option.name} />
-         ))}
-       </datalist>
+          {props.datalist.data.map((option) => (
+            <option key={option.id} value={option.name} />
+          ))}
+        </datalist>
       )}
     </div>
   );

--- a/view/next-project/src/components/common/Input/Input.tsx
+++ b/view/next-project/src/components/common/Input/Input.tsx
@@ -41,7 +41,6 @@ function Input(props: Props): JSX.Element {
         </datalist>
       )}
     </div>
-
   );
 }
 

--- a/view/next-project/src/components/common/Input/Input.tsx
+++ b/view/next-project/src/components/common/Input/Input.tsx
@@ -11,6 +11,9 @@ interface Props {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   children?: React.ReactNode;
   type?: string;
+  datalist?: { id: number; name: string }[];
+  listKey?: string;
+  enableDatalist?: boolean;
 }
 
 function Input(props: Props): JSX.Element {
@@ -18,16 +21,27 @@ function Input(props: Props): JSX.Element {
     'rounded-full border border-primary-1 py-2 px-4' +
     (props.className ? ` ${props.className}` : '');
   return (
-    <input
-      className={clsx(s.input, className)}
-      placeholder={props.placeholder}
-      id={props.id}
-      value={props.value}
-      onChange={props.onChange}
-      type={props.type}
-    >
-      {props.children}
-    </input>
+    <div>
+      <input
+        className={clsx(s.input, className)}
+        placeholder={props.placeholder}
+        id={props.id}
+        value={props.value}
+        onChange={props.onChange}
+        type={props.type}
+        list={props.enableDatalist ? props.listKey : undefined}
+      >
+        {props.children}
+      </input>
+      {props.enableDatalist && (
+        <datalist id={props.listKey}>
+          {props.datalist?.map((option) => (
+            <option key={option.id} value={option.name} />
+          ))}
+        </datalist>
+      )}
+    </div>
+
   );
 }
 

--- a/view/next-project/src/components/common/Input/Input.tsx
+++ b/view/next-project/src/components/common/Input/Input.tsx
@@ -11,9 +11,10 @@ interface Props {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   children?: React.ReactNode;
   type?: string;
-  datalist?: { id: number; name: string }[];
-  listKey?: string;
-  enableDatalist?: boolean;
+  datalist?: {
+    key: string;
+    data: { id:number; name: string}[];
+  }
 }
 
 function Input(props: Props): JSX.Element {
@@ -29,16 +30,16 @@ function Input(props: Props): JSX.Element {
         value={props.value}
         onChange={props.onChange}
         type={props.type}
-        list={props.enableDatalist ? props.listKey : undefined}
+        list={props.datalist?.key}
       >
         {props.children}
       </input>
-      {props.enableDatalist && (
-        <datalist id={props.listKey}>
-          {props.datalist?.map((option) => (
-            <option key={option.id} value={option.name} />
-          ))}
-        </datalist>
+      {props.datalist?.key && props.datalist?.data && (
+        <datalist id={props.datalist.key}>
+         {props.datalist.data.map((option) => (
+           <option key={option.id} value={option.name} />
+         ))}
+       </datalist>
       )}
     </div>
   );

--- a/view/next-project/src/components/common/Input/Input.tsx
+++ b/view/next-project/src/components/common/Input/Input.tsx
@@ -34,7 +34,7 @@ function Input(props: Props): JSX.Element {
       >
         {props.children}
       </input>
-      {props.datalist?.key && props.datalist?.data && (
+      {props.datalist && (
         <datalist id={props.datalist.key}>
           {props.datalist.data.map((option) => (
             <option key={option.id} value={option.name} />

--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -6,7 +6,7 @@ import { Modal, CloseButton, Input, Select, PrimaryButton } from '../common';
 import { userAtom } from '@/store/atoms';
 import { post } from '@api/fundInformations';
 import { BUREAUS } from '@constants/bureaus';
-import { DONATION_AMOUNT } from "@constants/donationAmount";
+import { DONATION_AMOUNT } from '@constants/donationAmount';
 import { Department, FundInformation, Teacher, User } from '@type/common';
 
 interface ModalProps {
@@ -54,9 +54,9 @@ const OpenAddModal: FC<ModalProps> = (props) => {
 
   const handler =
     (input: string) =>
-      (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
-        setFormData({ ...formData, [input]: e.target.value });
-      };
+    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
+      setFormData({ ...formData, [input]: e.target.value });
+    };
 
   const handleDepartmentID = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setDepartmentID(Number(e.target.value));

--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -6,6 +6,7 @@ import { Modal, CloseButton, Input, Select, PrimaryButton } from '../common';
 import { userAtom } from '@/store/atoms';
 import { post } from '@api/fundInformations';
 import { BUREAUS } from '@constants/bureaus';
+import { DONATION_AMOUNT } from "@constants/donationAmount";
 import { Department, FundInformation, Teacher, User } from '@type/common';
 
 interface ModalProps {
@@ -53,9 +54,9 @@ const OpenAddModal: FC<ModalProps> = (props) => {
 
   const handler =
     (input: string) =>
-    (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
-      setFormData({ ...formData, [input]: e.target.value });
-    };
+      (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
+        setFormData({ ...formData, [input]: e.target.value });
+      };
 
   const handleDepartmentID = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setDepartmentID(Number(e.target.value));
@@ -132,7 +133,14 @@ const OpenAddModal: FC<ModalProps> = (props) => {
         </div>
         <p className='col-span-1 text-black-600'>金額</p>
         <div className='col-span-4 w-full'>
-          <Input className='w-full' value={formData.price} onChange={handler('price')} />
+          <Input
+            className='w-full'
+            value={formData.price}
+            onChange={handler('price')}
+            datalist={DONATION_AMOUNT}
+            listKey='amoutOptions'
+            enableDatalist={true}
+          />
         </div>
         <p className='col-span-1 text-black-600'>備考</p>
         <div className='col-span-4 w-full'>

--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -137,9 +137,10 @@ const OpenAddModal: FC<ModalProps> = (props) => {
             className='w-full'
             value={formData.price}
             onChange={handler('price')}
-            datalist={DONATION_AMOUNT}
-            listKey='amoutOptions'
-            enableDatalist={true}
+            datalist={{
+              key: "amoutOptions",
+              data: DONATION_AMOUNT,
+            }}
           />
         </div>
         <p className='col-span-1 text-black-600'>備考</p>

--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -138,7 +138,7 @@ const OpenAddModal: FC<ModalProps> = (props) => {
             value={formData.price}
             onChange={handler('price')}
             datalist={{
-              key: "amoutOptions",
+              key: 'amoutOptions',
               data: DONATION_AMOUNT,
             }}
           />

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -146,7 +146,7 @@ export default function EditModal(props: ModalProps) {
             value={formData.price}
             onChange={handler('price')}
             datalist={{
-              key: "amoutOptions",
+              key: 'amoutOptions',
               data: DONATION_AMOUNT,
             }}
           />

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -4,7 +4,7 @@ import { Dispatch, SetStateAction, useEffect, useState, useMemo } from 'react';
 import { Modal, Input, Select, CloseButton, PrimaryButton } from '../common';
 import { put } from '@api/fundInformations';
 import { BUREAUS } from '@constants/bureaus';
-import { DONATION_AMOUNT } from "@constants/donationAmount";
+import { DONATION_AMOUNT } from '@constants/donationAmount';
 import { FundInformation, Teacher, User, Department } from '@type/common';
 
 interface ModalProps {
@@ -40,14 +40,14 @@ export default function EditModal(props: ModalProps) {
 
   const handler =
     (input: string) =>
-      (
-        e:
-          | React.ChangeEvent<HTMLInputElement>
-          | React.ChangeEvent<HTMLTextAreaElement>
-          | React.ChangeEvent<HTMLSelectElement>,
-      ) => {
-        setFormData({ ...formData, [input]: e.target.value });
-      };
+    (
+      e:
+        | React.ChangeEvent<HTMLInputElement>
+        | React.ChangeEvent<HTMLTextAreaElement>
+        | React.ChangeEvent<HTMLSelectElement>,
+    ) => {
+      setFormData({ ...formData, [input]: e.target.value });
+    };
 
   const submitFundInformation = async (data: FundInformation) => {
     const submitFundInformationURL = process.env.CSR_API_URI + '/fund_informations/' + data.id;

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -145,9 +145,10 @@ export default function EditModal(props: ModalProps) {
             className='w-full'
             value={formData.price}
             onChange={handler('price')}
-            datalist={DONATION_AMOUNT}
-            listKey='amoutOptions'
-            enableDatalist={true}
+            datalist={{
+              key: "amoutOptions",
+              data: DONATION_AMOUNT,
+            }}
           />
         </div>
         <p className='col-span-1 text-black-600'>備考</p>

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -4,6 +4,7 @@ import { Dispatch, SetStateAction, useEffect, useState, useMemo } from 'react';
 import { Modal, Input, Select, CloseButton, PrimaryButton } from '../common';
 import { put } from '@api/fundInformations';
 import { BUREAUS } from '@constants/bureaus';
+import { DONATION_AMOUNT } from "@constants/donationAmount";
 import { FundInformation, Teacher, User, Department } from '@type/common';
 
 interface ModalProps {
@@ -39,14 +40,14 @@ export default function EditModal(props: ModalProps) {
 
   const handler =
     (input: string) =>
-    (
-      e:
-        | React.ChangeEvent<HTMLInputElement>
-        | React.ChangeEvent<HTMLTextAreaElement>
-        | React.ChangeEvent<HTMLSelectElement>,
-    ) => {
-      setFormData({ ...formData, [input]: e.target.value });
-    };
+      (
+        e:
+          | React.ChangeEvent<HTMLInputElement>
+          | React.ChangeEvent<HTMLTextAreaElement>
+          | React.ChangeEvent<HTMLSelectElement>,
+      ) => {
+        setFormData({ ...formData, [input]: e.target.value });
+      };
 
   const submitFundInformation = async (data: FundInformation) => {
     const submitFundInformationURL = process.env.CSR_API_URI + '/fund_informations/' + data.id;
@@ -140,7 +141,14 @@ export default function EditModal(props: ModalProps) {
         </div>
         <p className='col-span-1 text-black-600'>金額</p>
         <div className='col-span-4 w-full'>
-          <Input className='w-full' value={formData.price} onChange={handler('price')} />
+          <Input
+            className='w-full'
+            value={formData.price}
+            onChange={handler('price')}
+            datalist={DONATION_AMOUNT}
+            listKey='amoutOptions'
+            enableDatalist={true}
+          />
         </div>
         <p className='col-span-1 text-black-600'>備考</p>
         <div className='col-span-4 w-full'>

--- a/view/next-project/src/constants/donationAmount.ts
+++ b/view/next-project/src/constants/donationAmount.ts
@@ -1,0 +1,18 @@
+export const DONATION_AMOUNT = [
+  {
+    id: 1,
+    name: '1000'
+  },
+  {
+    id: 2,
+    name: '2000'
+  },
+  {
+    id: 3,
+    name: '5000'
+  },
+  {
+    id: 4,
+    name: '10000'
+  },
+];

--- a/view/next-project/src/constants/donationAmount.ts
+++ b/view/next-project/src/constants/donationAmount.ts
@@ -1,18 +1,18 @@
 export const DONATION_AMOUNT = [
   {
     id: 1,
-    name: '1000'
+    name: '1000',
   },
   {
     id: 2,
-    name: '2000'
+    name: '2000',
   },
   {
     id: 3,
-    name: '5000'
+    name: '5000',
   },
   {
     id: 4,
-    name: '10000'
+    name: '10000',
   },
 ];


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #649 

# 概要
<!-- 開発内容の概要を記載 -->
募金登録の際に金額の入力フォームにプルダウン(選択肢)を追加する。
datalist要素を利用して実装する。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![スクリーンショット 2023-11-17 222713](https://github.com/NUTFes/FinanSu/assets/131145590/f89d90d0-65db-4cee-abc6-9b959f8a509e)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 学内募金の学内募金登録モーダルを開き、「金額」の入力フォームをクリックすると金額の候補が表示される。
- 登録した項目の編集モーダルを開き、「金額」の入力フォームをクリックすると金額の候補が表示される。


# 備考
https://developer.mozilla.org/ja/docs/Web/HTML/Element/datalist
