### PR TITLE
[feat]購入報告登録のバグ修正

### DIFF
--- a/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseReportItemNumModal.tsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { userAtom } from '@/store/atoms';
-import * as purchaseItemAPI from '@api/purchaseItem';
-import { post } from '@api/purchaseOrder';
 import {
   CloseButton,
   Modal,
@@ -14,7 +12,7 @@ import {
 } from '@components/common';
 import PurchaseReportAddModal from '@components/purchasereports/PurchaseReportAddModal';
 import { useUI } from '@components/ui/context';
-import { PurchaseItem, PurchaseOrder, Expense, YearPeriod } from '@type/common';
+import { PurchaseOrder, Expense, YearPeriod } from '@type/common';
 import { get } from '@utils/api/api_methods';
 
 export default function PurchaseReportItemNumModal() {
@@ -63,73 +61,34 @@ export default function PurchaseReportItemNumModal() {
     value: 1,
   });
   // 購入申請ID
-  const [purchaseOrderId, setPurchaseOrderId] = useState(1);
 
   // 購入物品数用のhandler
   const purchaseItemNumHandler = (input: string) => (e: React.ChangeEvent<HTMLSelectElement>) => {
     setPurchaseItemNum({ ...purchaseItemNum, [input]: e.target.value });
   };
 
-  // 購入報告は購入申請に紐づいているので、購入申請を追加
-  const addPurchaseOrder = async () => {
-    //年・月・日を取得する
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = now.getMonth() + 1;
-    const day = now.getDate();
-    let monthStr = '';
-    let dayStr = '';
-    if (month < 10) {
-      monthStr = '0' + String(month);
-    } else {
-      monthStr = String(month);
-    }
-    if (day < 10) {
-      dayStr = '0' + String(day);
-    } else {
-      dayStr = String(day);
-    }
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth() + 1;
+  const day = now.getDate();
+  let monthStr = '';
+  let dayStr = '';
+  if (month < 10) {
+    monthStr = '0' + String(month);
+  } else {
+    monthStr = String(month);
+  }
+  if (day < 10) {
+    dayStr = '0' + String(day);
+  } else {
+    dayStr = String(day);
+  }
 
-    const data: PurchaseOrder = {
-      deadline: String(year) + '-' + monthStr + '-' + dayStr,
-      userID: user.id,
-      financeCheck: false,
-      expenseID: expenseID || 0,
-    };
-    const addPurchaseOrderUrl = process.env.CSR_API_URI + '/purchaseorders';
-    const postRes = await post(addPurchaseOrderUrl, data);
-    const purchaseOrderID = postRes.id;
-    setPurchaseOrderId(purchaseOrderID);
-
-    // 購入物品数のpurchaseItemのリストを作成
-    const updatePurchaseItemList = [];
-    for (let i = 0; i < Number(purchaseItemNum.value); i++) {
-      const initialPurchaseItem: PurchaseItem = {
-        id: i + 1,
-        item: '',
-        price: 0,
-        quantity: 0,
-        detail: '',
-        url: '',
-        purchaseOrderID: purchaseOrderID,
-        financeCheck: false,
-        createdAt: '',
-        updatedAt: '',
-      };
-      updatePurchaseItemList.push(initialPurchaseItem);
-    }
-    // 購入報告モーダルではすでにある購入物品を更新する処理なので、先に購入物品を登録しておく
-    addPurchaseItem(updatePurchaseItemList);
-  };
-
-  // 購入報告の追加モーダルではPutをするので、ここではPostして購入物品を追加
-  const addPurchaseItem = async (data: PurchaseItem[]) => {
-    data.map(async (item) => {
-      const updatePurchaseItemUrl = process.env.CSR_API_URI + '/purchaseitems';
-      await purchaseItemAPI.post(updatePurchaseItemUrl, item);
-    });
-    // 購入報告の追加モーダルを開く
-    onOpen();
+  const purchaseOrder: PurchaseOrder = {
+    deadline: String(year) + '-' + monthStr + '-' + dayStr,
+    userID: user.id,
+    financeCheck: false,
+    expenseID: expenseID || 0,
   };
 
   return (
@@ -203,7 +162,7 @@ export default function PurchaseReportItemNumModal() {
           </OutlinePrimaryButton>
           <PrimaryButton
             onClick={() => {
-              addPurchaseOrder();
+              onOpen();
             }}
             disabled={!expenses}
           >
@@ -213,11 +172,11 @@ export default function PurchaseReportItemNumModal() {
       </Modal>
       {isOpen && (
         <PurchaseReportAddModal
-          purchaseOrderId={purchaseOrderId}
           purchaseItemNum={purchaseItemNum.value}
           isOpen={isOpen}
           setIsOpen={setIsOpen}
           isOnlyReported={true}
+          purchaseOrder={purchaseOrder}
         />
       )}
     </>


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #722 

# 概要
<!-- 開発内容の概要を記載 -->
- 購入報告の登録の際に、購入報告ページで報告登録→申請していない物品を登録する→報告へ進む
- 物品登録中にリロードをすると、虚無に購入申請と物品が登録されるため、最後にまとめて登録するようにした

# 画面スクリーンショット等
この画面でリロードすると、虚無の申請と物品が登録されていた
<img width="769" alt="スクリーンショット 2024-04-03 11 15 45" src="https://github.com/NUTFes/FinanSu/assets/115447919/3fd04cee-ecb7-4817-9129-fb51c419aebd">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 購入報告ページを開く
- 報告登録→申請していない物品を登録する→報告登録へ進む
- 最後まで登録し、データが問題なく登録できているか確認する
- 購入報告と購入申請と購入物品
- 報告登録→申請していない物品を登録する→報告登録へ進むでページをリロードし、購入申請ページに移動し、虚無の申請が作成されていないか確認する

# 備考
- 購入報告の登録周りを触ってみてバグがないか確認してください
- おかしな点があれば、コメントしてください