### PR TITLE
[fix] 年度別に支出の選択欄を選べるように変更

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -731,6 +731,26 @@ const docTemplate = `{
                 }
             },
         },
+				"/expenses/fiscalyear/{year}": {
+					"get": {
+							tags: ["expense"],
+							"description": "年度で指定されたexpensesを取得",
+							"parameters": [
+									{
+											"name": "year",
+											"in": "path",
+											"description": "year",
+											"required": true,
+											"type": "integer"
+									}
+							],
+							"responses": {
+									"200": {
+											"description": "yearで指定されたexpensesを取得",
+									}
+							}
+					},
+			},
         "/fund_informations": {
             "get": {
                 tags: ["fund_information"],

--- a/api/externals/controller/expense_controller.go
+++ b/api/externals/controller/expense_controller.go
@@ -21,6 +21,7 @@ type ExpenseController interface {
 	IndexExpenseDetails(echo.Context) error
 	ShowExpenseDetail(echo.Context) error
 	IndexExpenseDetailsByPeriod(echo.Context) error
+	IndexExpenseByPeriod(echo.Context) error
 }
 
 func NewExpenseController(u usecase.ExpenseUseCase) ExpenseController {
@@ -118,4 +119,13 @@ func (e *expenseController) IndexExpenseDetailsByPeriod(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, expenseDetails)
+}
+
+func (e *expenseController) IndexExpenseByPeriod(c echo.Context) error {
+	year := c.Param("year")
+	expense, err := e.u.GetExpensesByPeriod(c.Request().Context(), year)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, expense)
 }

--- a/api/internals/domain/expense.go
+++ b/api/internals/domain/expense.go
@@ -29,3 +29,8 @@ type ExpenseDetailsByperiod struct {
 	Year			Year			 `json:"year"`
 	PurchaseDetails []PurchaseDetail `json:"purchaseDetails"`
 }
+
+type ExpenseByPeriod struct {
+	Expense Expense `json:"expense"`
+	Year Year `json:"year"`
+}

--- a/api/internals/usecase/expense_usecase.go
+++ b/api/internals/usecase/expense_usecase.go
@@ -23,6 +23,7 @@ type ExpenseUseCase interface {
 	GetExpenseDetails(context.Context) ([]domain.ExpenseDetails, error)
 	GetExpenseDetailByID(context.Context, string) (domain.ExpenseDetails, error)
 	GetExpenseDetailsByPeriod(context.Context, string) ([]domain.ExpenseDetailsByperiod, error)
+	GetExpensesByPeriod(context.Context, string) ([]domain.ExpenseByPeriod, error)
 }
 
 func NewExpenseUseCase(rep rep.ExpenseRepository) ExpenseUseCase {
@@ -349,4 +350,35 @@ func (e *expenseUseCase) GetExpenseDetailsByPeriod(c context.Context, year strin
 		expenseDetails = append(expenseDetails, expenseDetail)
 	}
 	return expenseDetails, nil
+}
+
+func (e *expenseUseCase) GetExpensesByPeriod(c context.Context, year string) ([]domain.ExpenseByPeriod, error) {
+	ExpenseByperiod := domain.ExpenseByPeriod{}
+	var expenseByperiods []domain.ExpenseByPeriod
+	rows, err := e.rep.AllByPeriod(c, year)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+			err := rows.Scan(
+					&ExpenseByperiod.Expense.ID,
+					&ExpenseByperiod.Expense.Name,
+					&ExpenseByperiod.Expense.TotalPrice,
+					&ExpenseByperiod.Expense.YearID,
+					&ExpenseByperiod.Expense.CreatedAt,
+					&ExpenseByperiod.Expense.UpdatedAt,
+					&ExpenseByperiod.Year.ID,
+					&ExpenseByperiod.Year.Year,
+					&ExpenseByperiod.Year.CreatedAt,
+					&ExpenseByperiod.Year.UpdatedAt,
+			)
+			if err != nil {
+					return nil, err
+			}
+			expenseByperiods = append(expenseByperiods, ExpenseByperiod)
+	}
+	if err := rows.Err(); err != nil {
+			return nil, err
+	}
+	return expenseByperiods, nil
 }

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -126,6 +126,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.GET("/expenses/details/:year", r.expenseController.IndexExpenseDetailsByPeriod)
 	e.GET("/expenses/:id", r.expenseController.ShowExpense)
 	e.GET("/expenses/:id/details", r.expenseController.ShowExpenseDetail)
+	e.GET("/expenses/fiscalyear/:year", r.expenseController.IndexExpenseByPeriod)
 	e.POST("/expenses", r.expenseController.CreateExpense)
 	e.PUT("/expenses/:id", r.expenseController.UpdateExpense)
 	e.DELETE("/expenses/:id", r.expenseController.DestroyExpense)

--- a/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
+++ b/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
@@ -21,7 +21,13 @@ export default function OpenModalButton(props: Props) {
       >
         {props.children}
       </AddButton>
-      {isOpen && <PurchaseItemNumModal setIsOpen={setIsOpen} expenses={props.expenses} expenseByPeriods={props.expenseByPeriods}/>}
+      {isOpen && (
+        <PurchaseItemNumModal
+          setIsOpen={setIsOpen}
+          expenses={props.expenses}
+          expenseByPeriods={props.expenseByPeriods}
+        />
+      )}
     </>
   );
 }

--- a/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
+++ b/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
@@ -2,16 +2,17 @@ import React, { useState } from 'react';
 
 import PurchaseItemNumModal from './PurchaseItemNumModal';
 import { AddButton } from '@components/common';
-import { Expense } from '@type/common';
+import { Expense, YearPeriod } from '@type/common';
 
 interface Props {
   children?: React.ReactNode;
   expenses: Expense[];
+  yearPeriods: YearPeriod[];
+  selectedyear: string;
 }
 
 export default function OpenModalButton(props: Props) {
   const [isOpen, setIsOpen] = useState(false);
-
   return (
     <>
       <AddButton
@@ -21,7 +22,7 @@ export default function OpenModalButton(props: Props) {
       >
         {props.children}
       </AddButton>
-      {isOpen && <PurchaseItemNumModal setIsOpen={setIsOpen} expenses={props.expenses} />}
+      {isOpen && <PurchaseItemNumModal setIsOpen={setIsOpen} expenses={props.expenses} yearPeriods={props.yearPeriods} selectedYear={props.selectedyear}/>}
     </>
   );
 }

--- a/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
+++ b/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
@@ -2,13 +2,12 @@ import React, { useState } from 'react';
 
 import PurchaseItemNumModal from './PurchaseItemNumModal';
 import { AddButton } from '@components/common';
-import { Expense, YearPeriod } from '@type/common';
+import { Expense, ExpenseByPeriods } from '@type/common';
 
 interface Props {
   children?: React.ReactNode;
   expenses: Expense[];
-  yearPeriods: YearPeriod[];
-  selectedyear: string;
+  expenseByPeriods: ExpenseByPeriods[];
 }
 
 export default function OpenModalButton(props: Props) {
@@ -22,14 +21,7 @@ export default function OpenModalButton(props: Props) {
       >
         {props.children}
       </AddButton>
-      {isOpen && (
-        <PurchaseItemNumModal
-          setIsOpen={setIsOpen}
-          expenses={props.expenses}
-          yearPeriods={props.yearPeriods}
-          selectedYear={props.selectedyear}
-        />
-      )}
+      {isOpen && <PurchaseItemNumModal setIsOpen={setIsOpen} expenses={props.expenses} expenseByPeriods={props.expenseByPeriods}/>}
     </>
   );
 }

--- a/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
+++ b/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
@@ -22,7 +22,14 @@ export default function OpenModalButton(props: Props) {
       >
         {props.children}
       </AddButton>
-      {isOpen && <PurchaseItemNumModal setIsOpen={setIsOpen} expenses={props.expenses} yearPeriods={props.yearPeriods} selectedYear={props.selectedyear}/>}
+      {isOpen && (
+        <PurchaseItemNumModal
+          setIsOpen={setIsOpen}
+          expenses={props.expenses}
+          yearPeriods={props.yearPeriods}
+          selectedYear={props.selectedyear}
+        />
+      )}
     </>
   );
 }

--- a/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
@@ -5,11 +5,13 @@ import { userAtom } from '@/store/atoms';
 import { post } from '@api/purchaseOrder';
 import { CloseButton, Input, Modal, PrimaryButton, Select } from '@components/common';
 import AddModal from '@components/purchaseorders/PurchaseOrderAddModal';
-import { PurchaseItem, PurchaseOrder, Expense } from '@type/common';
+import { PurchaseItem, PurchaseOrder, Expense, YearPeriod } from '@type/common';
 
 export interface PurchaseItemNumModalProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   expenses: Expense[];
+  yearPeriods: YearPeriod[];
+  selectedYear: string;
 }
 
 export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
@@ -95,6 +97,16 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
     setFormDataList(initialPurchaseItemList);
   };
 
+  //yearPeriodsとselectedYearを紐づける
+  const selectedYear = props.yearPeriods.find((u) => {
+    return u.year === parseInt(props.selectedYear);
+  })?.id;
+
+  console.log(selectedYear);
+  console.log(props.expenses);
+  console.log(parseInt(props.selectedYear));
+  console.log(props.yearPeriods);
+
   return (
     <>
       <Modal>
@@ -121,11 +133,13 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
               onChange={formDataHandler('expenseID')}
               className='w-full'
             >
-              {props.expenses.map((data) => (
-                <option key={data.id} value={data.id}>
-                  {data.name}
-                </option>
-              ))}
+              {props.expenses
+                .filter((expense) => selectedYear === expense.yearID)
+                .map((data) => (
+                  <option key={data.id} value={data.id}>
+                    {data.name}
+                  </option>
+                ))}
             </Select>
           </div>
           <p className='grid-cols-1 text-black-600'>購入物品数</p>

--- a/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
@@ -5,13 +5,12 @@ import { userAtom } from '@/store/atoms';
 import { post } from '@api/purchaseOrder';
 import { CloseButton, Input, Modal, PrimaryButton, Select } from '@components/common';
 import AddModal from '@components/purchaseorders/PurchaseOrderAddModal';
-import { PurchaseItem, PurchaseOrder, Expense, YearPeriod } from '@type/common';
+import { PurchaseItem, PurchaseOrder, Expense, ExpenseByPeriods } from '@type/common';
 
 export interface PurchaseItemNumModalProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   expenses: Expense[];
-  yearPeriods: YearPeriod[];
-  selectedYear: string;
+  expenseByPeriods: ExpenseByPeriods[];
 }
 
 export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
@@ -97,16 +96,6 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
     setFormDataList(initialPurchaseItemList);
   };
 
-  //yearPeriodsとselectedYearを紐づける
-  const selectedYear = props.yearPeriods.find((u) => {
-    return u.year === parseInt(props.selectedYear);
-  })?.id;
-
-  console.log(selectedYear);
-  console.log(props.expenses);
-  console.log(parseInt(props.selectedYear));
-  console.log(props.yearPeriods);
-
   return (
     <>
       <Modal>
@@ -133,13 +122,11 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
               onChange={formDataHandler('expenseID')}
               className='w-full'
             >
-              {props.expenses
-                .filter((expense) => selectedYear === expense.yearID)
-                .map((data) => (
-                  <option key={data.id} value={data.id}>
-                    {data.name}
-                  </option>
-                ))}
+              {props.expenseByPeriods.map((data) => (
+                <option key={data.expense.id} value={data.expense.id}>
+                  {data.expense.name}
+                </option>
+              ))}
             </Select>
           </div>
           <p className='grid-cols-1 text-black-600'>購入物品数</p>

--- a/view/next-project/src/pages/purchaseorders/index.tsx
+++ b/view/next-project/src/pages/purchaseorders/index.tsx
@@ -215,7 +215,7 @@ export default function PurchaseOrders(props: Props) {
             </PrimaryButton>
           </div>
           <div className='hidden justify-end md:flex'>
-            <OpenAddModalButton expenses={props.expenses}>申請登録</OpenAddModalButton>
+            <OpenAddModalButton expenses={props.expenses} yearPeriods={yearPeriods} selectedyear={selectedYear}>申請登録</OpenAddModalButton>
           </div>
         </div>
         <div className='w-100 mb-2 overflow-scroll p-5'>
@@ -393,7 +393,7 @@ export default function PurchaseOrders(props: Props) {
         />
       )}
       <div className='fixed bottom-4 right-4 md:hidden'>
-        <OpenAddModalButton expenses={props.expenses} />
+        <OpenAddModalButton expenses={props.expenses} yearPeriods={props.yearPeriods} selectedyear={selectedYear}/>
       </div>
     </MainLayout>
   );

--- a/view/next-project/src/pages/purchaseorders/index.tsx
+++ b/view/next-project/src/pages/purchaseorders/index.tsx
@@ -215,7 +215,13 @@ export default function PurchaseOrders(props: Props) {
             </PrimaryButton>
           </div>
           <div className='hidden justify-end md:flex'>
-            <OpenAddModalButton expenses={props.expenses} yearPeriods={yearPeriods} selectedyear={selectedYear}>申請登録</OpenAddModalButton>
+            <OpenAddModalButton
+              expenses={props.expenses}
+              yearPeriods={yearPeriods}
+              selectedyear={selectedYear}
+            >
+              申請登録
+            </OpenAddModalButton>
           </div>
         </div>
         <div className='w-100 mb-2 overflow-scroll p-5'>
@@ -393,7 +399,11 @@ export default function PurchaseOrders(props: Props) {
         />
       )}
       <div className='fixed bottom-4 right-4 md:hidden'>
-        <OpenAddModalButton expenses={props.expenses} yearPeriods={props.yearPeriods} selectedyear={selectedYear}/>
+        <OpenAddModalButton
+          expenses={props.expenses}
+          yearPeriods={props.yearPeriods}
+          selectedyear={selectedYear}
+        />
       </div>
     </MainLayout>
   );

--- a/view/next-project/src/pages/purchaseorders/index.tsx
+++ b/view/next-project/src/pages/purchaseorders/index.tsx
@@ -21,6 +21,7 @@ import {
   PurchaseOrderView,
   Expense,
   YearPeriod,
+  ExpenseByPeriods,
 } from '@type/common';
 
 interface Props {
@@ -28,6 +29,7 @@ interface Props {
   purchaseOrderView: PurchaseOrderView[];
   expenses: Expense[];
   yearPeriods: YearPeriod[];
+  expenseByPeriods: ExpenseByPeriods[];
 }
 
 const date = new Date();
@@ -42,11 +44,18 @@ export async function getServerSideProps() {
   const getExpenseUrl = process.env.SSR_API_URI + '/expenses';
   const purchaseOrderViewRes = await get(getPurchaseOrderViewUrl);
   const expenseRes = await get(getExpenseUrl);
+  const getExpenseByPeriodsUrl =
+    process.env.SSR_API_URI +
+    '/expenses/fiscalyear/' +
+    (periodsRes ? String(periodsRes[periodsRes.length - 1].year) : String(date.getFullYear()));
+  const expenseByPeriodsRes = await get(getExpenseByPeriodsUrl);
+
   return {
     props: {
       purchaseOrderView: purchaseOrderViewRes,
       expenses: expenseRes,
       yearPeriods: periodsRes,
+      expenseByPeriods: expenseByPeriodsRes,
     },
   };
 }
@@ -172,6 +181,8 @@ export default function PurchaseOrders(props: Props) {
     getUser();
   }, []);
 
+  console.log(props.expenseByPeriods);
+
   return (
     <MainLayout>
       <Head>
@@ -215,11 +226,7 @@ export default function PurchaseOrders(props: Props) {
             </PrimaryButton>
           </div>
           <div className='hidden justify-end md:flex'>
-            <OpenAddModalButton
-              expenses={props.expenses}
-              yearPeriods={yearPeriods}
-              selectedyear={selectedYear}
-            >
+            <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods}>
               申請登録
             </OpenAddModalButton>
           </div>
@@ -399,11 +406,7 @@ export default function PurchaseOrders(props: Props) {
         />
       )}
       <div className='fixed bottom-4 right-4 md:hidden'>
-        <OpenAddModalButton
-          expenses={props.expenses}
-          yearPeriods={props.yearPeriods}
-          selectedyear={selectedYear}
-        />
+        <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods} />
       </div>
     </MainLayout>
   );

--- a/view/next-project/src/type/common.ts
+++ b/view/next-project/src/type/common.ts
@@ -67,6 +67,11 @@ export interface ExpenseView {
   ];
 }
 
+export interface ExpenseByPeriods {
+  expense: Expense;
+  year: Year;
+}
+
 // // PurchaseOrder(購入申請)
 export interface PurchaseOrder {
   id?: number;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #708

# 概要
<!-- 開発内容の概要を記載 -->
購入申請ページの新規登録モーダルにて、支出欄を年度別に切り替えられるようにしました
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- purchaseoordersの登録をクリックし、購入したい局、団体が年度別によって切り替わるか
-
-

# 備考
適当にpropsを投げまくっているためコードよく見てほしいです