### PR TITLE
[feat] purchaseItemが無い場合の表示を追加

### DIFF
--- a/view/next-project/src/components/purchaseorders/EditModal.tsx
+++ b/view/next-project/src/components/purchaseorders/EditModal.tsx
@@ -143,10 +143,14 @@ export default function EditModal(props: ModalProps) {
           </div>
           <p className='mx-auto mb-10 w-fit text-xl text-black-600'>購入物品の修正</p>
           {/* 購入物品があればステッパで表示、なければないと表示  */}
-          {formDataList.length > 0 && (
+          {formDataList && formDataList.length > 0 ? (
             <Stepper stepNum={formDataList.length} activeStep={activeStep} isDone={isDone}>
               {!isDone && <>{content(formDataList[activeStep - 1])}</>}
             </Stepper>
+          ) : (
+            <p className='text-center text-sm text-black-600'>
+              購入物品が存在しません。項目を削除した上で、再登録してください。
+            </p>
           )}
           {isDone ? (
             <div>
@@ -200,7 +204,7 @@ export default function EditModal(props: ModalProps) {
             </div>
           ) : (
             <div className='mb-5 mt-10 flex justify-center gap-5'>
-              {formDataList.length > 0 && (
+              {formDataList && formDataList.length > 0 && (
                 <>
                   {activeStep > 1 && (
                     <OutlinePrimaryButton onClick={prevStep}>戻る</OutlinePrimaryButton>

--- a/view/next-project/src/utils/createPurchaseOrderPdf.ts
+++ b/view/next-project/src/utils/createPurchaseOrderPdf.ts
@@ -381,7 +381,8 @@ export const createPurchasOrderFormPdf = async (purchaseOrdersViews: PurchaseOrd
       });
       sum += item.price * item.quantity;
       page.drawText(String(item.price * item.quantity), {
-        x: 18 + rectangleWidth + 3 * rectangleWidth2 - String(item.price * item.quantity).length * 7,
+        x:
+          18 + rectangleWidth + 3 * rectangleWidth2 - String(item.price * item.quantity).length * 7,
         y: height - (tableTextHight + 20 * (1 + index)) + 2,
         size: fontSizes[0],
         font: fontData,

--- a/view/next-project/src/utils/createPurchaseOrderPdf.ts
+++ b/view/next-project/src/utils/createPurchaseOrderPdf.ts
@@ -321,82 +321,11 @@ export const createPurchasOrderFormPdf = async (purchaseOrdersViews: PurchaseOrd
     font: fontData,
   });
   let sum = 0;
-  purchaseOrdersViews.purchaseItem.map((item, index, arr) => {
-    page.drawRectangle({
-      x: 22,
-      y: height - (tableHight + 20 * (1 + index)),
-      width: rectangleWidth,
-      height: 20,
-      borderColor: rgb(0, 0, 0),
-      borderWidth: 1,
-    });
-    for (let i = 0; i < 3; i++) {
-      page.drawRectangle({
-        x: 22 + rectangleWidth + i * rectangleWidth2,
-        y: height - (tableHight + 20 * (1 + index)),
-        width: rectangleWidth2,
-        height: 20,
-        borderColor: rgb(0, 0, 0),
-        borderWidth: 1,
-      });
-    }
-    for (let i = 0; i < 2; i++) {
-      page.drawRectangle({
-        x: 22 + rectangleWidth + 3 * rectangleWidth2 + i * rectangleWidth,
-        y: height - (tableHight + 20 * (1 + index)),
-        width: rectangleWidth,
-        height: 20,
-        borderColor: rgb(0, 0, 0),
-        borderWidth: 1,
-      });
-    }
-    page.drawRectangle({
-      x: 22 + 3 * rectangleWidth + 3 * rectangleWidth2,
-      y: height - (tableHight + 20 * (1 + index)),
-      width: 20,
-      height: 20,
-      borderColor: rgb(0, 0, 0),
-      borderWidth: 1,
-    });
-    const itemName = truncateString(item.item, 14, 24);
-    const itemFontSize = fontSizeFunc(item.item);
-    page.drawText(itemName, {
-      x: (rectangleWidth - itemName.length * itemFontSize) / 2 + 22,
-      y: height - (tableTextHight + 20 * (1 + index)) + 2,
-      size: fontSizes[2],
-      font: fontData,
-    });
-    page.drawText(String(item.price), {
-      x: 18 + rectangleWidth + rectangleWidth2 - String(item.price).length * 7,
-      y: height - (tableTextHight + 20 * (1 + index)),
-      size: fontSizes[0],
-      font: fontData,
-    });
-    page.drawText(String(item.quantity), {
-      x: 22 + rectangleWidth + rectangleWidth2 + rectangleWidth2 / 2 - 5,
-      y: height - (tableTextHight + 20 * (1 + index)),
-      size: fontSizes[0],
-      font: fontData,
-    });
-    sum += item.price * item.quantity;
-    page.drawText(String(item.price * item.quantity), {
-      x: 18 + rectangleWidth + 3 * rectangleWidth2 - String(item.price * item.quantity).length * 7,
-      y: height - (tableTextHight + 20 * (1 + index)) + 2,
-      size: fontSizes[0],
-      font: fontData,
-    });
-    const detail = truncateString(item.detail, 14, 24);
-    page.drawText(detail, {
-      x: 24 + 2 * rectangleWidth + 3 * rectangleWidth2,
-      y: height - (tableTextHight + 20 * (1 + index)),
-      size: fontSizes[2],
-      font: fontData,
-    });
-    //合計の処理
-    if (index === arr.length - 1) {
+  if (purchaseOrdersViews.purchaseItem) {
+    purchaseOrdersViews.purchaseItem.map((item, index, arr) => {
       page.drawRectangle({
         x: 22,
-        y: height - (tableHight + 20 * (2 + index)),
+        y: height - (tableHight + 20 * (1 + index)),
         width: rectangleWidth,
         height: 20,
         borderColor: rgb(0, 0, 0),
@@ -405,7 +334,7 @@ export const createPurchasOrderFormPdf = async (purchaseOrdersViews: PurchaseOrd
       for (let i = 0; i < 3; i++) {
         page.drawRectangle({
           x: 22 + rectangleWidth + i * rectangleWidth2,
-          y: height - (tableHight + 20 * (2 + index)),
+          y: height - (tableHight + 20 * (1 + index)),
           width: rectangleWidth2,
           height: 20,
           borderColor: rgb(0, 0, 0),
@@ -415,7 +344,7 @@ export const createPurchasOrderFormPdf = async (purchaseOrdersViews: PurchaseOrd
       for (let i = 0; i < 2; i++) {
         page.drawRectangle({
           x: 22 + rectangleWidth + 3 * rectangleWidth2 + i * rectangleWidth,
-          y: height - (tableHight + 20 * (2 + index)),
+          y: height - (tableHight + 20 * (1 + index)),
           width: rectangleWidth,
           height: 20,
           borderColor: rgb(0, 0, 0),
@@ -424,32 +353,165 @@ export const createPurchasOrderFormPdf = async (purchaseOrdersViews: PurchaseOrd
       }
       page.drawRectangle({
         x: 22 + 3 * rectangleWidth + 3 * rectangleWidth2,
-        y: height - (tableHight + 20 * (2 + index)),
+        y: height - (tableHight + 20 * (1 + index)),
         width: 20,
         height: 20,
         borderColor: rgb(0, 0, 0),
         borderWidth: 1,
       });
-      page.drawText('合計', {
-        x: 22 + rectangleWidth + rectangleWidth2 + 17,
-        y: height - (tableTextHight + 20 * (2 + index)),
+      const itemName = truncateString(item.item, 14, 24);
+      const itemFontSize = fontSizeFunc(item.item);
+      page.drawText(itemName, {
+        x: (rectangleWidth - itemName.length * itemFontSize) / 2 + 22,
+        y: height - (tableTextHight + 20 * (1 + index)) + 2,
+        size: fontSizes[2],
+        font: fontData,
+      });
+      page.drawText(String(item.price), {
+        x: 18 + rectangleWidth + rectangleWidth2 - String(item.price).length * 7,
+        y: height - (tableTextHight + 20 * (1 + index)),
         size: fontSizes[0],
         font: fontData,
       });
-      page.drawText(String(sum), {
-        x: 18 + rectangleWidth + 3 * rectangleWidth2 - String(sum).length * 7,
-        y: height - (tableTextHight + 20 * (2 + index)),
+      page.drawText(String(item.quantity), {
+        x: 22 + rectangleWidth + rectangleWidth2 + rectangleWidth2 / 2 - 5,
+        y: height - (tableTextHight + 20 * (1 + index)),
         size: fontSizes[0],
         font: fontData,
       });
-      page.drawText('以上', {
-        x: width - 65,
-        y: height - (tableTextHight + 20 * (3 + index)),
+      sum += item.price * item.quantity;
+      page.drawText(String(item.price * item.quantity), {
+        x: 18 + rectangleWidth + 3 * rectangleWidth2 - String(item.price * item.quantity).length * 7,
+        y: height - (tableTextHight + 20 * (1 + index)) + 2,
         size: fontSizes[0],
         font: fontData,
+      });
+      const detail = truncateString(item.detail, 14, 24);
+      page.drawText(detail, {
+        x: 24 + 2 * rectangleWidth + 3 * rectangleWidth2,
+        y: height - (tableTextHight + 20 * (1 + index)),
+        size: fontSizes[2],
+        font: fontData,
+      });
+      //合計の処理
+      if (index === arr.length - 1) {
+        page.drawRectangle({
+          x: 22,
+          y: height - (tableHight + 20 * (2 + index)),
+          width: rectangleWidth,
+          height: 20,
+          borderColor: rgb(0, 0, 0),
+          borderWidth: 1,
+        });
+        for (let i = 0; i < 3; i++) {
+          page.drawRectangle({
+            x: 22 + rectangleWidth + i * rectangleWidth2,
+            y: height - (tableHight + 20 * (2 + index)),
+            width: rectangleWidth2,
+            height: 20,
+            borderColor: rgb(0, 0, 0),
+            borderWidth: 1,
+          });
+        }
+        for (let i = 0; i < 2; i++) {
+          page.drawRectangle({
+            x: 22 + rectangleWidth + 3 * rectangleWidth2 + i * rectangleWidth,
+            y: height - (tableHight + 20 * (2 + index)),
+            width: rectangleWidth,
+            height: 20,
+            borderColor: rgb(0, 0, 0),
+            borderWidth: 1,
+          });
+        }
+        page.drawRectangle({
+          x: 22 + 3 * rectangleWidth + 3 * rectangleWidth2,
+          y: height - (tableHight + 20 * (2 + index)),
+          width: 20,
+          height: 20,
+          borderColor: rgb(0, 0, 0),
+          borderWidth: 1,
+        });
+        page.drawText('合計', {
+          x: 22 + rectangleWidth + rectangleWidth2 + 17,
+          y: height - (tableTextHight + 20 * (2 + index)),
+          size: fontSizes[0],
+          font: fontData,
+        });
+        page.drawText(String(sum), {
+          x: 18 + rectangleWidth + 3 * rectangleWidth2 - String(sum).length * 7,
+          y: height - (tableTextHight + 20 * (2 + index)),
+          size: fontSizes[0],
+          font: fontData,
+        });
+        page.drawText('以上', {
+          x: width - 65,
+          y: height - (tableTextHight + 20 * (3 + index)),
+          size: fontSizes[0],
+          font: fontData,
+        });
+      }
+    });
+  } else {
+    const totalY = height - (tableHight + 20 * 1);
+    page.drawRectangle({
+      x: 22,
+      y: totalY,
+      width: rectangleWidth,
+      height: 20,
+      borderColor: rgb(0, 0, 0),
+      borderWidth: 1,
+    });
+    for (let i = 0; i < 3; i++) {
+      page.drawRectangle({
+        x: 22 + rectangleWidth + i * rectangleWidth2,
+        y: totalY,
+        width: rectangleWidth2,
+        height: 20,
+        borderColor: rgb(0, 0, 0),
+        borderWidth: 1,
       });
     }
-  });
+    for (let i = 0; i < 2; i++) {
+      page.drawRectangle({
+        x: 22 + rectangleWidth + 3 * rectangleWidth2 + i * rectangleWidth,
+        y: totalY,
+        width: rectangleWidth,
+        height: 20,
+        borderColor: rgb(0, 0, 0),
+        borderWidth: 1,
+      });
+    }
+    page.drawRectangle({
+      x: 22 + 3 * rectangleWidth + 3 * rectangleWidth2,
+      y: totalY,
+      width: 20,
+      height: 20,
+      borderColor: rgb(0, 0, 0),
+      borderWidth: 1,
+    });
+
+    page.drawText('合計', {
+      x: 22 + rectangleWidth + rectangleWidth2 + 17,
+      y: totalY + 2,
+      size: fontSizes[0],
+      font: fontData,
+    });
+
+    page.drawText('0', {
+      x: 18 + rectangleWidth + 3 * rectangleWidth2 - String(0).length * 7,
+      y: totalY + 2,
+      size: fontSizes[0],
+      font: fontData,
+    });
+
+    page.drawText('以上', {
+      x: width - 65,
+      y: totalY - 20,
+      size: fontSizes[0],
+      font: fontData,
+    });
+  }
+
   // 内容の作成ここまで
   // 生成されたPDFデータを取得
   const pdfBytes = await pdfDoc.save();


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #701 

# 概要
<!-- 開発内容の概要を記載 -->
購入申請一覧ページで購入物品が何も登録されていないとき、見積書作成が行われないバグを修正する。
編集時にformDataListがnullによるエラーを回避する。

# 画面スクリーンショット等
![image](https://github.com/NUTFes/FinanSu/assets/131145590/d0041160-2713-4f3a-b788-b25798951991)

![image](https://github.com/NUTFes/FinanSu/assets/131145590/c72c9bc3-5a5c-4bc8-ac65-9506ac8890d7)

![スクリーンショット 2024-03-07 183313](https://github.com/NUTFes/FinanSu/assets/131145590/d250ae3b-28b1-41ed-ad98-ff3891bfb430)

![image](https://github.com/NUTFes/FinanSu/assets/131145590/1675005b-b792-49fa-acee-f62d0a896e83)



# テスト項目
<!-- テストしてほしい内容を記載 -->
- FinanSuをローカルで立ち上げ、`http://localhost:3000/purchaseorders` へアクセスできることを確認する。
- 新たに申請登録を行い、購入期限を入力し、「購入物品の詳細入力」を押して次のモーダルへ進む。そこで何も入力せず、ページをリロードする。
- ページのリロードにより、添付画像のように購入物品が空の状態で登録されることを確認する。
- 登録された項目をクリックし、申請の詳細から「見積書」作成を押すことでPDFがダウンロードされ、添付画像のようになるかを確認する。
- また購入物品が登録されている項目に対しても見積書が正常に作成されるかを確認する。
- 購入物品が無い項目を編集しようとすると、添付画像のように再作成を促す文言が表示されるかを確認する。

# 備考
