### PR TITLE
[fix] 登録されたデータが編集モーダルに反映されるよう修正

### DIFF
--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -78,7 +78,7 @@ export default function EditModal(props: ModalProps) {
       .filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
-    if (res.length !== 0) setFormData({ ...formData, userID: props.fundInformation.userID });
+    if (res.length !== 0) setFormData({ ...formData, userID: res[0].id });
     return res;
   }, [bureauId]);
 

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -34,7 +34,7 @@ export default function EditModal(props: ModalProps) {
   useEffect(() => {
     const teacher = props.teachers.find((teacher) => teacher.departmentID === departmentID);
     if (teacher && teacher.id) {
-      setFormData({ ...formData, teacherID: props.fundInformation.teacherID });
+      setFormData({ ...formData, teacherID: teacher.id });
     }
   }, [departmentID]);
 

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -29,30 +29,25 @@ export default function EditModal(props: ModalProps) {
     receivedAt: props.fundInformation.receivedAt,
   });
 
-  const [departmentID, setDepartmentID] = useState<number | string>(1);
-  const [defaultValue, setDefaultValue] = useState<boolean>(false);
+  const defaultTeacher = props.teachers.find(
+    (teacher) => teacher.id === props.fundInformation.teacherID,
+  );
+  const [teacher, setTeacher] = useState<Teacher | undefined>(defaultTeacher);
+  const [departmentID, setDepartmentID] = useState<number>(defaultTeacher?.departmentID || 1);
 
   useEffect(() => {
-    if (defaultValue == false) {
-      const selectedTeacher = props.teachers.find(
-        (teacher) => teacher.id === props.fundInformation.teacherID,
-      );
-      if (selectedTeacher?.id) {
-        setDepartmentID(selectedTeacher.departmentID);
-        setFormData({ ...formData, teacherID: selectedTeacher.id });
-      }
-      setTimeout(() => {
-        setDefaultValue(true);
-      });
-    } else {
+    if (teacher?.departmentID !== departmentID) {
       const relatedTeachers = props.teachers.filter(
         (teacher) => teacher.departmentID === departmentID,
       );
-      if (relatedTeachers) {
-        setFormData({ ...formData, teacherID: relatedTeachers[0].id || 0 });
-      }
+      relatedTeachers &&
+        setFormData({
+          ...formData,
+          teacherID: relatedTeachers[0]?.id || 0,
+        });
+      setTeacher(relatedTeachers[0]);
     }
-  }, [departmentID, props.teachers]);
+  }, [departmentID]);
 
   const handler =
     (input: string) =>

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -30,22 +30,29 @@ export default function EditModal(props: ModalProps) {
   });
 
   const [departmentID, setDepartmentID] = useState<number | string>(1);
+  const [defaultValue, setDefaultValue] = useState<boolean>(false);
 
   useEffect(() => {
-    const teacher = props.teachers.find((teacher) => teacher.departmentID === departmentID);
-    if (teacher && teacher.id) {
-      setFormData({ ...formData, teacherID: teacher.id });
+    if (defaultValue == false) {
+      const selectedTeacher = props.teachers.find(
+        (teacher) => teacher.id === props.fundInformation.teacherID,
+      );
+      if (selectedTeacher?.id) {
+        setDepartmentID(selectedTeacher.departmentID);
+        setFormData({ ...formData, teacherID: selectedTeacher.id });
+      }
+      setTimeout(() => {
+        setDefaultValue(true);
+      });
+    } else {
+      const relatedTeachers = props.teachers.filter(
+        (teacher) => teacher.departmentID === departmentID,
+      );
+      if (relatedTeachers) {
+        setFormData({ ...formData, teacherID: relatedTeachers[0].id || 0 });
+      }
     }
-  }, [departmentID]);
-
-  useEffect(() => {
-    const selectedTeacher = props.teachers.find(
-      (teacher) => teacher.id === props.fundInformation.teacherID,
-    );
-    if (selectedTeacher) {
-      setDepartmentID(selectedTeacher.departmentID);
-    }
-  }, [props.teachers, props.fundInformation.teacherID]);
+  }, [departmentID, props.teachers]);
 
   const handler =
     (input: string) =>

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -34,9 +34,18 @@ export default function EditModal(props: ModalProps) {
   useEffect(() => {
     const teacher = props.teachers.find((teacher) => teacher.departmentID === departmentID);
     if (teacher && teacher.id) {
-      setFormData({ ...formData, teacherID: teacher.id });
+      setFormData({ ...formData, teacherID: props.fundInformation.teacherID });
     }
   }, [departmentID]);
+
+  useEffect(() => {
+    const selectedTeacher = props.teachers.find(
+      (teacher) => teacher.id === props.fundInformation.teacherID,
+    );
+    if (selectedTeacher) {
+      setDepartmentID(selectedTeacher.departmentID);
+    }
+  }, [props.teachers, props.fundInformation.teacherID]);
 
   const handler =
     (input: string) =>
@@ -69,7 +78,7 @@ export default function EditModal(props: ModalProps) {
       .filter((user, index, self) => {
         return self.findIndex((u) => u.name === user.name) === index;
       });
-    if (res.length !== 0) setFormData({ ...formData, userID: res[0].id });
+    if (res.length !== 0) setFormData({ ...formData, userID: props.fundInformation.userID });
     return res;
   }, [bureauId]);
 


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #663 

# 概要
<!-- 開発内容の概要を記載 -->
Issue内容は、担当者が各局の一番上の人になるバグの解消です。
しかし、教員の所属・教員名・担当者の局の項目でも同様のバグが発生していたため、まとめて修正しました。
修正内容は、各項目の初期値として登録される値を、既に登録されている内容から参照するように変更しました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![FireShot Capture 169 - 学内募金一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/2051d018-ffa8-47e9-b8c1-761636f41bc2)


![FireShot Capture 170 - 学内募金一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/bdf4e270-862d-424a-99ed-b855d8e63c95)

# テスト項目

<!-- テストしてほしい内容を記載 -->
- FinanSuをローカルで立ち上げ、`http://localhost:3000/fund_informations` へアクセスできることを確認する。
- 登録項目の編集ボタンを押し、編集モーダルが開くことを確認する。
- 各項目を初期値以外のものに設定し、登録ボタンを押す。（スクショ画像を参考にしてください。）
- 登録できたことを確認して再度、編集ボタンを押し、登録内容が初期化されていないかを確認する。
(各項目が全て1番目の要素に初期化されていないか。)

# 備考
24/03/29 更新：モーダルの展開時はpropsの値を表示し、セレクト要素の選択時にUseEffectの再レンダリングで教員名の初期値を設定するようにしました。もっと良い方法あれば教えて下さい。
