### PR TITLE
[feat] 年度別に協賛活動を取得するAPIの作成

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -56,6 +56,26 @@ const docTemplate = `{
                 }
             },
         },
+				"/activities/details/{year}": {
+						"get": {
+								tags: ["activity"],
+								"description": "年度で指定されたactivitiesとsponsor,sponsorStyle,userの一覧を取得",
+								"parameters": [
+										{
+												"name": "year",
+												"in": "path",
+												"description": "year",
+												"required": true,
+												"type": "integer"
+										}
+								],
+								"responses": {
+										"200": {
+												"description": "年度で指定されたactivitiesとsponsor,sponsorStyle,userの一覧を取得",
+										}
+								}
+						},
+				},
         "/activities/{id}": {
             "get": {
                 tags: ["activity"],

--- a/api/externals/controller/activity_controller.go
+++ b/api/externals/controller/activity_controller.go
@@ -21,6 +21,7 @@ type ActivityController interface {
 	UpdateActivity(echo.Context) error
 	DestroyActivity(echo.Context) error
 	IndexActivityDetail(echo.Context) error
+	IndexActivityDetailsByPeriod(echo.Context) error
 }
 
 func NewActivityController(u usecase.ActivityUseCase) ActivityController {
@@ -88,6 +89,16 @@ func (a *activityController) DestroyActivity(c echo.Context) error {
 // For admin view
 func (a *activityController) IndexActivityDetail(c echo.Context) error {
 	activities, err := a.u.GetActivityDetail(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, activities)
+}
+
+// 年度で指定されたactivitiesとsponsor,sponsorStyle,userの一覧を取得
+func (a *activityController) IndexActivityDetailsByPeriod(c echo.Context) error {
+	year := c.Param("year")
+	activities, err := a.u.GetActivityDetailsByPeriod(c.Request().Context(), year)
 	if err != nil {
 		return err
 	}

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -83,6 +83,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.PUT("/activities/:id", r.activityController.UpdateActivity)
 	e.DELETE("/activities/:id", r.activityController.DestroyActivity)
 	e.GET("/activities/details", r.activityController.IndexActivityDetail)
+	e.GET("/activities/details/:year",r.activityController.IndexActivityDetailsByPeriod)
 
 	// activityStyleのRoute
 	e.GET("/activity_styles", r.activityStyleController.IndexActivityStyle)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #673 

# 概要
<!-- 開発内容の概要を記載 -->
協賛活動の年度別に取得するAPIを作成しました
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
<img width="960" alt="image" src="https://github.com/NUTFes/FinanSu/assets/106811268/2a186611-b662-4b70-b7a6-7c5613abe534">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- `docker compose up`でswaggerを開き**/activities/details/{year}**を探す
- yearを指定して実行し結果が返ってくるか確認してください
- 2023にはデータがなくnullが返ってきます。

# 備考
