### PR TITLE
[feat] 年度別のfund_informationsを取得するAPIの作成

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -870,6 +870,26 @@ const docTemplate = `{
                 }
             },
         },
+				"/fund_informations/details/{year}": {
+						"get": {
+								tags: ["fund_information"],
+								"description": "年度で指定されたfund_informationsに紐づくデータを取得",
+								"parameters": [
+										{
+												"name": "year",
+												"in": "path",
+												"description": "year",
+												"required": true,
+												"type": "integer"
+										}
+								],
+								"responses": {
+										"200": {
+												"description": "年度で指定されたfund_informationsに紐づくデータを取得",
+										}
+								}
+						},
+			},
         "/purchaseitems": {
             "get": {
                 tags: ["purchase_item"],

--- a/api/externals/controller/fund_information_controller.go
+++ b/api/externals/controller/fund_information_controller.go
@@ -19,6 +19,7 @@ type FundInformationController interface {
 	DestroyFundInformation(echo.Context) error
 	IndexFundInformationDetails(echo.Context) error
 	ShowFundInformationDetailByID(echo.Context) error
+	IndexFundInformationDetailsByYear(echo.Context) error
 }
 
 func NewFundInformationController(u usecase.FundInformationUseCase) FundInformationController {
@@ -105,4 +106,14 @@ func (f *fundInformationController) ShowFundInformationDetailByID(c echo.Context
 		return err
 	}
 	return c.JSON(http.StatusOK, fundinforuserandteacher)
+}
+
+// IndexFundInformationDetailsByYear
+func (f *fundInformationController) IndexFundInformationDetailsByYear(c echo.Context) error {
+	year := c.Param("year")
+	fundInformationDetailsByYear, err := f.u.GetFundInformationDetailsByYear(c.Request().Context(), year)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, fundInformationDetailsByYear)
 }

--- a/api/externals/controller/fund_information_controller.go
+++ b/api/externals/controller/fund_information_controller.go
@@ -19,7 +19,7 @@ type FundInformationController interface {
 	DestroyFundInformation(echo.Context) error
 	IndexFundInformationDetails(echo.Context) error
 	ShowFundInformationDetailByID(echo.Context) error
-	IndexFundInformationDetailsByYear(echo.Context) error
+	IndexFundInformationDetailsByPeriod(echo.Context) error
 }
 
 func NewFundInformationController(u usecase.FundInformationUseCase) FundInformationController {
@@ -108,12 +108,12 @@ func (f *fundInformationController) ShowFundInformationDetailByID(c echo.Context
 	return c.JSON(http.StatusOK, fundinforuserandteacher)
 }
 
-// IndexFundInformationDetailsByYear
-func (f *fundInformationController) IndexFundInformationDetailsByYear(c echo.Context) error {
+// IndexFundInformationDetailsByPeriod
+func (f *fundInformationController) IndexFundInformationDetailsByPeriod(c echo.Context) error {
 	year := c.Param("year")
-	fundInformationDetailsByYear, err := f.u.GetFundInformationDetailsByYear(c.Request().Context(), year)
+	fundInformationDetailsByPeriod, err := f.u.GetFundInformationDetailsByPeriod(c.Request().Context(), year)
 	if err != nil {
 		return err
 	}
-	return c.JSON(http.StatusOK, fundInformationDetailsByYear)
+	return c.JSON(http.StatusOK, fundInformationDetailsByPeriod)
 }

--- a/api/externals/repository/fund_information_repository.go
+++ b/api/externals/repository/fund_information_repository.go
@@ -22,7 +22,7 @@ type FundInformationRepository interface {
 	FindDetails(context.Context) (*sql.Rows, error)
 	FindDetailByID(context.Context, string) (*sql.Row, error)
 	FindLatestRecord(context.Context) (*sql.Row, error)
-	AllDetailsForPeriods(context.Context, string) (*sql.Rows, error)
+	AllDetailsByPeriod(context.Context, string) (*sql.Rows, error)
 }
 
 func NewFundInformationRepository(c db.Client, ac abstract.Crud) FundInformationRepository {
@@ -165,7 +165,7 @@ func (fir *fundInformationRepository) FindLatestRecord(c context.Context) (*sql.
 }
 
 // 年度別のfund_informationに紐づくuserとteacherを取得する
-func (fir *fundInformationRepository) AllDetailsForPeriods(c context.Context, year string) (*sql.Rows, error) {
+func (fir *fundInformationRepository) AllDetailsByPeriod(c context.Context, year string) (*sql.Rows, error) {
 	query := `
 		SELECT
 			fund_informations.*,

--- a/api/internals/usecase/fund_information_usecase.go
+++ b/api/internals/usecase/fund_information_usecase.go
@@ -19,7 +19,7 @@ type FundInformationUseCase interface {
 	DestroyFundInformation(context.Context, string) error
 	GetFundInformationDetails(context.Context) ([]domain.FundInformationDetail, error)
 	GetFundInformationDetailByID(context.Context, string) (domain.FundInformationDetail, error)
-	GetFundInformationDetailsByYear(context.Context, string) ([]domain.FundInformationDetail, error)
+	GetFundInformationDetailsByPeriod(context.Context, string) ([]domain.FundInformationDetail, error)
 }
 
 func NewFundInformationUseCase(rep rep.FundInformationRepository) FundInformationUseCase {
@@ -244,16 +244,16 @@ func (f *fundInformationUseCase) GetFundInformationDetailByID(c context.Context,
 }
 
 //fund_informations_byyear-api(GETS)
-func (f *fundInformationUseCase) GetFundInformationDetailsByYear(c context.Context, year string) ([]domain.FundInformationDetail, error) {
+func (f *fundInformationUseCase) GetFundInformationDetailsByPeriod(c context.Context, year string) ([]domain.FundInformationDetail, error) {
 	fundInformationDetail:= domain.FundInformationDetail{}
 	var fundInformationDetails []domain.FundInformationDetail
 
-	rows, err := f.rep.AllDetailsForPeriods(c, year)
+	rows, err := f.rep.AllDetailsByPeriod(c, year)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	
+
 	for rows.Next() {
 		err := rows.Scan(
 		&fundInformationDetail.FundInformation.ID,

--- a/api/internals/usecase/fund_information_usecase.go
+++ b/api/internals/usecase/fund_information_usecase.go
@@ -19,6 +19,7 @@ type FundInformationUseCase interface {
 	DestroyFundInformation(context.Context, string) error
 	GetFundInformationDetails(context.Context) ([]domain.FundInformationDetail, error)
 	GetFundInformationDetailByID(context.Context, string) (domain.FundInformationDetail, error)
+	GetFundInformationDetailsByYear(context.Context, string) ([]domain.FundInformationDetail, error)
 }
 
 func NewFundInformationUseCase(rep rep.FundInformationRepository) FundInformationUseCase {
@@ -194,6 +195,7 @@ func (f *fundInformationUseCase) GetFundInformationDetails(c context.Context) ([
 			return nil, err
 		}
 		fundInformationDetails = append(fundInformationDetails, fundInformationDetail)
+
 	}
 	return fundInformationDetails, nil
 }
@@ -239,4 +241,55 @@ func (f *fundInformationUseCase) GetFundInformationDetailByID(c context.Context,
 		return fundInformationDetail, err
 	}
 	return fundInformationDetail, nil
+}
+
+//fund_informations_byyear-api(GETS)
+func (f *fundInformationUseCase) GetFundInformationDetailsByYear(c context.Context, year string) ([]domain.FundInformationDetail, error) {
+	fundInformationDetail:= domain.FundInformationDetail{}
+	var fundInformationDetails []domain.FundInformationDetail
+
+	rows, err := f.rep.AllDetailsForPeriods(c, year)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	
+	for rows.Next() {
+		err := rows.Scan(
+		&fundInformationDetail.FundInformation.ID,
+		&fundInformationDetail.FundInformation.UserID,
+		&fundInformationDetail.FundInformation.TeacherID,
+		&fundInformationDetail.FundInformation.Price,
+		&fundInformationDetail.FundInformation.Remark,
+		&fundInformationDetail.FundInformation.IsFirstCheck,
+		&fundInformationDetail.FundInformation.IsLastCheck,
+		&fundInformationDetail.FundInformation.ReceivedAt,
+		&fundInformationDetail.FundInformation.CreatedAt,
+		&fundInformationDetail.FundInformation.UpdatedAt,
+		&fundInformationDetail.User.ID,
+		&fundInformationDetail.User.Name,
+		&fundInformationDetail.User.BureauID,
+		&fundInformationDetail.User.RoleID,
+		&fundInformationDetail.User.CreatedAt,
+		&fundInformationDetail.User.UpdatedAt,
+		&fundInformationDetail.Teacher.ID,
+		&fundInformationDetail.Teacher.Name,
+		&fundInformationDetail.Teacher.Position,
+		&fundInformationDetail.Teacher.DepartmentID,
+		&fundInformationDetail.Teacher.Room,
+		&fundInformationDetail.Teacher.IsBlack,
+		&fundInformationDetail.Teacher.Remark,
+		&fundInformationDetail.Teacher.CreatedAt,
+		&fundInformationDetail.Teacher.UpdatedAt,
+		&fundInformationDetail.Department.ID,
+		&fundInformationDetail.Department.Name,
+		&fundInformationDetail.Department.CreatedAt,
+		&fundInformationDetail.Department.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		fundInformationDetails = append(fundInformationDetails, fundInformationDetail)
+	}
+	return fundInformationDetails, nil
 }

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -135,6 +135,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.DELETE("/fund_informations/:id", r.fundInformationController.DestroyFundInformation)
 	e.GET("/fund_informations/details", r.fundInformationController.IndexFundInformationDetails)
 	e.GET("/fund_informations/:id/details", r.fundInformationController.ShowFundInformationDetailByID)
+	e.GET("/fund_informations/details/:year", r.fundInformationController.IndexFundInformationDetailsByYear)
 
 	// mail auth
 	e.POST("/mail_auth/signup", r.mailAuthController.SignUp)

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -135,7 +135,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.DELETE("/fund_informations/:id", r.fundInformationController.DestroyFundInformation)
 	e.GET("/fund_informations/details", r.fundInformationController.IndexFundInformationDetails)
 	e.GET("/fund_informations/:id/details", r.fundInformationController.ShowFundInformationDetailByID)
-	e.GET("/fund_informations/details/:year", r.fundInformationController.IndexFundInformationDetailsByYear)
+	e.GET("/fund_informations/details/:year", r.fundInformationController.IndexFundInformationDetailsByPeriod)
 
 	// mail auth
 	e.POST("/mail_auth/signup", r.mailAuthController.SignUp)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #668

# 概要
<!-- 開発内容の概要を記載 -->
年度別でfund_informations/detailsを取得するAPIを作成しました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="960" alt="image" src="https://github.com/NUTFes/FinanSu/assets/106811268/c15b9e28-fbcd-4354-b607-045945ed639c">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- upした後に[swagger](localhost:1323/swagger/index.html#/)にアクセスしてfundinformations/details/[year]を探す
- あったらtry itからyearに2024を指定して実行しスクショのように結果が返ってくるか確認する

- 2023に関しては紐づくデータがないためnullが返ってくる。
- 確認したい場合はyear_periodsの2023の終了日を変更するか、2023に新しいデータを追加してください

# 備考
ByYearだったり、ForPeriodsだったりで統一感ないですがどちらかがいいでしょうか。