### PR TITLE
申請登録の購入したい局を年度別で選択できるように修正

### DIFF
--- a/api/internals/domain/expense.go
+++ b/api/internals/domain/expense.go
@@ -29,8 +29,3 @@ type ExpenseDetailsByperiod struct {
 	Year			Year			 `json:"year"`
 	PurchaseDetails []PurchaseDetail `json:"purchaseDetails"`
 }
-
-type ExpenseByPeriod struct {
-	Expense Expense `json:"expense"`
-	Year Year `json:"year"`
-}

--- a/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
+++ b/view/next-project/src/components/purchaseorders/OpenAddModalButton.tsx
@@ -2,12 +2,13 @@ import React, { useState } from 'react';
 
 import PurchaseItemNumModal from './PurchaseItemNumModal';
 import { AddButton } from '@components/common';
-import { Expense, ExpenseByPeriods } from '@type/common';
+import { Expense, YearPeriod } from '@type/common';
 
 interface Props {
   children?: React.ReactNode;
   expenses: Expense[];
-  expenseByPeriods: ExpenseByPeriods[];
+  expenseByPeriods: Expense[];
+  yearPeriods: YearPeriod[];
 }
 
 export default function OpenModalButton(props: Props) {
@@ -26,6 +27,7 @@ export default function OpenModalButton(props: Props) {
           setIsOpen={setIsOpen}
           expenses={props.expenses}
           expenseByPeriods={props.expenseByPeriods}
+          yearPeriods={props.yearPeriods}
         />
       )}
     </>

--- a/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
@@ -62,7 +62,6 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
   });
 
   const [expenseByPeriods, setExpenseByPeriods] = useState<Expense[]>(props.expenseByPeriods);
-  console.log(expenseByPeriods);
 
   const date = new Date();
   const [selectedYear, setSelectedYear] = useState<number>(date.getFullYear());
@@ -73,6 +72,8 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
     const getExpenseByPeriods = async (url: string) => {
       const expenseByPeriodsRes: Expense[] = await get(url);
       setExpenseByPeriods(expenseByPeriodsRes);
+      expenseByPeriodsRes &&
+      setFormData({ ...formData, expenseID: expenseByPeriodsRes[0].id || 1 });
     };
     getExpenseByPeriods(getExpenseByPeriodsUrl);
   }, [selectedYear]);
@@ -178,6 +179,7 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
         </div>
         <div className='mx-auto my-3 w-fit'>
           <PrimaryButton
+            disabled={!expenseByPeriods}
             onClick={() => {
               submit(formData);
               onOpen();

--- a/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
@@ -1,15 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { userAtom } from '@/store/atoms';
+import { get } from '@api/api_methods';
 import { CloseButton, Input, Modal, PrimaryButton, Select } from '@components/common';
 import AddModal from '@components/purchaseorders/PurchaseOrderAddModal';
-import { PurchaseItem, PurchaseOrder, Expense, ExpenseByPeriods } from '@type/common';
+import { PurchaseItem, PurchaseOrder, Expense, YearPeriod } from '@type/common';
 
 export interface PurchaseItemNumModalProps {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   expenses: Expense[];
-  expenseByPeriods: ExpenseByPeriods[];
+  expenseByPeriods: Expense[];
+  yearPeriods: YearPeriod[];
 }
 
 export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
@@ -58,6 +60,22 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
     }
     return initFormDataList;
   });
+
+  const [expenseByPeriods, setExpenseByPeriods] = useState<Expense[]>(props.expenseByPeriods);
+  console.log(expenseByPeriods);
+
+  const date = new Date();
+  const [selectedYear, setSelectedYear] = useState<number>(date.getFullYear());
+  const yearPeriods: YearPeriod[] = props.yearPeriods;
+
+  useEffect(() => {
+    const getExpenseByPeriodsUrl = process.env.CSR_API_URI + '/expenses/fiscalyear/' + selectedYear;
+    const getExpenseByPeriods = async (url: string) => {
+      const expenseByPeriodsRes: Expense[] = await get(url);
+      setExpenseByPeriods(expenseByPeriodsRes);
+    };
+    getExpenseByPeriods(getExpenseByPeriodsUrl);
+  }, [selectedYear]);
 
   // 購入申請用のhandler
   const formDataHandler =
@@ -111,6 +129,22 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
               className='w-full'
             />
           </div>
+          <div className='col-span-1 text-black-600'>年度</div>
+          <div className='col-span-4 w-full'>
+            <Select
+              value={selectedYear}
+              onChange={(e) => {
+                setSelectedYear(Number(e.target.value));
+              }}
+            >
+              {yearPeriods.map((yearPeriod) => (
+                <option key={yearPeriod.id} value={yearPeriod.year}>
+                  {yearPeriod.year}年度
+                </option>
+              ))}
+              {}
+            </Select>
+          </div>
           <p className='grid-cols-1 text-black-600'>購入したい局・団体</p>
           <div className='col-span-4 w-full'>
             <Select
@@ -118,11 +152,13 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
               onChange={formDataHandler('expenseID')}
               className='w-full'
             >
-              {props.expenseByPeriods.map((data) => (
-                <option key={data.expense.id} value={data.expense.id}>
-                  {data.expense.name}
-                </option>
-              ))}
+              {expenseByPeriods &&
+                expenseByPeriods.map((data) => (
+                  <option key={data.id} value={data.id}>
+                    {data.name}
+                  </option>
+                ))}
+              {!expenseByPeriods && <option>局・団体が登録されていません</option>}
             </Select>
           </div>
           <p className='grid-cols-1 text-black-600'>購入物品数</p>

--- a/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
+++ b/view/next-project/src/components/purchaseorders/PurchaseItemNumModal.tsx
@@ -73,7 +73,7 @@ export default function PurchaseItemNumModal(props: PurchaseItemNumModalProps) {
       const expenseByPeriodsRes: Expense[] = await get(url);
       setExpenseByPeriods(expenseByPeriodsRes);
       expenseByPeriodsRes &&
-      setFormData({ ...formData, expenseID: expenseByPeriodsRes[0].id || 1 });
+        setFormData({ ...formData, expenseID: expenseByPeriodsRes[0].id || 1 });
     };
     getExpenseByPeriods(getExpenseByPeriodsUrl);
   }, [selectedYear]);

--- a/view/next-project/src/pages/purchaseorders/index.tsx
+++ b/view/next-project/src/pages/purchaseorders/index.tsx
@@ -21,7 +21,6 @@ import {
   PurchaseOrderView,
   Expense,
   YearPeriod,
-  ExpenseByPeriods,
 } from '@type/common';
 
 interface Props {
@@ -29,7 +28,7 @@ interface Props {
   purchaseOrderView: PurchaseOrderView[];
   expenses: Expense[];
   yearPeriods: YearPeriod[];
-  expenseByPeriods: ExpenseByPeriods[];
+  expenseByPeriods: Expense[];
 }
 
 const date = new Date();
@@ -41,8 +40,8 @@ export async function getServerSideProps() {
     process.env.SSR_API_URI +
     '/purchaseorders/details/' +
     (periodsRes ? String(periodsRes[periodsRes.length - 1].year) : String(date.getFullYear()));
+    const purchaseOrderViewRes = await get(getPurchaseOrderViewUrl);
   const getExpenseUrl = process.env.SSR_API_URI + '/expenses';
-  const purchaseOrderViewRes = await get(getPurchaseOrderViewUrl);
   const expenseRes = await get(getExpenseUrl);
   const getExpenseByPeriodsUrl =
     process.env.SSR_API_URI +
@@ -226,7 +225,7 @@ export default function PurchaseOrders(props: Props) {
             </PrimaryButton>
           </div>
           <div className='hidden justify-end md:flex'>
-            <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods}>
+            <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods} yearPeriods={yearPeriods}>
               申請登録
             </OpenAddModalButton>
           </div>
@@ -406,7 +405,7 @@ export default function PurchaseOrders(props: Props) {
         />
       )}
       <div className='fixed bottom-4 right-4 md:hidden'>
-        <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods} />
+        <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods} yearPeriods={yearPeriods}/>
       </div>
     </MainLayout>
   );

--- a/view/next-project/src/pages/purchaseorders/index.tsx
+++ b/view/next-project/src/pages/purchaseorders/index.tsx
@@ -40,7 +40,7 @@ export async function getServerSideProps() {
     process.env.SSR_API_URI +
     '/purchaseorders/details/' +
     (periodsRes ? String(periodsRes[periodsRes.length - 1].year) : String(date.getFullYear()));
-    const purchaseOrderViewRes = await get(getPurchaseOrderViewUrl);
+  const purchaseOrderViewRes = await get(getPurchaseOrderViewUrl);
   const getExpenseUrl = process.env.SSR_API_URI + '/expenses';
   const expenseRes = await get(getExpenseUrl);
   const getExpenseByPeriodsUrl =
@@ -225,7 +225,11 @@ export default function PurchaseOrders(props: Props) {
             </PrimaryButton>
           </div>
           <div className='hidden justify-end md:flex'>
-            <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods} yearPeriods={yearPeriods}>
+            <OpenAddModalButton
+              expenses={props.expenses}
+              expenseByPeriods={props.expenseByPeriods}
+              yearPeriods={yearPeriods}
+            >
               申請登録
             </OpenAddModalButton>
           </div>
@@ -405,7 +409,11 @@ export default function PurchaseOrders(props: Props) {
         />
       )}
       <div className='fixed bottom-4 right-4 md:hidden'>
-        <OpenAddModalButton expenses={props.expenses} expenseByPeriods={props.expenseByPeriods} yearPeriods={yearPeriods}/>
+        <OpenAddModalButton
+          expenses={props.expenses}
+          expenseByPeriods={props.expenseByPeriods}
+          yearPeriods={yearPeriods}
+        />
       </div>
     </MainLayout>
   );


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #719 

# 概要
<!-- 開発内容の概要を記載 -->
購入申請ページにある申請登録の購入したい局・団体を年度別に選択できるようにしました。
デフォルトは最新年度になっています
それに伴って、新たに**年度**という項目を追加しました
propsにyearPeriodsを渡して処理を行っています

また、api作成時にcommon.tsに不必要な定義をしていて削除し忘れていたので消しました。
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/NUTFes/FinanSu/assets/106811268/4d1ccab0-b282-440c-9719-42b0700029ce)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 購入申請(purchaseorders)に行き、申請登録でスクリーンショットのような画面になっているか
- 年度を切り替えると購入したい局・団体も切り替わるか
- nullの場合、局・団体が登録されていませんと表示されエラーが返ってこないか

# 備考
