### PR TITLE
[feat] 年度別に取得するAPIを使って表示させるように変更

### DIFF
--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { useState as UseState, useEffect as UseEffect } from 'react';
+import { useState , useEffect } from 'react';
 import OpenDeleteModalButton from '@/components/sponsors/OpenDeleteModalButton';
 import OpenEditModalButton from '@/components/sponsors/OpenEditModalButton';
 import { get } from '@/utils/api/api_methods';
@@ -33,23 +33,22 @@ export const getServerSideProps = async () => {
   };
 };
 
-const sponsorship: NextPage<Props> = (props: Props) => {
-  const [sponsors, setSponsors] = UseState<Sponsor[]>(props.sponsor);
+const Sponsorship: NextPage<Props> = (props: Props) => {
+  const [sponsors, setSponsors] = useState<Sponsor[]>(props.sponsor);
 
   const yearPeriods = props.yearPeriods;
-  const [selectedYear, setSelectedYear] = UseState<string>(
+  const [selectedYear, setSelectedYear] = useState<string>(
     yearPeriods ? String(yearPeriods[yearPeriods.length - 1].year) : String(date.getFullYear()),
   );
 
   //年度別のsponsorsを取得
   const getSponsors = async () => {
     const getSponsorViewUrlByYear = process.env.CSR_API_URI + '/sponsors/' + selectedYear;
-    console.log(getSponsorViewUrlByYear);
     const getSponsorsByYears = await get(getSponsorViewUrlByYear);
     setSponsors(getSponsorsByYears);
   };
 
-  UseEffect(() => {
+  useEffect(() => {
     getSponsors();
   }, [selectedYear]);
 
@@ -154,4 +153,4 @@ const sponsorship: NextPage<Props> = (props: Props) => {
   );
 };
 
-export default sponsorship;
+export default Sponsorship;

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { useState , useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import OpenDeleteModalButton from '@/components/sponsors/OpenDeleteModalButton';
 import OpenEditModalButton from '@/components/sponsors/OpenEditModalButton';
 import { get } from '@/utils/api/api_methods';

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -1,42 +1,57 @@
 import clsx from 'clsx';
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { useState as UseState, useMemo as UseMemo } from 'react';
-
+import { useState as UseState, useEffect as UseEffect } from 'react';
 import OpenDeleteModalButton from '@/components/sponsors/OpenDeleteModalButton';
 import OpenEditModalButton from '@/components/sponsors/OpenEditModalButton';
 import { get } from '@/utils/api/api_methods';
 import { Card, Title } from '@components/common';
 import MainLayout from '@components/layout/MainLayout';
 import OpenAddModalButton from '@components/sponsors/OpenAddModalButton';
-import { Sponsor } from '@type/common';
+import { Sponsor, YearPeriod } from '@type/common';
 
 interface Props {
   sponsor: Sponsor[];
+  yearPeriods: YearPeriod[];
 }
 
+const date = new Date();
+
 export const getServerSideProps = async () => {
-  const getSponsorUrl = process.env.SSR_API_URI + '/sponsors';
-  const sponsorRes = await get(getSponsorUrl);
+  const getPeriodsUrl = process.env.SSR_API_URI + '/years/periods';
+  const periodsRes = await get(getPeriodsUrl);
+  const getSponsorViewUrl =
+    process.env.SSR_API_URI +
+    '/sponsors/' +
+    (periodsRes ? String(periodsRes[periodsRes.length - 1].year) : String(date.getFullYear()));
 
   return {
     props: {
-      sponsor: sponsorRes,
+      sponsorView: getSponsorViewUrl,
+      yearPeriods: periodsRes,
     },
   };
 };
 
 const sponsorship: NextPage<Props> = (props: Props) => {
-  const sponsorList: Sponsor[] = props.sponsor;
+  const [sponsors, setSponsors] = UseState<Sponsor[]>(props.sponsor);
 
-  const currentYear = new Date().getFullYear().toString();
-  const [selectedYear, setSelectedYear] = UseState<string>(currentYear);
+  const yearPeriods = props.yearPeriods;
+  const [selectedYear, setSelectedYear] = UseState<string>(
+    yearPeriods ? String(yearPeriods[yearPeriods.length - 1].year) : String(date.getFullYear()),
+  );
 
-  const filteredSponsorListViews = UseMemo(() => {
-    return sponsorList.filter((sponsor) => {
-      return sponsor.createdAt?.includes(selectedYear);
-    });
-  }, [sponsorList, selectedYear]);
+  //年度別のsponsorsを取得
+  const getSponsors = async () => {
+    const getSponsorViewUrlByYear = process.env.CSR_API_URI + '/sponsors/' + selectedYear;
+    console.log(getSponsorViewUrlByYear);
+    const getSponsorsByYears = await get(getSponsorViewUrlByYear);
+    setSponsors(getSponsorsByYears);
+  };
+
+  UseEffect(() => {
+    getSponsors();
+  }, [selectedYear]);
 
   return (
     <MainLayout>
@@ -50,12 +65,17 @@ const sponsorship: NextPage<Props> = (props: Props) => {
             <Title title={'協賛企業一覧'} />
             <select
               className='w-100'
-              defaultValue={currentYear}
+              defaultValue={selectedYear}
               onChange={(e) => setSelectedYear(e.target.value)}
             >
-              <option value='2021'>2021</option>
-              <option value='2022'>2022</option>
-              <option value='2023'>2023</option>
+              {props.yearPeriods &&
+                props.yearPeriods.map((year) => {
+                  return (
+                    <option value={year.year} key={year.id}>
+                      {year.year}年度
+                    </option>
+                  );
+                })}
             </select>
           </div>
           <div className='hidden justify-end md:flex'>
@@ -87,10 +107,10 @@ const sponsorship: NextPage<Props> = (props: Props) => {
               </tr>
             </thead>
             <tbody className='border border-x-white-0 border-b-primary-1 border-t-white-0'>
-              {filteredSponsorListViews &&
-                filteredSponsorListViews.map((sponsor, index) => (
+              {sponsors && sponsors.length > 0 ? (
+                sponsors.map((sponsor, index) => (
                   <tr
-                    className={clsx(index !== sponsorList.length - 1 && 'border-b')}
+                    className={clsx(index !== sponsors.length - 1 && 'border-b')}
                     key={sponsor.id}
                   >
                     <td className='py-3'>
@@ -115,8 +135,8 @@ const sponsorship: NextPage<Props> = (props: Props) => {
                       </div>
                     </td>
                   </tr>
-                ))}
-              {!filteredSponsorListViews.length && (
+                ))
+              ) : (
                 <tr>
                   <td colSpan={6} className='py-3'>
                     <div className='text-center text-black-300'>データがありません</div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #678 

# 概要
<!-- 開発内容の概要を記載 -->
前回、年度別に取得するAPIを作成したのでそれに伴ってフロントでフィルターを掛けるのではなくバックで取得したデータを表示させるように変更した

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/NUTFes/FinanSu/assets/106811268/1cc3aa5d-e60e-4173-b13c-22b430ede456)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- `docker compose up -d`でコンテナを立ち上げて`localhost:3000/sponsors`にアクセスし、年度の切替でデータの取得、切替がなされているか確認お願いします。
- consoleでsponsorsのurlを表示しているので、年度を変更した時に正しい年度のurlが確認できたら大丈夫だと思ってます。
- 2023年度にはデータはないです。`localhost:3000/yearperiods`で年度の編集ができるので2023年度の終了期間を変更すれば確認できると思います。
-

# 備考
過去の遺物に疑問が2点あります。
- `import { useState as UseState, useEffect as UseEffect } from 'react';`でわざわざ別名を当てて定義しているのには意味があるのでしょうか。他のページではしてないようです。
- `onChange={(e) => setSelectedYear(e.target.value)}`下記コードが他のページでは`onChange={async (e) => { setSelectedYear(e.target.value); }}`とコーディングされています。syncを付けなくても動作するのですが何故つけているのでしょうか