### PR TITLE
[支出]年度別取得APIの作成

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -671,6 +671,26 @@ const docTemplate = `{
                 }
             },
         },
+        "/expenses/details/{year}": {
+            "get": {
+                tags: ["expense"],
+                "description": "年度で指定されたexpenseに紐づく購入申請と購入報告を取得",
+                "parameters": [
+                    {
+                        "name": "year",
+                        "in": "path",
+                        "description": "year",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "yearで指定されたexpenseに紐づく購入申請と購入報告を取得",
+                    }
+                }
+            },
+        },
         "/fund_informations": {
             "get": {
                 tags: ["fund_information"],

--- a/api/externals/controller/expense_controller.go
+++ b/api/externals/controller/expense_controller.go
@@ -20,6 +20,7 @@ type ExpenseController interface {
 	UpdateExpenseTP(echo.Context) error
 	IndexExpenseDetails(echo.Context) error
 	ShowExpenseDetail(echo.Context) error
+	IndexExpenseDetailsByPeriod(echo.Context) error
 }
 
 func NewExpenseController(u usecase.ExpenseUseCase) ExpenseController {
@@ -104,4 +105,17 @@ func (e *expenseController) ShowExpenseDetail(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, expenseDetail)
+}
+
+func (e *expenseController) IndexExpenseDetailsByPeriod(c echo.Context) error {
+	year := c.Param("year")
+	err := e.u.UpdateExpenseTP(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	expenseDetails, err := e.u.GetExpenseDetailsByPeriod(c.Request().Context(), year)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, expenseDetails)
 }

--- a/api/externals/repository/expense_repository.go
+++ b/api/externals/repository/expense_repository.go
@@ -23,6 +23,7 @@ type ExpenseRepository interface {
 	FindLatestRecord(context.Context) (*sql.Row, error)
 	AllItemInfo(context.Context, string) (*sql.Rows, error)
 	AllOrderAndReportInfo(context.Context, string) (*sql.Rows, error)
+	AllByPeriod(context.Context, string) (*sql.Rows, error)
 }
 
 func NewExpenseRepository(c db.Client, ac abstract.Crud) ExpenseRepository {
@@ -105,5 +106,21 @@ func (er *expenseRepository) AllOrderAndReportInfo(c context.Context, expenseID 
 		AND
 			po.finance_check IS true
 		`
+	return er.crud.Read(c, query)
+}
+
+func (er *expenseRepository) AllByPeriod(c context.Context, year string) (*sql.Rows, error) {
+	query := `
+			SELECT
+				*
+			FROM
+				expense
+			INNER JOIN
+				years
+			ON
+				expense.yearID = years.id
+			WHERE
+				years.year = ` + year +
+			" ORDER BY expense.id;"
 	return er.crud.Read(c, query)
 }

--- a/api/internals/domain/expense.go
+++ b/api/internals/domain/expense.go
@@ -23,3 +23,9 @@ type PurchaseDetail struct {
 	PurchaseReport PurchaseReport `json:"purchaseReport"`
 	PurchaseItems  []PurchaseItem `json:"purchaseItems"`
 }
+
+type ExpenseDetailsByperiod struct {
+	Expense         Expense          `json:"expense"`
+	Year			Year			 `json:"year"`
+	PurchaseDetails []PurchaseDetail `json:"purchaseDetails"`
+}

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -121,6 +121,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.GET("/expenses", r.expenseController.IndexExpense)
 	e.GET("/expenses/updateTP", r.expenseController.UpdateExpenseTP)
 	e.GET("/expenses/details", r.expenseController.IndexExpenseDetails)
+	e.GET("/expenses/details/:year", r.expenseController.IndexExpenseDetailsByPeriod)
 	e.GET("/expenses/:id", r.expenseController.ShowExpense)
 	e.GET("/expenses/:id/details", r.expenseController.ShowExpenseDetail)
 	e.POST("/expenses", r.expenseController.CreateExpense)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #671 

# 概要
<!-- 開発内容の概要を記載 -->
- 支出の年度ごとに取得するAPIを作成しました。
- 年度のidを持っていたため他のページと年度の取得を期間ではなくyear_idにより取得するようにしました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1036" alt="スクリーンショット 2024-01-28 18 27 38" src="https://github.com/NUTFes/FinanSu/assets/115447919/85961759-d7d2-4d54-810f-a2126262e8ff">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- `docker compose up`した後にswaggerにアクセスして`expense/details/{year}`を探す
- あったらtry itからyearに2024を指定して年度ごとに取得できるか確認する
- 2023に関しては紐づくデータがないためnullが返ってくる。
- 確認したい場合はyear_periodsの2023の終了日を変更するか、2023に新しいデータを追加してください

# 備考
