### PR TITLE
Feat/yama/738/add date input

### DIFF
--- a/view/next-project/src/components/common/Modal.tsx
+++ b/view/next-project/src/components/common/Modal.tsx
@@ -14,7 +14,9 @@ export default function Modal(props: Props) {
   return (
     <>
       <div className='fixed inset-0 z-50 flex items-center justify-center overflow-y-auto overflow-x-hidden bg-black-300/50 outline-none focus:outline-none'>
-        <div className={clsx(className)}>{props.children}</div>
+        <div className={clsx(className)} style={{ maxHeight: '90vh', overflowY: 'auto' }}>
+          {props.children}
+        </div>
       </div>
     </>
   );

--- a/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
@@ -105,7 +105,7 @@ export default function AddPdfDetailModal(props: ModalProps) {
               createSponsoractivitiesPDF(
                 props.sponsorActivitiesViewItem,
                 formatDate(formData.receivedAt),
-                formData.billIssuedAt,
+                formatDate(formData.billIssuedAt),
                 remarks,
               );
               props.setIsOpen(false);
@@ -119,7 +119,7 @@ export default function AddPdfDetailModal(props: ModalProps) {
         <PreviewPDF
           sponsorActivitiesViewItem={props.sponsorActivitiesViewItem}
           date={formatDate(formData.receivedAt)}
-          issuedDate={formData.billIssuedAt}
+          issuedDate={formatDate(formData.billIssuedAt)}
           remarks={remarks}
         />
       </div>

--- a/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
@@ -105,7 +105,7 @@ export default function AddPdfDetailModal(props: ModalProps) {
               createSponsoractivitiesPDF(
                 props.sponsorActivitiesViewItem,
                 formatDate(formData.receivedAt),
-                formatDate(formData.billIssuedAt),
+                formatDate(formData.billIssuedAt, false),
                 remarks,
               );
               props.setIsOpen(false);

--- a/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
@@ -13,6 +13,7 @@ interface ModalProps {
 
 interface FormDateFormat {
   receivedAt: string;
+  billIssuedAt: string;
 }
 
 export default function AddPdfDetailModal(props: ModalProps) {
@@ -39,7 +40,17 @@ export default function AddPdfDetailModal(props: ModalProps) {
     return `令和${reiwaYear}年${month}月${day}日(${weekday})`;
   };
 
-  const [formData, setFormData] = useState<FormDateFormat>({ receivedAt: ymd });
+  const todayFormatted = () => {
+    const today = new Date();
+    return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(
+      today.getDate(),
+    ).padStart(2, '0')}`;
+  };
+
+  const [formData, setFormData] = useState<FormDateFormat>({
+    receivedAt: ymd,
+    billIssuedAt: todayFormatted(),
+  });
   const [remarks, setRemarks] = useState('');
 
   const handler =
@@ -66,14 +77,22 @@ export default function AddPdfDetailModal(props: ModalProps) {
           振込締め切り日・備考の入力
         </p>
         <div className='col-span-4 w-full'>
+          <p className='text-gray-600 mb-3 ml-1 text-sm'>請求書発行日</p>
+          <Input
+            type='date'
+            value={formData.billIssuedAt}
+            onChange={handler('billIssuedAt')}
+            className='mb-3 w-full'
+          />
+          <p className='text-gray-600 mb-3 ml-1 text-sm'>振込締め切り日</p>
           <Input
             type='date'
             value={formData.receivedAt}
             onChange={handler('receivedAt')}
             className='mb-3 w-full'
           />
+          <p className='text-gray-600 mb-3 ml-1 text-sm'>備考を入力</p>
           <Input
-            placeholder='備考を入力'
             type='text'
             value={remarks}
             onChange={handleRemarksChange}
@@ -86,6 +105,7 @@ export default function AddPdfDetailModal(props: ModalProps) {
               createSponsoractivitiesPDF(
                 props.sponsorActivitiesViewItem,
                 formatDate(formData.receivedAt),
+                formData.billIssuedAt,
                 remarks,
               );
               props.setIsOpen(false);
@@ -99,6 +119,7 @@ export default function AddPdfDetailModal(props: ModalProps) {
         <PreviewPDF
           sponsorActivitiesViewItem={props.sponsorActivitiesViewItem}
           date={formatDate(formData.receivedAt)}
+          issuedDate={formData.billIssuedAt}
           remarks={remarks}
         />
       </div>

--- a/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/AddPdfDetailModal.tsx
@@ -32,12 +32,12 @@ export default function AddPdfDetailModal(props: ModalProps) {
   };
   const ymd = `${yyyy}-${mm}-${dd}`;
 
-  const formatDate = (date: string) => {
+  const formatDate = (date: string, showWeekday = true) => {
     const [year, month, day] = date.split('-').map(Number);
     const dateObj = new Date(year, month - 1, day);
     const reiwaYear = toReiwaYear(year);
     const weekday = getWeekday(dateObj);
-    return `令和${reiwaYear}年${month}月${day}日(${weekday})`;
+    return `令和${reiwaYear}年${month}月${day}日${showWeekday ? `(${weekday})` : ''}`;
   };
 
   const todayFormatted = () => {
@@ -119,7 +119,7 @@ export default function AddPdfDetailModal(props: ModalProps) {
         <PreviewPDF
           sponsorActivitiesViewItem={props.sponsorActivitiesViewItem}
           date={formatDate(formData.receivedAt)}
-          issuedDate={formatDate(formData.billIssuedAt)}
+          issuedDate={formatDate(formData.billIssuedAt, false)}
           remarks={remarks}
         />
       </div>

--- a/view/next-project/src/utils/createSponsoractivitiesReceiptPDF.tsx
+++ b/view/next-project/src/utils/createSponsoractivitiesReceiptPDF.tsx
@@ -134,6 +134,7 @@ interface MyDocumentProps {
   sponsorActivitiesViewItem: SponsorActivityView;
   totalPrice: number;
   date: string;
+  issuedDate: string;
   remarks: string;
   formatDate: (date: string) => string;
 }
@@ -170,10 +171,7 @@ const MyDocument = (props: MyDocumentProps) => (
             </View>
           </View>
           <View>
-            <Text style={styles.marginButtom}>
-              請求日 :{' '}
-              {props.formatDate(props.sponsorActivitiesViewItem.sponsorActivity.createdAt || '')}
-            </Text>
+            <Text style={styles.marginButtom}>請求日 :{props.issuedDate}</Text>
             <View>
               <View style={styles.marginButtom}>
                 <Text>技大祭実行委員会</Text>
@@ -261,6 +259,7 @@ const formatDate = (datetime: string) => {
 export const createSponsoractivitiesPDF = async (
   sponsorActivitiesViewItem: SponsorActivityView,
   date: string,
+  issuedDate: string,
   remarks: string,
 ) => {
   const asPdf = pdf(
@@ -268,6 +267,7 @@ export const createSponsoractivitiesPDF = async (
       sponsorActivitiesViewItem={sponsorActivitiesViewItem}
       totalPrice={CalculateTotalPrice(sponsorActivitiesViewItem)}
       date={date}
+      issuedDate={issuedDate}
       remarks={remarks}
       formatDate={formatDate}
     />,
@@ -285,18 +285,21 @@ export const createSponsoractivitiesPDF = async (
 interface PreviewProps {
   sponsorActivitiesViewItem: SponsorActivityView;
   date: string;
+  issuedDate: string;
   remarks: string;
 }
 
 export const PreviewPDF: React.FC<PreviewProps> = ({
   sponsorActivitiesViewItem,
   date,
+  issuedDate,
   remarks,
 }) => (
   <PDFViewer style={{ width: '100vw', height: '100vh' }} showToolbar={false}>
     <MyDocument
       sponsorActivitiesViewItem={sponsorActivitiesViewItem}
       date={date}
+      issuedDate={issuedDate}
       remarks={remarks}
       totalPrice={CalculateTotalPrice(sponsorActivitiesViewItem)}
       formatDate={formatDate}

--- a/view/next-project/src/utils/createSponsoractivitiesReceiptPDF.tsx
+++ b/view/next-project/src/utils/createSponsoractivitiesReceiptPDF.tsx
@@ -171,7 +171,7 @@ const MyDocument = (props: MyDocumentProps) => (
             </View>
           </View>
           <View>
-            <Text style={styles.marginButtom}>請求日 :{props.issuedDate}</Text>
+            <Text style={styles.marginButtom}>請求日 : {props.issuedDate}</Text>
             <View>
               <View style={styles.marginButtom}>
                 <Text>技大祭実行委員会</Text>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #738 

# 概要
<!-- 開発内容の概要を記載 -->
協賛活動一覧ページにおいて作成される請求書の発行日が作成当日でない & 変更がかけられない問題の修正

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![FireShot Capture 009 - 協賛活動一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/7e50baab-eff9-4940-a40a-a0349a9171a9)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- `localhost:3000/sponsoractivities`にアクセスし、請求書作成モーダルを開くことができる。
- 請求書の発行日の初期値が作成当日になっている。
- 請求書の発行日を任意の日付に変更できる。

# 備考
