### PR TITLE
[feat] 年度で指定されたsponsorsを取得する

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1627,6 +1627,26 @@ const docTemplate = `{
                 },
             },
         },
+				"/sponsors/{year}": {
+					"get": {
+							tags: ["sponsor"],
+							"description": "年度で指定されたsponsorを取得",
+							"parameters": [
+									{
+											"name": "year",
+											"in": "path",
+											"description": "year",
+											"required": true,
+											"type": "integer"
+									}
+							],
+							"responses": {
+									"200": {
+											"description": "sponsorの取得完了",
+									}
+							}
+					},
+			},
         "/sponsorstyles": {
             "get": {
                 tags: ["sponsorstyle"],

--- a/api/externals/controller/sponsor_controller.go
+++ b/api/externals/controller/sponsor_controller.go
@@ -19,6 +19,7 @@ type SponsorController interface {
 	CreateSponsor(echo.Context) error
 	UpdateSponsor(echo.Context) error
 	DestroySponsor(echo.Context) error
+	IndexSponsorByPeriod(echo.Context) error
 }
 
 func NewSponsorController(u usecase.SponsorUseCase) SponsorController {
@@ -89,4 +90,14 @@ func (s *sponsorController) DestroySponsor(c echo.Context) error {
 		return err
 	}
 	return c.String(http.StatusOK, "Destroy Sponsor")
+}
+
+//年度別に取得
+func (s *sponsorController) IndexSponsorByPeriod(c echo.Context) error {
+	year := c.Param("year")
+	sponsors, err := s.u.GetSponsorByPeriod(c.Request().Context(), year)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, sponsors)
 }

--- a/api/externals/repository/sponsor_repository.go
+++ b/api/externals/repository/sponsor_repository.go
@@ -20,6 +20,7 @@ type SponsorRepository interface {
 	Update(context.Context, string, string, string, string, string, string) error
 	Delete(context.Context, string) error
 	FindLatestRecord(context.Context) (*sql.Row, error)
+	AllByPeriod(context.Context, string) (*sql.Rows, error)
 }
 
 func NewSponsorRepository(c db.Client, ac abstract.Crud) SponsorRepository {
@@ -91,4 +92,27 @@ func (sr *sponsorRepository) Delete(
 func (sr *sponsorRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
 	query := `SELECT * FROM sponsors ORDER BY id DESC LIMIT 1`
 	return sr.crud.ReadByID(c, query)
+}
+
+// 年度別に取得
+func (sr *sponsorRepository) AllByPeriod(c context.Context, year string) (*sql.Rows, error) {
+	query := `
+	SELECT
+		sponsors.*
+	FROM
+		sponsors
+	INNER JOIN
+		year_periods
+	ON
+		sponsors.created_at > year_periods.started_at
+	AND
+		sponsors.created_at < year_periods.ended_at
+	INNER JOIN
+		years
+	ON
+		year_periods.year_id = years.id
+	WHERE
+		years.year = ` + year +
+		" ORDER BY sponsors.id;"
+	return sr.crud.Read(c, query)
 }

--- a/api/internals/usecase/sponsor_usecase.go
+++ b/api/internals/usecase/sponsor_usecase.go
@@ -17,6 +17,7 @@ type SponsorUseCase interface {
 	CreateSponsor(context.Context, string, string, string, string, string) (domain.Sponsor, error)
 	UpdateSponsor(context.Context, string, string, string, string, string, string) (domain.Sponsor, error)
 	DestroySponsor(context.Context, string) error
+	GetSponsorByPeriod(context.Context, string) ([]domain.Sponsor, error)
 }
 
 func NewSponsorUseCase(rep rep.SponsorRepository) SponsorUseCase {
@@ -131,4 +132,31 @@ func (s *sponsorUseCase) DestroySponsor(
 ) error {
 	err := s.rep.Delete(c, id)
 	return err
+}
+
+// 年度別のsponsorsの取得(GetByPeriod)
+func (s *sponsorUseCase) GetSponsorByPeriod(c context.Context, year string) ([]domain.Sponsor, error) {
+	sponsor := domain.Sponsor{}
+	var sponsors []domain.Sponsor
+	rows, err := s.rep.AllByPeriod(c, year)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		err := rows.Scan(
+			&sponsor.ID,
+			&sponsor.Name,
+			&sponsor.Tel,
+			&sponsor.Email,
+			&sponsor.Address,
+			&sponsor.Representative,
+			&sponsor.CreatedAt,
+			&sponsor.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		sponsors = append(sponsors, sponsor)
+	}
+	return sponsors, nil
 }

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -187,6 +187,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.POST("/sponsors", r.sponsorController.CreateSponsor)
 	e.PUT("/sponsors/:id", r.sponsorController.UpdateSponsor)
 	e.DELETE("/sponsors/:id", r.sponsorController.DestroySponsor)
+	e.GET("/sponsors/:year", r.sponsorController.IndexSponsorByPeriod)
 
 	// sponsorstylesのRoute
 	e.GET("/sponsorstyles", r.sponsorStyleController.IndexSponsorStyle)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #675

# 概要
<!-- 開発内容の概要を記載 -->
年度別に指定したsponsorを全権取得するAPIを作成しました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/NUTFes/FinanSu/assets/106811268/07e8b2a9-a1d2-47ee-8ebe-3c4374b853a1)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- swaggerを開き、sponsors/{year}を見つけてください
- 年度を指定して実行でデータを取得できたら成功です。
- 2024にのみデータが存在しています。他の年度でも動作するか確認したいときはlocalhost:3000/yearperiodsで年度を変更して確認してください

# 備考
余談ですがsponsorのスペル間違ったまま作業してブランチ名をsponserにしてしまいました。誤解なきようお願いします。