### PR TITLE
Fix/yama/730 make modal responsive

### DIFF
--- a/view/next-project/src/components/common/Modal.tsx
+++ b/view/next-project/src/components/common/Modal.tsx
@@ -14,8 +14,10 @@ export default function Modal(props: Props) {
   return (
     <>
       <div className='fixed inset-0 z-50 flex items-center justify-center overflow-y-auto overflow-x-hidden bg-black-300/50 outline-none focus:outline-none'>
-        <div className={clsx(className)}>{props.children}</div>
-      </div>
+        <div className={clsx(className)} style={{ maxHeight: '90vh', overflowY: 'auto' }}>
+          {props.children}
+        </div>
+      </div>  
     </>
   );
 }

--- a/view/next-project/src/components/common/Modal.tsx
+++ b/view/next-project/src/components/common/Modal.tsx
@@ -17,7 +17,7 @@ export default function Modal(props: Props) {
         <div className={clsx(className)} style={{ maxHeight: '90vh', overflowY: 'auto' }}>
           {props.children}
         </div>
-      </div>  
+      </div>
     </>
   );
 }

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -325,7 +325,7 @@ export default function EditModal(props: ModalProps) {
   );
 
   return (
-    <Modal className='mt-64 md:mt-10 md:w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton

--- a/view/next-project/src/components/sponsoractivities/OpenAddModalButton.tsx
+++ b/view/next-project/src/components/sponsoractivities/OpenAddModalButton.tsx
@@ -18,7 +18,7 @@ export default function OpenModalButton(props: Props) {
   return (
     <>
       <AddButton
-        className='fixed bottom-4 right-4 z-50 md:static md:bottom-auto md:right-auto md:z-auto'
+        className='fixed bottom-4 right-4 md:static md:bottom-auto md:right-auto md:z-auto'
         onClick={() => {
           setIsOpen(true);
         }}

--- a/view/next-project/src/components/sponsoractivities/OpenAddModalButton.tsx
+++ b/view/next-project/src/components/sponsoractivities/OpenAddModalButton.tsx
@@ -18,6 +18,7 @@ export default function OpenModalButton(props: Props) {
   return (
     <>
       <AddButton
+        className='fixed bottom-4 right-4 z-50 md:static md:bottom-auto md:right-auto md:z-auto'
         onClick={() => {
           setIsOpen(true);
         }}

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -410,7 +410,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
   };
 
   return (
-    <Modal className='mt-64 md:mt-10 md:w-1/2'>
+    <Modal className='md:w-1/2'>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -300,16 +300,24 @@ export default function SponsorActivities(props: Props) {
                 CSVダウンロード
               </PrimaryButton>
             </div>
-          </div>
-          <div className='hidden justify-end md:flex '>
-            <OpenModalButton
-              users={props.users}
-              sponsors={sponsors}
-              sponsorStyles={props.sponsorStyles}
-              yearPeriods={yearPeriods}
-            >
-              協賛活動登録
-            </OpenModalButton>
+            <div className='hidden justify-end md:flex '>
+              <OpenModalButton
+                users={props.users}
+                sponsors={sponsors}
+                sponsorStyles={props.sponsorStyles}
+                yearPeriods={yearPeriods}
+              >
+                協賛活動登録
+              </OpenModalButton>
+            </div>
+            <div className='md:hidden'>
+              <OpenModalButton
+                users={props.users}
+                sponsors={props.sponsors}
+                sponsorStyles={props.sponsorStyles}
+                yearPeriods={yearPeriods}
+              />
+            </div>
           </div>
         </div>
         <div className='mb-7 md:hidden'>
@@ -605,14 +613,6 @@ export default function SponsorActivities(props: Props) {
               )}
             </tbody>
           </table>
-        </div>
-        <div className='fixed bottom-4 right-4 md:hidden '>
-          <OpenModalButton
-            users={props.users}
-            sponsors={props.sponsors}
-            sponsorStyles={props.sponsorStyles}
-            yearPeriods={yearPeriods}
-          />
         </div>
       </Card>
       {isOpen && sponsorActivitiesItem && (


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #730 

# 概要
<!-- 開発内容の概要を記載 -->
モーダルを開いた際に、閉じるボタンが押せなくなる問題を修正
モーダルの縦幅を90vhに制限し、以降は内部でスクロールする仕組みに変更しました。
OpenModalButtonにCSSを当てず、AddButtonに直接記述する方式に切り替えました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
|![FireShot Capture 001 - 協賛活動一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/bb7378e8-7747-4cc6-9b9d-7418a4d41e97)|![FireShot Capture 002 - 協賛活動一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/4f06e1ef-b96e-488d-945a-1bd820d2b31f)|
|---|---|

|![FireShot Capture 003 - 協賛活動一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/abb7ca67-8187-488f-beb9-9868ddca6914)|![FireShot Capture 004 - 協賛活動一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/ea27f756-cfd0-4c4e-bda8-fef20183f4ab)|
|---|---|





# テスト項目
<!-- テストしてほしい内容を記載 -->
- `localhost:3000/sponsoractivities`にアクセスできる。
- 編集モーダル・修正モーダル・新規登録のモーダルが画面幅を超過すると、モーダル内部でスクロールできる。
- Z-Indexが正常に働いている。→ ヘッダーと重ならないかどうか。

# 備考
