### PR TITLE
[feat]予算支出ページの年度切り替え実装

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -283,6 +283,26 @@ const docTemplate = `{
                 }
             },
         },
+        "/budgets/details/{year}": {
+            "get": {
+                tags: ["budget"],
+                "description": "年度で指定されたbudgetsに紐づく年度とソースを取得",
+                "parameters": [
+                    {
+                        "name": "year",
+                        "in": "path",
+                        "description": "year",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "年度で指定されたbudgetsに紐づく年度とソースを取得",
+                    }
+                }
+            },
+        },
         "/budgets/{id}": {
             "get": {
                 tags: ["budget"],

--- a/api/externals/controller/budget_controller.go
+++ b/api/externals/controller/budget_controller.go
@@ -19,6 +19,7 @@ type BudgetController interface {
 	DestroyBudget(echo.Context) error
 	ShowBudgetDetailById(echo.Context) error
 	ShowBudgetDetails(echo.Context) error
+	ShowBudgetDetailsByPeriods(echo.Context) error
 }
 
 func NewBudgetController(u usecase.BudgetUseCase) BudgetController {
@@ -92,6 +93,16 @@ func (b *budgetController) ShowBudgetDetailById(c echo.Context) error {
 // Budgetに紐づくyearとsourceの全件取得
 func (b *budgetController) ShowBudgetDetails(c echo.Context) error {
 	budgetDetails, err := b.u.GetBudgetDetails(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, budgetDetails)
+}
+
+// 年度ごとにBudgetと紐づくデータ全件取得
+func (b *budgetController) ShowBudgetDetailsByPeriods(c echo.Context) error {
+	year := c.Param("year")
+	budgetDetails, err := b.u.GetBudgetDetailsByPeriod(c.Request().Context(), year)
 	if err != nil {
 		return err
 	}

--- a/api/externals/repository/budget_repository.go
+++ b/api/externals/repository/budget_repository.go
@@ -22,6 +22,7 @@ type BudgetRepository interface {
 	FindDetailByID(context.Context, string) (*sql.Row, error)
 	FindLatestRecord(context.Context) (*sql.Row, error)
 	FindDetail(context.Context) (*sql.Rows, error)
+	FindDetailsByPeriod(context.Context, string) (*sql.Rows, error)
 }
 
 func NewBudgetRepository(c db.Client, ac abstract.Crud) BudgetRepository {
@@ -127,4 +128,26 @@ func (br *budgetRepository) FindLatestRecord(c context.Context) (*sql.Row, error
 		DESC LIMIT 1
 	`
 	return br.crud.ReadByID(c, query)
+}
+
+// yearで切り替えるBudgetに紐づくyearとsourceを全件取得する
+func (br *budgetRepository) FindDetailsByPeriod(c context.Context, year string) (*sql.Rows, error) {
+	query := `
+		SELECT
+			*
+		FROM
+			budgets
+		INNER JOIN
+			years
+		ON
+			budgets.year_id = years.id
+		INNER JOIN
+			sources
+		ON
+			budgets.source_id = sources.id
+		WHERE
+			years.year = ` + year +
+		" ORDER BY budgets.id;"
+
+	return br.crud.Read(c, query)
 }

--- a/api/internals/usecase/budget_usecase.go
+++ b/api/internals/usecase/budget_usecase.go
@@ -20,6 +20,7 @@ type BudgetUseCase interface {
 	DestroyBudget(context.Context, string) error
 	GetBudgetDetailByID(context.Context, string) (domain.BudgetDetail, error)
 	GetBudgetDetails(c context.Context) ([]domain.BudgetDetail, error)
+	GetBudgetDetailsByPeriod(context.Context, string) ([]domain.BudgetDetail, error)
 }
 
 func NewBudgetUseCase(rep rep.BudgetRepository) BudgetUseCase {
@@ -150,6 +151,42 @@ func (b *budgetUseCase) GetBudgetDetails(c context.Context) ([]domain.BudgetDeta
 		return nil, err
 	}
 	// defer rows.Close()
+
+	for rows.Next() {
+		err := rows.Scan(
+			&budgetDetail.Budget.ID,
+			&budgetDetail.Budget.Price,
+			&budgetDetail.Budget.YearID,
+			&budgetDetail.Budget.SourceID,
+			&budgetDetail.Budget.CreatedAt,
+			&budgetDetail.Budget.UpdatedAt,
+			&budgetDetail.Year.ID,
+			&budgetDetail.Year.Year,
+			&budgetDetail.Year.CreatedAt,
+			&budgetDetail.Year.UpdatedAt,
+			&budgetDetail.Source.ID,
+			&budgetDetail.Source.Name,
+			&budgetDetail.Source.CreatedAt,
+			&budgetDetail.Source.UpdatedAt,
+		)
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot connect SQL")
+		}
+		budgetDetails = append(budgetDetails, budgetDetail)
+	}
+	return budgetDetails, nil
+}
+
+
+func (b *budgetUseCase) GetBudgetDetailsByPeriod(c context.Context, year string) ([]domain.BudgetDetail, error) {
+	budgetDetail := domain.BudgetDetail{}
+	var budgetDetails []domain.BudgetDetail
+
+	rows, err := b.rep.FindDetailsByPeriod(c, year)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
 	for rows.Next() {
 		err := rows.Scan(

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -100,6 +100,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.DELETE("/budgets/:id", r.budgetController.DestroyBudget)
 	e.GET("/budgets/:id/details", r.budgetController.ShowBudgetDetailById)
 	e.GET("/budgets/details", r.budgetController.ShowBudgetDetails)
+	e.GET("/budgets/details/:year", r.budgetController.ShowBudgetDetailsByPeriods)
 
 	//bureauのRoute
 	e.GET("/bureaus", r.bureauController.IndexBureau)

--- a/view/next-project/src/pages/budgets/index.tsx
+++ b/view/next-project/src/pages/budgets/index.tsx
@@ -94,11 +94,8 @@ export default function BudgetList(props: Props) {
 
   const getBudgets = async () => {
     const getBudgtesByYearsURL = process.env.CSR_API_URI + '/budgets/details/' + selectedYear;
-    const getExpensesByYearsURL = process.env.CSR_API_URI + '/expenses/details/' + selectedYear;
     const getBudgetsByYears = await get(getBudgtesByYearsURL);
-    const getExpensesByYears = await get(getExpensesByYearsURL);
     setBudgetViews(getBudgetsByYears);
-    setExpenseViews(getExpensesByYears);
   };
 
   const getExpenses = async () => {
@@ -117,13 +114,17 @@ export default function BudgetList(props: Props) {
   }, [selectedExpenseYear]);
 
   // 合計金額用の変数
-  const budgetsTotalFee = budgetViews.reduce((prev, current) => {
-    return prev + current.budget.price;
-  }, 0);
+  const budgetsTotalFee =
+    budgetViews &&
+    budgetViews.reduce((prev, current) => {
+      return prev + current.budget.price;
+    }, 0);
 
-  const expensesTotalFee = expenseViews.reduce((prev, current) => {
-    return prev + current.expense.totalPrice;
-  }, 0);
+  const expensesTotalFee =
+    expenseViews &&
+    expenseViews.reduce((prev, current) => {
+      return prev + current.expense.totalPrice;
+    }, 0);
 
   const formatDate = (date: string) => {
     const datetime = date.replace('T', ' ');
@@ -188,42 +189,43 @@ export default function BudgetList(props: Props) {
                       </tr>
                     </thead>
                     <tbody>
-                      {budgetViews.map((budgetView, index) => (
-                        <tr
-                          key={budgetView.budget.id}
-                          className={clsx(
-                            index !== budgets.length - 1 && 'border-b',
-                            'py-3 text-black-600',
-                          )}
-                        >
-                          <td className='py-3 text-center'>{budgetView.source.name}</td>
-                          <td className='py-3 text-center'>{budgetView.year.year}</td>
-                          <td className='py-3 text-center'>{budgetView.budget.price}</td>
-                          <td className='py-3 text-center'>
-                            {formatDate(
-                              budgetView.budget.createdAt ? budgetView.budget.createdAt : '',
+                      {budgetViews &&
+                        budgetViews.map((budgetView, index) => (
+                          <tr
+                            key={budgetView.budget.id}
+                            className={clsx(
+                              index !== budgets.length - 1 && 'border-b',
+                              'py-3 text-black-600',
                             )}
-                          </td>
-                          <td className='py-3 text-center'>
-                            {formatDate(
-                              budgetView.budget.updatedAt ? budgetView.budget.updatedAt : '',
-                            )}
-                          </td>
-                          <td className='flex items-center justify-center gap-3 py-3'>
-                            <OpenEditModalButton
-                              id={budgetView.budget.id ? budgetView.budget.id : 0}
-                              sources={sources}
-                              years={years}
-                              isDisabled={isDisabled}
-                            />
-                            <OpenDeleteModalButton
-                              id={budgetView.budget.id ? budgetView.budget.id : 0}
-                              isDisabled={isDisabled}
-                            />
-                          </td>
-                        </tr>
-                      ))}
-                      {!budgetViews.length && (
+                          >
+                            <td className='py-3 text-center'>{budgetView.source.name}</td>
+                            <td className='py-3 text-center'>{budgetView.year.year}</td>
+                            <td className='py-3 text-center'>{budgetView.budget.price}</td>
+                            <td className='py-3 text-center'>
+                              {formatDate(
+                                budgetView.budget.createdAt ? budgetView.budget.createdAt : '',
+                              )}
+                            </td>
+                            <td className='py-3 text-center'>
+                              {formatDate(
+                                budgetView.budget.updatedAt ? budgetView.budget.updatedAt : '',
+                              )}
+                            </td>
+                            <td className='flex items-center justify-center gap-3 py-3'>
+                              <OpenEditModalButton
+                                id={budgetView.budget.id ? budgetView.budget.id : 0}
+                                sources={sources}
+                                years={years}
+                                isDisabled={isDisabled}
+                              />
+                              <OpenDeleteModalButton
+                                id={budgetView.budget.id ? budgetView.budget.id : 0}
+                                isDisabled={isDisabled}
+                              />
+                            </td>
+                          </tr>
+                        ))}
+                      {!budgetViews && (
                         <tr>
                           <td colSpan={6} className='py-3 text-center text-sm text-black-600'>
                             データがありません
@@ -231,7 +233,7 @@ export default function BudgetList(props: Props) {
                         </tr>
                       )}
                     </tbody>
-                    {budgetViews.length > 0 && (
+                    {budgetViews && budgetViews.length > 0 && (
                       <tfoot
                         className={clsx(
                           'border border-x-white-0 border-b-white-0 border-t-primary-1',
@@ -298,56 +300,57 @@ export default function BudgetList(props: Props) {
                       </tr>
                     </thead>
                     <tbody>
-                      {expenseViews.map((expenseView, index) => (
-                        <tr
-                          key={expenseView.expense.id}
-                          className={clsx(
-                            index !== expenses.length - 1 && 'border-b',
-                            'py-3 text-black-600',
-                          )}
-                        >
-                          <td
-                            className='py-3 text-center'
-                            onClick={() => onOpen(expenseView.expense.id || 0, expenseView)}
-                          >
-                            {expenseView.expense.name}
-                          </td>
-                          <td
-                            onClick={() => onOpen(expenseView.expense.id || 0, expenseView)}
-                            className='py-3 text-center'
-                          >
-                            {expenseView.expense.totalPrice}
-                          </td>
-                          <td
-                            onClick={() => onOpen(expenseView.expense.id || 0, expenseView)}
-                            className='py-3 text-center'
-                          >
-                            {formatDate(
-                              expenseView.expense.createdAt ? expenseView.expense.createdAt : '',
+                      {expenseViews &&
+                        expenseViews.map((expenseView, index) => (
+                          <tr
+                            key={expenseView.expense.id}
+                            className={clsx(
+                              index !== expenses.length - 1 && 'border-b',
+                              'py-3 text-black-600',
                             )}
-                          </td>
-                          <td
-                            onClick={() => onOpen(expenseView.expense.id || 0, expenseView)}
-                            className='py-3 text-center'
                           >
-                            {formatDate(
-                              expenseView.expense.updatedAt ? expenseView.expense.updatedAt : '',
-                            )}
-                          </td>
-                          <td className='flex justify-center gap-3 py-3'>
-                            <OpenExpenseEditModalButton
-                              disabled={isDisabled}
-                              id={expenseView.expense.id ? expenseView.expense.id : 0}
-                              expense={expenseView.expense}
-                            />
-                            <OpenExpenseDeleteModalButton
-                              disabled={isDisabled}
-                              id={expenseView.expense.id ? expenseView.expense.id : 0}
-                            />
-                          </td>
-                        </tr>
-                      ))}
-                      {!expenseViews.length && (
+                            <td
+                              className='py-3 text-center'
+                              onClick={() => onOpen(expenseView.expense.id || 0, expenseView)}
+                            >
+                              {expenseView.expense.name}
+                            </td>
+                            <td
+                              onClick={() => onOpen(expenseView.expense.id || 0, expenseView)}
+                              className='py-3 text-center'
+                            >
+                              {expenseView.expense.totalPrice}
+                            </td>
+                            <td
+                              onClick={() => onOpen(expenseView.expense.id || 0, expenseView)}
+                              className='py-3 text-center'
+                            >
+                              {formatDate(
+                                expenseView.expense.createdAt ? expenseView.expense.createdAt : '',
+                              )}
+                            </td>
+                            <td
+                              onClick={() => onOpen(expenseView.expense.id || 0, expenseView)}
+                              className='py-3 text-center'
+                            >
+                              {formatDate(
+                                expenseView.expense.updatedAt ? expenseView.expense.updatedAt : '',
+                              )}
+                            </td>
+                            <td className='flex justify-center gap-3 py-3'>
+                              <OpenExpenseEditModalButton
+                                disabled={isDisabled}
+                                id={expenseView.expense.id ? expenseView.expense.id : 0}
+                                expense={expenseView.expense}
+                              />
+                              <OpenExpenseDeleteModalButton
+                                disabled={isDisabled}
+                                id={expenseView.expense.id ? expenseView.expense.id : 0}
+                              />
+                            </td>
+                          </tr>
+                        ))}
+                      {!expenseViews && (
                         <tr>
                           <td colSpan={6} className='py-3 text-center text-sm text-black-600'>
                             データがありません
@@ -355,7 +358,7 @@ export default function BudgetList(props: Props) {
                         </tr>
                       )}
                     </tbody>
-                    {expenseViews.length > 0 && (
+                    {expenseViews && expenseViews.length > 0 && (
                       <tfoot
                         className={clsx(
                           'border border-x-white-0 border-b-white-0 border-t-primary-1',

--- a/view/next-project/src/pages/budgets/index.tsx
+++ b/view/next-project/src/pages/budgets/index.tsx
@@ -26,11 +26,20 @@ interface Props {
   expenses: ExpenseView[];
 }
 
+const date = new Date();
+
 export async function getServerSideProps() {
-  const getBudgetUrl = process.env.SSR_API_URI + '/budgets/details';
-  const getSourceUrl = process.env.SSR_API_URI + '/sources';
   const getYearUrl = process.env.SSR_API_URI + '/years';
-  const getExpenseUrl = process.env.SSR_API_URI + '/expenses/details';
+  const periodsRes = await get(getYearUrl);
+  const getBudgetUrl =
+    process.env.SSR_API_URI +
+    '/budgets/details/' +
+    (periodsRes ? String(periodsRes[periodsRes.length - 1].year) : String(date.getFullYear()));
+  const getSourceUrl = process.env.SSR_API_URI + '/sources';
+  const getExpenseUrl =
+    process.env.SSR_API_URI +
+    '/expenses/details/' +
+    (periodsRes ? String(periodsRes[periodsRes.length - 1].year) : String(date.getFullYear()));
 
   const budgetRes = await get(getBudgetUrl);
   const sourceRes = await get(getSourceUrl);
@@ -50,6 +59,8 @@ export default function BudgetList(props: Props) {
   const { budgets, sources, years, expenses } = props;
   const auth = useRecoilValue(authAtom);
   const [currentUser, setCurrentUser] = useState<User>();
+  const [budgetViews, setBudgetViews] = useState<BudgetView[]>(props.budgets);
+  const [expenseViews, setExpenseViews] = useState<ExpenseView[]>(props.expenses);
 
   useEffect(() => {
     const getUser = async () => {
@@ -66,42 +77,51 @@ export default function BudgetList(props: Props) {
     return true;
   }, [currentUser]);
 
-  const [expenseView, setExpenseView] = useState<ExpenseView>(props.expenses[0]);
+  const [forcusExpense, setForcusExpense] = useState<ExpenseView>(props.expenses[0]);
   const [isOpen, setIsOpen] = useState(false);
   const onOpen = (expenseID: number, expenseView: ExpenseView) => {
-    setExpenseView(expenseView);
+    setForcusExpense(expenseView);
     setIsOpen(true);
   };
 
-  const currentYear: Year = { year: new Date().getFullYear() };
-  const [selectedYear, setSelectedYear] = useState<Year>(currentYear);
-  const [selectedExpenseYear, setSelectedExpenseYear] = useState<string>(
-    currentYear.year.toString(),
+  const [selectedYear, setSelectedYear] = useState<string>(
+    years ? String(years[years.length - 1].year) : String(date.getFullYear()),
   );
-  const handleSelectedYear = (selectedYear: number) => {
-    const year: Year = { year: selectedYear };
-    setSelectedYear(year);
+
+  const [selectedExpenseYear, setSelectedExpenseYear] = useState<string>(
+    years ? String(years[years.length - 1].year) : String(date.getFullYear()),
+  );
+
+  const getBudgets = async () => {
+    const getBudgtesByYearsURL = process.env.CSR_API_URI + '/budgets/details/' + selectedYear;
+    const getExpensesByYearsURL = process.env.CSR_API_URI + '/expenses/details/' + selectedYear;
+    const getBudgetsByYears = await get(getBudgtesByYearsURL);
+    const getExpensesByYears = await get(getExpensesByYearsURL);
+    setBudgetViews(getBudgetsByYears);
+    setExpenseViews(getExpensesByYears);
   };
 
-  const filteredBudgets = useMemo(() => {
-    if (!budgets || budgets.length === 0) return [];
-    return budgets.filter((budgetView) => {
-      return budgetView.year.year == selectedYear.year;
-    });
-  }, [budgets, selectedYear]);
+  const getExpenses = async () => {
+    const getExpensesByYearsURL =
+      process.env.CSR_API_URI + '/expenses/details/' + selectedExpenseYear;
+    const getExpensesByYears = await get(getExpensesByYearsURL);
+    setExpenseViews(getExpensesByYears);
+  };
 
-  const filteredExpenses = useMemo(() => {
-    return expenses.filter((expenseView) => {
-      return expenseView.expense.createdAt?.includes(selectedExpenseYear);
-    });
-  }, [expenses, selectedExpenseYear]);
+  useEffect(() => {
+    getBudgets();
+  }, [selectedYear]);
+
+  useEffect(() => {
+    getExpenses();
+  }, [selectedExpenseYear]);
 
   // 合計金額用の変数
-  const budgetsTotalFee = filteredBudgets.reduce((prev, current) => {
+  const budgetsTotalFee = budgetViews.reduce((prev, current) => {
     return prev + current.budget.price;
   }, 0);
 
-  const expensesTotalFee = filteredExpenses.reduce((prev, current) => {
+  const expensesTotalFee = expenseViews.reduce((prev, current) => {
     return prev + current.expense.totalPrice;
   }, 0);
 
@@ -130,8 +150,8 @@ export default function BudgetList(props: Props) {
                   <Title title={'収入一覧'} />
                   <select
                     className='w-100'
-                    defaultValue={currentYear.year}
-                    onChange={(e) => handleSelectedYear(Number(e.target.value))}
+                    defaultValue={selectedYear}
+                    onChange={(e) => setSelectedYear(e.target.value)}
                   >
                     {years.map((year) => (
                       <option key={year.year} value={year.year}>
@@ -168,7 +188,7 @@ export default function BudgetList(props: Props) {
                       </tr>
                     </thead>
                     <tbody>
-                      {filteredBudgets.map((budgetView, index) => (
+                      {budgetViews.map((budgetView, index) => (
                         <tr
                           key={budgetView.budget.id}
                           className={clsx(
@@ -203,7 +223,7 @@ export default function BudgetList(props: Props) {
                           </td>
                         </tr>
                       ))}
-                      {!filteredBudgets.length && (
+                      {!budgetViews.length && (
                         <tr>
                           <td colSpan={6} className='py-3 text-center text-sm text-black-600'>
                             データがありません
@@ -211,7 +231,7 @@ export default function BudgetList(props: Props) {
                         </tr>
                       )}
                     </tbody>
-                    {filteredBudgets.length > 0 && (
+                    {budgetViews.length > 0 && (
                       <tfoot
                         className={clsx(
                           'border border-x-white-0 border-b-white-0 border-t-primary-1',
@@ -244,12 +264,14 @@ export default function BudgetList(props: Props) {
                   <Title title={'支出一覧'} />
                   <select
                     className='w-100 '
-                    defaultValue={currentYear.year}
+                    defaultValue={selectedYear}
                     onChange={(e) => setSelectedExpenseYear(e.target.value)}
                   >
-                    <option value='2021'>2021</option>
-                    <option value='2022'>2022</option>
-                    <option value='2023'>2023</option>
+                    {years.map((year) => (
+                      <option key={year.year} value={year.year}>
+                        {year.year}
+                      </option>
+                    ))}
                   </select>
                 </div>
                 <div className='mb-2 mt-4 overflow-scroll md:p-5'>
@@ -276,7 +298,7 @@ export default function BudgetList(props: Props) {
                       </tr>
                     </thead>
                     <tbody>
-                      {filteredExpenses.map((expenseView, index) => (
+                      {expenseViews.map((expenseView, index) => (
                         <tr
                           key={expenseView.expense.id}
                           className={clsx(
@@ -325,7 +347,7 @@ export default function BudgetList(props: Props) {
                           </td>
                         </tr>
                       ))}
-                      {!filteredExpenses.length && (
+                      {!expenseViews.length && (
                         <tr>
                           <td colSpan={6} className='py-3 text-center text-sm text-black-600'>
                             データがありません
@@ -333,7 +355,7 @@ export default function BudgetList(props: Props) {
                         </tr>
                       )}
                     </tbody>
-                    {filteredExpenses.length > 0 && (
+                    {expenseViews.length > 0 && (
                       <tfoot
                         className={clsx(
                           'border border-x-white-0 border-b-white-0 border-t-primary-1',
@@ -358,7 +380,7 @@ export default function BudgetList(props: Props) {
           </TabPanel>
         </TabPanels>
       </Tabs>
-      {isOpen && <DetailModal setIsOpen={setIsOpen} expenseView={expenseView} />}
+      {isOpen && <DetailModal setIsOpen={setIsOpen} expenseView={forcusExpense} />}
     </MainLayout>
   );
 }

--- a/view/next-project/src/pages/budgets/index.tsx
+++ b/view/next-project/src/pages/budgets/index.tsx
@@ -194,7 +194,7 @@ export default function BudgetList(props: Props) {
                           <tr
                             key={budgetView.budget.id}
                             className={clsx(
-                              index !== budgets.length - 1 && 'border-b',
+                              budgetViews && index !== budgetViews.length - 1 && 'border-b',
                               'py-3 text-black-600',
                             )}
                           >
@@ -305,7 +305,7 @@ export default function BudgetList(props: Props) {
                           <tr
                             key={expenseView.expense.id}
                             className={clsx(
-                              index !== expenses.length - 1 && 'border-b',
+                              expenseViews && index !== expenseViews.length - 1 && 'border-b',
                               'py-3 text-black-600',
                             )}
                           >


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #676 

# 概要
<!-- 開発内容の概要を記載 -->
- 予算の年度切り合えAPI作成
- 予算ページの年度切り替え実装
- 支出ページの年度切り替え実装

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="917" alt="スクリーンショット 2024-02-21 15 01 22" src="https://github.com/NUTFes/FinanSu/assets/115447919/163af742-0fc5-433a-a201-a6d0189816b7">
<img width="917" alt="スクリーンショット 2024-02-21 15 01 10" src="https://github.com/NUTFes/FinanSu/assets/115447919/5a52e29c-2a91-4714-9e26-773e86ebf389">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- swaggerへアクセスし、`/budgets/details/{year}`で取得できるか確認
- FinanSuをローカルで立ち上げ、予算ページを表示できるか確認する
- 予算ページで予算と支出を確認する

# 備考
