### PR TITLE
[fix] 各年度ごとに取得するように修正

### DIFF
--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -601,7 +601,7 @@ export default function SponsorActivities(props: Props) {
               {(!sortedAndFilteredSponsorActivitiesViews ||
                 sortedAndFilteredSponsorActivitiesViews.length === 0) && (
                 <tr>
-                  <td colSpan={6} className='py-3'>
+                  <td colSpan={9} className='py-3'>
                     <div className='text-center text-sm text-black-600'>データがありません</div>
                   </td>
                 </tr>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #677 

# 概要
<!-- 開発内容の概要を記載 -->
協賛活動一覧ページにおいて、選択した年度のデータのみを取得するように修正。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

![FireShot Capture 164 - 協賛活動一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/904127f3-2545-48a4-84ec-150fa50725aa)
![FireShot Capture 166 - 協賛活動一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/06a8b811-7b27-4e1b-9be6-75091bfb7091)

↓ 24/03/05 New 「CSSを修正」


![FireShot Capture 171 - 協賛活動一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/b2969151-3852-48b6-84af-b3dbd57b72ef)



# テスト項目
<!-- テストしてほしい内容を記載 -->
- http://localhost:3000/sponsoractivities にアクセスし、年度切り替えが行えるかを確認する。
- 項目の並べ替えやフィルター機能が働くかを確認する。

# 備考