### PR TITLE
Fix/yama/733/set default data

### DIFF
--- a/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
@@ -18,8 +18,8 @@ interface FormDateFormat {
 export default function AddPdfDetailModal(props: ModalProps) {
   const today = new Date();
   const yyyy = String(today.getFullYear());
-  const mm = String(today.getMonth() + 1).padStart(2, '0');
-  const dd = String(today.getDate()).padStart(2, '0');
+  const mm = '08';
+  const dd = '30';
   const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
   const toReiwaYear = (year: number) => {
     const reiwaStartYear = 2019;

--- a/view/next-project/src/utils/createSponsoractivitiesReceiptPDF.tsx
+++ b/view/next-project/src/utils/createSponsoractivitiesReceiptPDF.tsx
@@ -176,7 +176,7 @@ const MyDocument = (props: MyDocumentProps) => (
             </Text>
             <View>
               <View style={styles.marginButtom}>
-                <Text>技大祭実行委員</Text>
+                <Text>技大祭実行委員会</Text>
                 <Text>〒940-2137</Text>
                 <Text>新潟県長岡市上富岡町1603-1</Text>
                 <Text>長岡技術科学大学 大学集会施設</Text>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #733

# 概要
<!-- 開発内容の概要を記載 -->
請求日の初期値を8月30日に設定
実行委員→実行委員会に修正

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

![4665a3a9-d174-4355-bcad-5b62bbe189b0](https://github.com/NUTFes/FinanSu/assets/131145590/d565bf10-d32b-4091-8868-fcfc0bcbd1f8)

# テスト項目
<!-- テストしてほしい内容を記載 -->

- `http://localhost:3000/sponsoractivities`にアクセスできる。
- 請求書作成ボタンを押したときに、請求日の初期値が8月30日になっているかを確認する。
- 実行委員→実行委員会の文言に変更されている。

# 備考
