### PR TITLE
[feat]購入報告の年度取得api作成

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1363,6 +1363,26 @@ const docTemplate = `{
                 }
             },
         },
+        "/purchasereports/details/{year}": {
+            "get": {
+                tags: ["purchase_report"],
+                "description": "年度で指定されたpurchase_reportsに紐づくデータを取得",
+                "parameters": [
+                    {
+                        "name": "year",
+                        "in": "path",
+                        "description": "year",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "年度で指定されたpurchase_reportsに紐づくデータを取得",
+                    }
+                }
+            },
+        },
         "/sources": {
             "get": {
                 tags: ["source"],

--- a/api/externals/controller/purchase_report_controller.go
+++ b/api/externals/controller/purchase_report_controller.go
@@ -21,6 +21,7 @@ type PurchaseReportController interface {
 	DestroyPurchaseReport(echo.Context) error
 	IndexPurchaseReportDetails(echo.Context) error
 	ShowPurchaseReportDetail(echo.Context) error
+	IndexPurchaseReportDetailsByYear(echo.Context) error
 }
 
 func NewPurchaseReportController(u usecase.PurchaseReportUseCase) PurchaseReportController {
@@ -98,4 +99,13 @@ func (p *purchaseReportController) ShowPurchaseReportDetail(c echo.Context) erro
 		return err
 	}
 	return c.JSON(http.StatusOK, purchaseReportDetail)
+}
+
+func (p *purchaseReportController) IndexPurchaseReportDetailsByYear(c echo.Context) error {
+	year := c.Param("year")
+	purchaseReportDetails, err := p.u.GetPurchaseReportDetailsByYear(c.Request().Context(), year)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, purchaseReportDetails)
 }

--- a/api/externals/repository/purchase_report_repository.go
+++ b/api/externals/repository/purchase_report_repository.go
@@ -166,35 +166,10 @@ func (ppr *purchaseReportRepository) FindNewRecord(c context.Context) (*sql.Row,
 func (ppr *purchaseReportRepository) AllDetailsForPeriods(c context.Context, year string) (*sql.Rows, error) {
 	query := `
 		SELECT
-			purchase_reports.id,
-			purchase_reports.user_id,
-			purchase_reports.discount,
-			purchase_reports.addition,
-			purchase_reports.finance_check,
-			purchase_reports.purchase_order_id,
-			purchase_reports.remark,
-			purchase_reports.buyer,
-			purchase_reports.created_at,
-			purchase_reports.updated_at,
-			report_user.id,
-			report_user.name,
-			report_user.bureau_id,
-			report_user.role_id,
-			report_user.created_at,
-			report_user.updated_at,
-			purchase_orders.id,
-			purchase_orders.deadline,
-			purchase_orders.user_id,
-			purchase_orders.expense_id,
-			purchase_orders.finance_check,
-			purchase_orders.created_at,
-			purchase_orders.updated_at,
-			order_user.id,
-			order_user.name,
-			order_user.bureau_id,
-			order_user.role_id,
-			order_user.created_at,
-			order_user.updated_at
+			purchase_reports.*,
+			report_user.*,
+			purchase_orders.*,
+			order_user.*
 		FROM
 			purchase_reports
 		INNER JOIN

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -169,6 +169,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.DELETE("/purchasereports/:id", r.purchaseReportController.DestroyPurchaseReport)
 	e.GET("/purchasereports/details", r.purchaseReportController.IndexPurchaseReportDetails)
 	e.GET("/purchasereports/:id/details", r.purchaseReportController.ShowPurchaseReportDetail)
+	e.GET("/purchasereports/details/:year", r.purchaseReportController.IndexPurchaseReportDetailsByYear)
 
 	// sources
 	e.GET("/sources", r.sourceController.IndexSource)


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #664

# 概要
<!-- 開発内容の概要を記載 -->
- 購入報告のapiを作成
- `/purchasereports/details/:year`
- swaggerにapiの追加

# テスト項目
- swaggerにアクセスする `http://localhost:1323/swagger/index.html#/`
- swaggerでpurchase_reportsの`/purchasereports/details/:year`を実行する。
- 指定した年度範囲のレコードが取得できるか

# 備考