### PR TITLE
購入報告の登録時に支出のフィルターをかける

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -731,6 +731,26 @@ const docTemplate = `{
                 }
             },
         },
+				"/expenses/fiscalyear/{year}": {
+					"get": {
+							tags: ["expense"],
+							"description": "年度で指定されたexpensesを取得",
+							"parameters": [
+									{
+											"name": "year",
+											"in": "path",
+											"description": "year",
+											"required": true,
+											"type": "integer"
+									}
+							],
+							"responses": {
+									"200": {
+											"description": "yearで指定されたexpensesを取得",
+									}
+							}
+					},
+			},
         "/fund_informations": {
             "get": {
                 tags: ["fund_information"],

--- a/api/externals/controller/expense_controller.go
+++ b/api/externals/controller/expense_controller.go
@@ -21,6 +21,7 @@ type ExpenseController interface {
 	IndexExpenseDetails(echo.Context) error
 	ShowExpenseDetail(echo.Context) error
 	IndexExpenseDetailsByPeriod(echo.Context) error
+	IndexExpenseByPeriod(echo.Context) error
 }
 
 func NewExpenseController(u usecase.ExpenseUseCase) ExpenseController {
@@ -118,4 +119,13 @@ func (e *expenseController) IndexExpenseDetailsByPeriod(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, expenseDetails)
+}
+
+func (e *expenseController) IndexExpenseByPeriod(c echo.Context) error {
+	year := c.Param("year")
+	expense, err := e.u.GetExpensesByPeriod(c.Request().Context(), year)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, expense)
 }

--- a/api/externals/repository/expense_repository.go
+++ b/api/externals/repository/expense_repository.go
@@ -24,6 +24,7 @@ type ExpenseRepository interface {
 	AllItemInfo(context.Context, string) (*sql.Rows, error)
 	AllOrderAndReportInfo(context.Context, string) (*sql.Rows, error)
 	AllByPeriod(context.Context, string) (*sql.Rows, error)
+	OnlyExpensesByPeriod(context.Context, string) (*sql.Rows, error)
 }
 
 func NewExpenseRepository(c db.Client, ac abstract.Crud) ExpenseRepository {
@@ -113,6 +114,22 @@ func (er *expenseRepository) AllByPeriod(c context.Context, year string) (*sql.R
 	query := `
 			SELECT
 				*
+			FROM
+				expenses
+			INNER JOIN
+				years
+			ON
+				expenses.yearID = years.id
+			WHERE
+				years.year = ` + year +
+			" ORDER BY expenses.id;"
+	return er.crud.Read(c, query)
+}
+
+func (er *expenseRepository) OnlyExpensesByPeriod(c context.Context, year string) (*sql.Rows, error) {
+	query := `
+			SELECT
+				expenses.*
 			FROM
 				expenses
 			INNER JOIN

--- a/api/internals/domain/expense.go
+++ b/api/internals/domain/expense.go
@@ -29,3 +29,8 @@ type ExpenseDetailsByperiod struct {
 	Year			Year			 `json:"year"`
 	PurchaseDetails []PurchaseDetail `json:"purchaseDetails"`
 }
+
+type ExpenseByPeriod struct {
+	Expense Expense `json:"expense"`
+	Year Year `json:"year"`
+}

--- a/api/internals/usecase/expense_usecase.go
+++ b/api/internals/usecase/expense_usecase.go
@@ -23,7 +23,7 @@ type ExpenseUseCase interface {
 	GetExpenseDetails(context.Context) ([]domain.ExpenseDetails, error)
 	GetExpenseDetailByID(context.Context, string) (domain.ExpenseDetails, error)
 	GetExpenseDetailsByPeriod(context.Context, string) ([]domain.ExpenseDetailsByperiod, error)
-	GetExpensesByPeriod(context.Context, string) ([]domain.ExpenseByPeriod, error)
+	GetExpensesByPeriod(context.Context, string) ([]domain.Expense, error)
 }
 
 func NewExpenseUseCase(rep rep.ExpenseRepository) ExpenseUseCase {
@@ -352,25 +352,21 @@ func (e *expenseUseCase) GetExpenseDetailsByPeriod(c context.Context, year strin
 	return expenseDetails, nil
 }
 
-func (e *expenseUseCase) GetExpensesByPeriod(c context.Context, year string) ([]domain.ExpenseByPeriod, error) {
-	ExpenseByperiod := domain.ExpenseByPeriod{}
-	var expenseByperiods []domain.ExpenseByPeriod
-	rows, err := e.rep.AllByPeriod(c, year)
+func (e *expenseUseCase) GetExpensesByPeriod(c context.Context, year string) ([]domain.Expense, error) {
+	ExpenseByperiod := domain.Expense{}
+	var expenseByperiods []domain.Expense
+	rows, err := e.rep.OnlyExpensesByPeriod(c, year)
 	if err != nil {
 		return nil, err
 	}
 	for rows.Next() {
 			err := rows.Scan(
-					&ExpenseByperiod.Expense.ID,
-					&ExpenseByperiod.Expense.Name,
-					&ExpenseByperiod.Expense.TotalPrice,
-					&ExpenseByperiod.Expense.YearID,
-					&ExpenseByperiod.Expense.CreatedAt,
-					&ExpenseByperiod.Expense.UpdatedAt,
-					&ExpenseByperiod.Year.ID,
-					&ExpenseByperiod.Year.Year,
-					&ExpenseByperiod.Year.CreatedAt,
-					&ExpenseByperiod.Year.UpdatedAt,
+					&ExpenseByperiod.ID,
+					&ExpenseByperiod.Name,
+					&ExpenseByperiod.TotalPrice,
+					&ExpenseByperiod.YearID,
+					&ExpenseByperiod.CreatedAt,
+					&ExpenseByperiod.UpdatedAt,
 			)
 			if err != nil {
 					return nil, err

--- a/api/internals/usecase/expense_usecase.go
+++ b/api/internals/usecase/expense_usecase.go
@@ -23,6 +23,7 @@ type ExpenseUseCase interface {
 	GetExpenseDetails(context.Context) ([]domain.ExpenseDetails, error)
 	GetExpenseDetailByID(context.Context, string) (domain.ExpenseDetails, error)
 	GetExpenseDetailsByPeriod(context.Context, string) ([]domain.ExpenseDetailsByperiod, error)
+	GetExpensesByPeriod(context.Context, string) ([]domain.ExpenseByPeriod, error)
 }
 
 func NewExpenseUseCase(rep rep.ExpenseRepository) ExpenseUseCase {
@@ -349,4 +350,35 @@ func (e *expenseUseCase) GetExpenseDetailsByPeriod(c context.Context, year strin
 		expenseDetails = append(expenseDetails, expenseDetail)
 	}
 	return expenseDetails, nil
+}
+
+func (e *expenseUseCase) GetExpensesByPeriod(c context.Context, year string) ([]domain.ExpenseByPeriod, error) {
+	ExpenseByperiod := domain.ExpenseByPeriod{}
+	var expenseByperiods []domain.ExpenseByPeriod
+	rows, err := e.rep.AllByPeriod(c, year)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+			err := rows.Scan(
+					&ExpenseByperiod.Expense.ID,
+					&ExpenseByperiod.Expense.Name,
+					&ExpenseByperiod.Expense.TotalPrice,
+					&ExpenseByperiod.Expense.YearID,
+					&ExpenseByperiod.Expense.CreatedAt,
+					&ExpenseByperiod.Expense.UpdatedAt,
+					&ExpenseByperiod.Year.ID,
+					&ExpenseByperiod.Year.Year,
+					&ExpenseByperiod.Year.CreatedAt,
+					&ExpenseByperiod.Year.UpdatedAt,
+			)
+			if err != nil {
+					return nil, err
+			}
+			expenseByperiods = append(expenseByperiods, ExpenseByperiod)
+	}
+	if err := rows.Err(); err != nil {
+			return nil, err
+	}
+	return expenseByperiods, nil
 }

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -126,6 +126,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.GET("/expenses/details/:year", r.expenseController.IndexExpenseDetailsByPeriod)
 	e.GET("/expenses/:id", r.expenseController.ShowExpense)
 	e.GET("/expenses/:id/details", r.expenseController.ShowExpenseDetail)
+	e.GET("/expenses/fiscalyear/:year", r.expenseController.IndexExpenseByPeriod)
 	e.POST("/expenses", r.expenseController.CreateExpense)
 	e.PUT("/expenses/:id", r.expenseController.UpdateExpense)
 	e.DELETE("/expenses/:id", r.expenseController.DestroyExpense)

--- a/view/next-project/src/components/budgets/DetailModal.tsx
+++ b/view/next-project/src/components/budgets/DetailModal.tsx
@@ -1,11 +1,11 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC } from 'react';
 import { RiCloseCircleLine } from 'react-icons/ri';
 import { Modal } from '@components/common';
 import { ExpenseView } from '@type/common';
 
 interface ModalProps {
   setIsOpen: (isOpen: boolean) => void;
-  expenseView: ExpenseView;
+  expenseView: ExpenseView | null;
 }
 
 const DetailModal: FC<ModalProps> = (props) => {
@@ -13,21 +13,25 @@ const DetailModal: FC<ModalProps> = (props) => {
     props.setIsOpen(false);
   };
 
-  const discountTotal = useMemo(() => {
-    return props.expenseView.purchaseDetails
-      ? props.expenseView.purchaseDetails.reduce((acc, cur) => {
+  const expenseView = props.expenseView;
+
+  if (!expenseView) {
+    onClose();
+    return <></>;
+  }
+
+  const discountTotal =
+    expenseView && expenseView.purchaseDetails
+      ? expenseView.purchaseDetails.reduce((acc, cur) => {
           return acc + cur.purchaseReport.discount;
         }, 0)
       : 0;
-  }, [props.expenseView.purchaseDetails]);
 
-  const additionTotal = useMemo(() => {
-    return props.expenseView.purchaseDetails
-      ? props.expenseView.purchaseDetails.reduce((acc, cur) => {
-          return acc + cur.purchaseReport.addition;
-        }, 0)
-      : 0;
-  }, [props.expenseView.purchaseDetails]);
+  const additionTotal = expenseView.purchaseDetails
+    ? expenseView.purchaseDetails.reduce((acc, cur) => {
+        return acc + cur.purchaseReport.addition;
+      }, 0)
+    : 0;
 
   return (
     <Modal className='w-fit'>
@@ -42,11 +46,11 @@ const DetailModal: FC<ModalProps> = (props) => {
       <div className='my-10 flex flex-wrap justify-center gap-8'>
         <div className='flex gap-3'>
           <p className='text-black-600'>支出元</p>
-          <p className='border-b border-primary-1'>{props.expenseView.expense.name}</p>
+          <p className='border-b border-primary-1'>{expenseView.expense.name}</p>
         </div>
         <div className='flex gap-3'>
           <p className='text-black-600'>合計金額</p>
-          <p className='border-b border-primary-1'>{props.expenseView.expense.totalPrice}</p>
+          <p className='border-b border-primary-1'>{expenseView.expense.totalPrice}</p>
         </div>
         <div className='flex gap-3'>
           <p className='text-black-600'>割引合計</p>
@@ -73,8 +77,8 @@ const DetailModal: FC<ModalProps> = (props) => {
           </tr>
         </thead>
         <tbody className='border border-x-white-0 border-b-primary-1'>
-          {props.expenseView.purchaseDetails ? (
-            props.expenseView.purchaseDetails.map((purchaseDetail) =>
+          {expenseView.purchaseDetails ? (
+            expenseView.purchaseDetails.map((purchaseDetail) =>
               purchaseDetail.purchaseItems.map((purchaseItem) => (
                 <tr key={purchaseItem.id}>
                   <td className='py-3'>

--- a/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
+++ b/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
@@ -2,16 +2,16 @@ import React, { useState } from 'react';
 
 import PurchaseItemNumModal from './PurchaseItemNumModal';
 import { AddButton } from '@components/common';
-import { Expense } from '@type/common';
+import { Expense, ExpenseByPeriods } from '@type/common';
 
 interface Props {
   children?: React.ReactNode;
   expenses: Expense[];
+  expenseByPeriods: ExpenseByPeriods[];
 }
 
 export default function OpenModalButton(props: Props) {
   const [isOpen, setIsOpen] = useState(false);
-
   return (
     <>
       <AddButton
@@ -21,7 +21,13 @@ export default function OpenModalButton(props: Props) {
       >
         {props.children}
       </AddButton>
-      {isOpen && <PurchaseItemNumModal setIsOpen={setIsOpen} expenses={props.expenses} />}
+      {isOpen && (
+        <PurchaseItemNumModal
+          setIsOpen={setIsOpen}
+          expenses={props.expenses}
+          expenseByPeriods={props.expenseByPeriods}
+        />
+      )}
     </>
   );
 }

--- a/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
@@ -4,11 +4,12 @@ import { useRecoilState } from 'recoil';
 import { userAtom } from '@/store/atoms';
 import { CloseButton, Input, Modal, PrimaryButton, Select } from '@components/common';
 import AddModal from '@components/purchaseorders/PurchaseOrderAddModal';
-import { PurchaseItem, PurchaseOrder, Expense } from '@type/common';
+import { PurchaseItem, PurchaseOrder, Expense, ExpenseByPeriods } from '@type/common';
 
 export interface PurchaseItemNumModalProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   expenses: Expense[];
+  expenseByPeriods: ExpenseByPeriods[];
 }
 
 export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
@@ -117,9 +118,9 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
               onChange={formDataHandler('expenseID')}
               className='w-full'
             >
-              {props.expenses.map((data) => (
-                <option key={data.id} value={data.id}>
-                  {data.name}
+              {props.expenseByPeriods.map((data) => (
+                <option key={data.expense.id} value={data.expense.id}>
+                  {data.expense.name}
                 </option>
               ))}
             </Select>

--- a/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
@@ -76,7 +76,7 @@ export default function PurchaseItemNumModal() {
   };
 
   return (
-    <Modal className='mt-32 overflow-scroll md:m-0'>
+    <Modal className='mt-32 overflow-scroll md:m-0 md:h-5/6'>
       <div className={clsx('w-full ')}>
         <div className={clsx('mr-5 grid w-full justify-items-end')}>
           <CloseButton onClick={closeModal} />
@@ -85,10 +85,10 @@ export default function PurchaseItemNumModal() {
       <div className={clsx('mb-10 grid w-full justify-items-center text-xl text-black-600')}>
         購入申請
       </div>
-      <div className={clsx('mb-4 grid grid-cols-12 gap-4')}>
+      <div className={clsx('mb-4 grid h-2/3 grid-cols-12 gap-4 overflow-scroll')}>
         <div className={clsx('col-span-1 grid')} />
         <div className={clsx('col-span-10 grid')}>
-          <div className={clsx('mb-2 w-full overflow-scroll p-5')}>
+          <div className={clsx('mb-2 w-full p-5')}>
             <table className={clsx('w-max table-fixed border-collapse md:w-full')}>
               <thead>
                 <tr

--- a/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
@@ -4,9 +4,16 @@ import { useEffect, useState } from 'react';
 
 import PurchaseReportAddModal from './PurchaseReportAddModal';
 import { get } from '@api/api_methods';
-import { CloseButton, Modal, OutlinePrimaryButton, PrimaryButton, Radio } from '@components/common';
+import {
+  CloseButton,
+  Modal,
+  OutlinePrimaryButton,
+  PrimaryButton,
+  Radio,
+  Select,
+} from '@components/common';
 import { useUI } from '@components/ui/context';
-import { PurchaseOrder, User, PurchaseItem, Expense } from '@type/common';
+import { PurchaseOrder, User, PurchaseItem, Expense, YearPeriod } from '@type/common';
 
 interface PurchaseOrderView {
   purchaseOrder: PurchaseOrder;
@@ -29,9 +36,24 @@ export default function PurchaseItemNumModal() {
   const [purchaseOrderId, setPurchaseOrderId] = useState<number>();
   const [purchaseItemNum, setPurchaseItemNum] = useState<number>(0);
 
+  const date = new Date();
+  const [selectedYear, setSelectedYear] = useState<number>(date.getFullYear());
+  const [yearPeriods, setYearPeriods] = useState<YearPeriod[]>([]);
+  useEffect(() => {
+    const getPurchaseReportsUrl = process.env.CSR_API_URI + '/years/periods';
+    const getPeriods = async () => {
+      const res = await get(getPurchaseReportsUrl);
+      const year = res ? res[res.length - 1].year : date.getFullYear();
+      setSelectedYear(year);
+      setYearPeriods(res);
+    };
+    getPeriods();
+  }, []);
+
   useEffect(() => {
     if (router.isReady) {
-      const getPurchaseOrderViewUrl = process.env.CSR_API_URI + '/purchaseorders/details';
+      const getPurchaseOrderViewUrl =
+        process.env.CSR_API_URI + '/purchaseorders/details/' + String(selectedYear);
       const getExpensesUrl = process.env.CSR_API_URI + '/expenses';
 
       const getPurchaseOrderView = async (url: string) => {
@@ -45,7 +67,7 @@ export default function PurchaseItemNumModal() {
       getPurchaseOrderView(getPurchaseOrderViewUrl);
       getExpenses(getExpensesUrl);
     }
-  }, [router]);
+  }, [router, selectedYear]);
 
   // 日付のフォーマットを変更
   const formatDate = (date: string | undefined) => {
@@ -84,6 +106,27 @@ export default function PurchaseItemNumModal() {
       </div>
       <div className={clsx('mb-10 grid w-full justify-items-center text-xl text-black-600')}>
         購入申請
+      </div>
+      <div className='mb-2 flex w-full justify-items-center'>
+        <div className='mx-auto flex w-1/2 justify-items-center'>
+          <div className='flex w-1/2 items-center justify-center'>
+            <p className=' text-black-600'>年度</p>
+          </div>
+          <div className='w-1/2'>
+            <Select
+              value={selectedYear}
+              onChange={(e) => {
+                setSelectedYear(Number(e.target.value));
+              }}
+            >
+              {yearPeriods.map((yearPeriod) => (
+                <option key={yearPeriod.id} value={yearPeriod.year}>
+                  {yearPeriod.year}年度
+                </option>
+              ))}
+            </Select>
+          </div>
+        </div>
       </div>
       <div className={clsx('mb-4 grid h-2/3 grid-cols-12 gap-4 overflow-scroll')}>
         <div className={clsx('col-span-1 grid')} />

--- a/view/next-project/src/components/purchasereports/PurchaseReportConfirmModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportConfirmModal.tsx
@@ -25,32 +25,17 @@ export default function PurchaseItemNumModal(props: ModalProps) {
     props.setIsOpen(false);
   };
 
-  // 購入報告した物品
-  const [reportedPurchaseItems, setReportedPurchaseItems] = useState<PurchaseItem[]>([]);
-  // 購入報告しない物品
-  const [notReportedPurchaseItems, setNotReportedPurchaseItems] = useState<PurchaseItem[]>([]);
-
   const tableColumns = ['物品名', '単価', '個数', '備考', 'URL'];
 
-  // 購入報告する物品と報告しない物品を仕分け
-  const judgeItems = useCallback(() => {
-    props.formDataList.map((formData: PurchaseItem) => {
-      if (formData.financeCheck) {
-        setReportedPurchaseItems((reportedPurchaseItem) => [...reportedPurchaseItem, formData]);
-      } else {
-        setNotReportedPurchaseItems((notReportedPurchaseItem) => [
-          ...notReportedPurchaseItem,
-          formData,
-        ]);
-      }
-    });
-  }, [props.formDataList, setReportedPurchaseItems, setNotReportedPurchaseItems]);
+  // 購入報告した物品
+  const reportedPurchaseItems = props.formDataList.filter((formData) => {
+    return formData.financeCheck;
+  });
 
-  useEffect(() => {
-    if (router.isReady) {
-      judgeItems();
-    }
-  }, [router, judgeItems]);
+  // 購入報告しない物品
+  const notReportedPurchaseItems = props.formDataList.filter((formData) => {
+    return !formData.financeCheck;
+  });
 
   const PurchaseItemTable = (purchaseItems: PurchaseItem[]) => {
     return (

--- a/view/next-project/src/components/purchasereports/PurchaseReportConfirmModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportConfirmModal.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
 import { RiExternalLinkLine, RiFileCopyLine } from 'react-icons/ri';
 
 import { Modal, PrimaryButton, CloseButton, Tooltip } from '@components/common';

--- a/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
@@ -34,7 +34,7 @@ export default function PurchaseReportItemNumModal() {
 
   const [user] = useRecoilState(userAtom);
   const [expenses, setExpenses] = useState<Expense[]>([]);
-  const [expenseID, setExpenseID] = useState(1);
+  const [expenseID, setExpenseID] = useState(0);
 
   useEffect(() => {
     const getExpenseByPeriodsUrl =
@@ -42,6 +42,7 @@ export default function PurchaseReportItemNumModal() {
     const getExpenses = async () => {
       const res = await get(getExpenseByPeriodsUrl);
       setExpenses(res);
+      setExpenseID(res[0].id);
     };
     getExpenses();
   }, [selectedYear]);
@@ -93,7 +94,7 @@ export default function PurchaseReportItemNumModal() {
       deadline: String(year) + '-' + monthStr + '-' + dayStr,
       userID: user.id,
       financeCheck: false,
-      expenseID: expenseID,
+      expenseID: expenseID || 0,
     };
     const addPurchaseOrderUrl = process.env.CSR_API_URI + '/purchaseorders';
     const postRes = await post(addPurchaseOrderUrl, data);

--- a/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
@@ -42,7 +42,7 @@ export default function PurchaseReportItemNumModal() {
     const getExpenses = async () => {
       const res = await get(getExpenseByPeriodsUrl);
       setExpenses(res);
-      setExpenseID(res[0].id);
+      setExpenseID(res ? res[0].id : null);
     };
     getExpenses();
   }, [selectedYear]);
@@ -157,7 +157,7 @@ export default function PurchaseReportItemNumModal() {
             <div className='col-span-2 flex w-full items-center justify-center'>
               <p className=' text-black-600'>年度</p>
             </div>
-            <div className='col-span-3 w-2/3'>
+            <div className='col-span-3 w-3/4'>
               <Select
                 value={selectedYear}
                 onChange={(e) => {
@@ -174,7 +174,7 @@ export default function PurchaseReportItemNumModal() {
             <div className='col-span-2 flex w-full items-center justify-center'>
               <p className=' text-black-600'>購入した局・団体</p>
             </div>
-            <div className='col-span-3 w-2/3'>
+            <div className='col-span-3 w-3/4'>
               <Select
                 value={expenseID}
                 onChange={(e) => {
@@ -187,6 +187,7 @@ export default function PurchaseReportItemNumModal() {
                       {data.name}
                     </option>
                   ))}
+                {!expenses && <option>局・団体が登録されていません</option>}
               </Select>
             </div>
           </div>
@@ -204,6 +205,7 @@ export default function PurchaseReportItemNumModal() {
             onClick={() => {
               addPurchaseOrder();
             }}
+            disabled={!expenses}
           >
             報告へ進む
           </PrimaryButton>

--- a/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
@@ -14,22 +14,37 @@ import {
 } from '@components/common';
 import PurchaseReportAddModal from '@components/purchasereports/PurchaseReportAddModal';
 import { useUI } from '@components/ui/context';
-import { PurchaseItem, PurchaseOrder, Expense } from '@type/common';
+import { PurchaseItem, PurchaseOrder, Expense, YearPeriod } from '@type/common';
 import { get } from '@utils/api/api_methods';
 
 export default function PurchaseReportItemNumModal() {
+  const date = new Date();
+  const [selectedYear, setSelectedYear] = useState<number>(date.getFullYear());
+  const [yearPeriods, setYearPeriods] = useState<YearPeriod[]>([]);
+  useEffect(() => {
+    const getPurchaseReportsUrl = process.env.CSR_API_URI + '/years/periods';
+    const getPeriods = async () => {
+      const res = await get(getPurchaseReportsUrl);
+      const year = res ? res[res.length - 1].year : date.getFullYear();
+      setSelectedYear(year);
+      setYearPeriods(res);
+    };
+    getPeriods();
+  }, []);
+
   const [user] = useRecoilState(userAtom);
   const [expenses, setExpenses] = useState<Expense[]>([]);
   const [expenseID, setExpenseID] = useState(1);
 
   useEffect(() => {
-    const getExpensesUrl = process.env.CSR_API_URI + '/expenses';
+    const getExpenseByPeriodsUrl =
+      process.env.CSR_API_URI + '/expenses/fiscalyear/' + String(selectedYear);
     const getExpenses = async () => {
-      const res = await get(getExpensesUrl);
+      const res = await get(getExpenseByPeriodsUrl);
       setExpenses(res);
     };
     getExpenses();
-  }, []);
+  }, [selectedYear]);
 
   const { setModalView, openModal, closeModal } = useUI();
 
@@ -137,20 +152,40 @@ export default function PurchaseReportItemNumModal() {
               </PullDown>
             </div>
           </div>
-          <div className='my-10 flex items-center justify-center gap-5'>
-            <p>購入した局・団体</p>
-            <div className='w-1/3'>
+          <div className='my-10 grid grid-cols-5 gap-5'>
+            <div className='col-span-2 flex w-full items-center justify-center'>
+              <p className=' text-black-600'>年度</p>
+            </div>
+            <div className='col-span-3 w-2/3'>
+              <Select
+                value={selectedYear}
+                onChange={(e) => {
+                  setSelectedYear(Number(e.target.value));
+                }}
+              >
+                {yearPeriods.map((yearPeriod) => (
+                  <option key={yearPeriod.id} value={yearPeriod.year}>
+                    {yearPeriod.year}年度
+                  </option>
+                ))}
+              </Select>
+            </div>
+            <div className='col-span-2 flex w-full items-center justify-center'>
+              <p className=' text-black-600'>購入した局・団体</p>
+            </div>
+            <div className='col-span-3 w-2/3'>
               <Select
                 value={expenseID}
                 onChange={(e) => {
                   setExpenseID(Number(e.target.value));
                 }}
               >
-                {expenses.map((data) => (
-                  <option key={data.id} value={data.id}>
-                    {data.name}
-                  </option>
-                ))}
+                {expenses &&
+                  expenses.map((data) => (
+                    <option key={data.id} value={data.id}>
+                      {data.name}
+                    </option>
+                  ))}
               </Select>
             </div>
           </div>

--- a/view/next-project/src/pages/budgets/index.tsx
+++ b/view/next-project/src/pages/budgets/index.tsx
@@ -77,7 +77,7 @@ export default function BudgetList(props: Props) {
     return true;
   }, [currentUser]);
 
-  const [forcusExpense, setForcusExpense] = useState<ExpenseView>(props.expenses[0]);
+  const [forcusExpense, setForcusExpense] = useState<ExpenseView | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const onOpen = (expenseID: number, expenseView: ExpenseView) => {
     setForcusExpense(expenseView);

--- a/view/next-project/src/pages/purchaseorders/index.tsx
+++ b/view/next-project/src/pages/purchaseorders/index.tsx
@@ -21,6 +21,7 @@ import {
   PurchaseOrderView,
   Expense,
   YearPeriod,
+  ExpenseByPeriods,
 } from '@type/common';
 
 interface Props {
@@ -28,6 +29,7 @@ interface Props {
   purchaseOrderView: PurchaseOrderView[];
   expenses: Expense[];
   yearPeriods: YearPeriod[];
+  expenseByPeriods: ExpenseByPeriods[];
 }
 
 const date = new Date();
@@ -42,11 +44,18 @@ export async function getServerSideProps() {
   const getExpenseUrl = process.env.SSR_API_URI + '/expenses';
   const purchaseOrderViewRes = await get(getPurchaseOrderViewUrl);
   const expenseRes = await get(getExpenseUrl);
+  const getExpenseByPeriodsUrl =
+    process.env.SSR_API_URI +
+    '/expenses/fiscalyear/' +
+    (periodsRes ? String(periodsRes[periodsRes.length - 1].year) : String(date.getFullYear()));
+  const expenseByPeriodsRes = await get(getExpenseByPeriodsUrl);
+
   return {
     props: {
       purchaseOrderView: purchaseOrderViewRes,
       expenses: expenseRes,
       yearPeriods: periodsRes,
+      expenseByPeriods: expenseByPeriodsRes,
     },
   };
 }
@@ -172,6 +181,8 @@ export default function PurchaseOrders(props: Props) {
     getUser();
   }, []);
 
+  console.log(props.expenseByPeriods);
+
   return (
     <MainLayout>
       <Head>
@@ -215,7 +226,9 @@ export default function PurchaseOrders(props: Props) {
             </PrimaryButton>
           </div>
           <div className='hidden justify-end md:flex'>
-            <OpenAddModalButton expenses={props.expenses}>申請登録</OpenAddModalButton>
+            <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods}>
+              申請登録
+            </OpenAddModalButton>
           </div>
         </div>
         <div className='w-100 mb-2 overflow-scroll p-5'>
@@ -393,7 +406,7 @@ export default function PurchaseOrders(props: Props) {
         />
       )}
       <div className='fixed bottom-4 right-4 md:hidden'>
-        <OpenAddModalButton expenses={props.expenses} />
+        <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods} />
       </div>
     </MainLayout>
   );

--- a/view/next-project/src/pages/purchasereports/index.tsx
+++ b/view/next-project/src/pages/purchasereports/index.tsx
@@ -189,7 +189,7 @@ export default function PurchaseReports(props: Props) {
       setCurrentUser(res);
     };
     getUser();
-  });
+  }, []);
 
   return (
     <MainLayout>

--- a/view/next-project/src/type/common.ts
+++ b/view/next-project/src/type/common.ts
@@ -67,6 +67,11 @@ export interface ExpenseView {
   ];
 }
 
+export interface ExpenseByPeriods {
+  expense: Expense;
+  year: Year;
+}
+
 // // PurchaseOrder(購入申請)
 export interface PurchaseOrder {
   id?: number;


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #715 

# 概要
<!-- 開発内容の概要を記載 -->
- 購入報告ページで購入していない物品を登録する際に、購入した局・(団体)の選択肢を年度ごとに変更するようにした
- デフォルトは最新年度

# 画面スクリーンショット等
<img width="764" alt="スクリーンショット 2024-03-31 14 20 45" src="https://github.com/NUTFes/FinanSu/assets/115447919/b299ee02-5d8c-4183-b4ba-36c76d4be32a">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 購入報告ページを開く
- 購入報告の登録→申請していない物品を登録
- 年度を切り替えると購入した局・団体が切り替わるか確認する

# 備考
