### PR TITLE
協賛活動の企業のドロップダウンに企業の検索機能を追加した

### DIFF
--- a/view/next-project/src/components/common/MultiSelect/MultiSelect.tsx
+++ b/view/next-project/src/components/common/MultiSelect/MultiSelect.tsx
@@ -10,10 +10,15 @@ interface MultiSelectProps {
   options: Option[];
   values?: Option[];
   onChange: (value: Option[]) => void;
-  placeholder?: string
+  placeholder?: string;
 }
 
-const MultiSelect: React.FC<MultiSelectProps> = ({ options, onChange, values = [options[0]], placeholder }) => {
+const MultiSelect: React.FC<MultiSelectProps> = ({
+  options,
+  onChange,
+  values = [options[0]],
+  placeholder,
+}) => {
   const [selected, setSelected] = useState<{ value: string; label: string }[]>(values);
 
   return (

--- a/view/next-project/src/components/common/MultiSelect/MultiSelect.tsx
+++ b/view/next-project/src/components/common/MultiSelect/MultiSelect.tsx
@@ -10,9 +10,10 @@ interface MultiSelectProps {
   options: Option[];
   values?: Option[];
   onChange: (value: Option[]) => void;
+  placeholder?: string
 }
 
-const MultiSelect: React.FC<MultiSelectProps> = ({ options, onChange, values = [options[0]] }) => {
+const MultiSelect: React.FC<MultiSelectProps> = ({ options, onChange, values = [options[0]], placeholder }) => {
   const [selected, setSelected] = useState<{ value: string; label: string }[]>(values);
 
   return (
@@ -20,6 +21,7 @@ const MultiSelect: React.FC<MultiSelectProps> = ({ options, onChange, values = [
       isMulti
       options={options}
       value={selected}
+      placeholder={placeholder}
       onChange={(_, actionMeta) => {
         switch (actionMeta.action) {
           case 'select-option':

--- a/view/next-project/src/components/common/SearchSelect/SearchSelect.tsx
+++ b/view/next-project/src/components/common/SearchSelect/SearchSelect.tsx
@@ -11,9 +11,16 @@ interface SearchSelectProps {
   value?: Option;
   onChange?: (value: Option) => void;
   setID?: Dispatch<SetStateAction<string>>;
+  noOptionMessage?: string;
 }
 
-const SearchSelect: React.FC<SearchSelectProps> = ({ options, value, onChange, setID }) => {
+const SearchSelect: React.FC<SearchSelectProps> = ({
+  options,
+  value,
+  onChange,
+  setID,
+  noOptionMessage,
+}) => {
   const [selected, setSelected] = useState<Option | null>(value || (options && options[0]) || null);
 
   useEffect(() => {
@@ -24,6 +31,7 @@ const SearchSelect: React.FC<SearchSelectProps> = ({ options, value, onChange, s
     <Select
       options={options}
       value={selected}
+      noOptionsMessage={() => noOptionMessage}
       onChange={(option, actionMeta) => {
         switch (actionMeta.action) {
           case 'select-option':

--- a/view/next-project/src/components/common/SearchSelect/SearchSelect.tsx
+++ b/view/next-project/src/components/common/SearchSelect/SearchSelect.tsx
@@ -1,0 +1,54 @@
+import { Dispatch, useEffect, useState, SetStateAction } from 'react';
+import Select from 'react-select';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface SearchSelectProps {
+  options?: Option[];
+  value?: Option;
+  onChange?: (value: Option) => void;
+  setID?: Dispatch<SetStateAction<string>>;
+}
+
+const SearchSelect: React.FC<SearchSelectProps> = ({ options, value, onChange, setID }) => {
+  const [selected, setSelected] = useState<Option | null>(value || (options && options[0]) || null);
+
+  useEffect(() => {
+    setSelected(value || (options && options[0]) || null);
+  }, [options]);
+
+  return (
+    <Select
+      options={options}
+      value={selected}
+      onChange={(option, actionMeta) => {
+        switch (actionMeta.action) {
+          case 'select-option':
+            if (option) {
+              setSelected(option);
+              setID && setID(option?.value || '0');
+            }
+            break;
+          case 'remove-value':
+          case 'pop-value':
+            if (actionMeta.removedValue) {
+              setSelected(null);
+              setID && setID('');
+            }
+            break;
+          case 'clear':
+            setSelected(null);
+            setID && setID('');
+            break;
+          default:
+            break;
+        }
+      }}
+    />
+  );
+};
+
+export default SearchSelect;

--- a/view/next-project/src/components/common/SearchSelect/SearchSelect.tsx
+++ b/view/next-project/src/components/common/SearchSelect/SearchSelect.tsx
@@ -12,6 +12,7 @@ interface SearchSelectProps {
   onChange?: (value: Option) => void;
   setID?: Dispatch<SetStateAction<string>>;
   noOptionMessage?: string;
+  placeholder?: string;
 }
 
 const SearchSelect: React.FC<SearchSelectProps> = ({
@@ -20,6 +21,7 @@ const SearchSelect: React.FC<SearchSelectProps> = ({
   onChange,
   setID,
   noOptionMessage,
+  placeholder,
 }) => {
   const [selected, setSelected] = useState<Option | null>(value || (options && options[0]) || null);
 
@@ -32,6 +34,7 @@ const SearchSelect: React.FC<SearchSelectProps> = ({
       options={options}
       value={selected}
       noOptionsMessage={() => noOptionMessage}
+      placeholder={placeholder}
       onChange={(option, actionMeta) => {
         switch (actionMeta.action) {
           case 'select-option':

--- a/view/next-project/src/components/common/SearchSelect/index.ts
+++ b/view/next-project/src/components/common/SearchSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SearchSelect';

--- a/view/next-project/src/components/common/index.ts
+++ b/view/next-project/src/components/common/index.ts
@@ -25,3 +25,4 @@ export { default as BureauLabel } from './BureauLabel';
 export { default as Header } from './Header';
 export { default as SideNav } from './SideNav';
 export { default as MultiSelect } from './MultiSelect/MultiSelect';
+export { default as SearchSelect } from './SearchSelect';

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -236,6 +236,7 @@ export default function EditModal(props: ModalProps) {
           options={sponsorOptions || undefined}
           setID={setFormDataSponsorID}
           noOptionMessage={NO_SPONSORS_MESSAGE}
+          placeholder={NO_SPONSORS_MESSAGE}
           value={
             (sponsorOptions &&
               sponsorOptions.filter((option) => {
@@ -249,6 +250,7 @@ export default function EditModal(props: ModalProps) {
       <div className='col-span-4 w-full'>
         <MultiSelect
           options={styleOotions}
+          placeholder={'協賛スタイルが登録されていません'}
           values={
             selectedStyleIds
               ? styleOotions.filter((option) => selectedStyleIds.includes(Number(option.value)))

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -12,7 +12,7 @@ import {
   Input,
   Textarea,
 } from '@components/common';
-import { MultiSelect } from '@components/common';
+import { MultiSelect, SearchSelect } from '@components/common';
 import { BUREAUS } from '@constants/bureaus';
 import { DESIGNER_VALUES } from '@constants/designers';
 import {
@@ -46,6 +46,7 @@ export default function EditModal(props: ModalProps) {
 
   // 協賛企業のリスト
   const [formData, setFormData] = useState<SponsorActivity>(props.sponsorActivity);
+  const [formDataSponsorID, setFormDataSponsorID] = useState<string>(String(formData.sponsorID));
   const [selectedYear, setSelectedYear] = useState<string>(props.year);
   const [sponsors, setSponsors] = useState<Sponsor[]>(props.sponsors || []);
 
@@ -194,6 +195,22 @@ export default function EditModal(props: ModalProps) {
     return res;
   }, [bureauId]);
 
+  const sponsorOptions = useMemo(() => {
+    const options = sponsors
+      ? sponsors.map((sponsor) => {
+          return { value: String(sponsor?.id) || '', label: sponsor.name };
+        })
+      : null;
+
+    return options;
+  }, [sponsors]);
+
+  useEffect(() => {
+    setFormData({ ...formData, sponsorID: Number(formDataSponsorID) });
+  }, [formDataSponsorID]);
+
+  const NO_SPONSORS_MESSAGE = '企業が登録されていません';
+
   // 協賛企業の情報
   const content = (data: SponsorActivity) => (
     <div className='my-4 grid grid-cols-5 items-center justify-items-center gap-2'>
@@ -215,15 +232,18 @@ export default function EditModal(props: ModalProps) {
       </div>
       <p className='text-black-600'>企業名</p>
       <div className='col-span-4 w-full'>
-        <Select className='w-full' onChange={handler('sponsorID')} value={data.sponsorID}>
-          {sponsors &&
-            sponsors.map((sponsor) => (
-              <option key={sponsor.id} value={sponsor.id}>
-                {sponsor.name}
-              </option>
-            ))}
-          {!sponsors && <option>企業が登録されていません</option>}
-        </Select>
+        <SearchSelect
+          options={sponsorOptions || undefined}
+          setID={setFormDataSponsorID}
+          noOptionMessage={NO_SPONSORS_MESSAGE}
+          value={
+            (sponsorOptions &&
+              sponsorOptions.filter((option) => {
+                return option.value === formDataSponsorID;
+              })[0]) ||
+            undefined
+          }
+        />
       </div>
       <p className='text-black-600'>協賛スタイル</p>
       <div className='col-span-4 w-full'>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import React, { useState, useEffect, useMemo } from 'react';
 import { RiArrowDropRightLine } from 'react-icons/ri';
 import { get, post } from '@/utils/api/api_methods';
-import { MultiSelect } from '@components/common';
+import { MultiSelect, SearchSelect } from '@components/common';
 
 import {
   CloseButton,
@@ -54,6 +54,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
     expense: 0,
     remark: '',
   });
+  const [formDataSponsorID, setFormDataSponsorID] = useState<string>(String(formData.sponsorID));
 
   const setDesign = (e: React.ChangeEvent<HTMLInputElement>) => {
     const remarkOption = formData.feature === 'クーポン' ? REMARK_COUPON : '';
@@ -138,6 +139,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
     });
   };
 
+  //react-selectのmulti-select用のオプション作成
   const styleOotions = useMemo(() => {
     const options = sponsorStyles.map((style) => {
       return {
@@ -177,9 +179,25 @@ export default function SponsorActivitiesAddModal(props: Props) {
     setSponsors(getSponsorsByYears);
   };
 
+  const sponsorOptions = useMemo(() => {
+    const options = sponsors
+      ? sponsors.map((sponsor) => {
+          return { value: String(sponsor?.id) || '', label: sponsor.name };
+        })
+      : null;
+
+    return options;
+  }, [sponsors]);
+
   useEffect(() => {
     getSponsors();
   }, [selectedYear]);
+
+  useEffect(() => {
+    setFormData({ ...formData, sponsorID: Number(formDataSponsorID) });
+  }, [formDataSponsorID]);
+
+  const NO_SPONSORS_MESSAGE = '企業が登録されていません';
 
   // 協賛活動の情報
   const content = (data: SponsorActivity) => (
@@ -202,15 +220,11 @@ export default function SponsorActivitiesAddModal(props: Props) {
       </div>
       <p className='text-black-600'>協賛企業</p>{' '}
       <div className='col-span-4 w-full'>
-        <Select value={data.sponsorID} onChange={formDataHandler('sponsorID')}>
-          {sponsors &&
-            sponsors.map((sponsor: Sponsor) => (
-              <option key={sponsor.id} value={sponsor.id}>
-                {sponsor.name}
-              </option>
-            ))}
-          {!sponsors && <option>企業が登録されていません</option>}
-        </Select>
+        <SearchSelect
+          options={sponsorOptions || undefined}
+          setID={setFormDataSponsorID}
+          noOptionMessage={NO_SPONSORS_MESSAGE}
+        />
       </div>
       <p className='text-black-600'>協賛スタイル</p>
       <div className='col-span-4 w-full'>

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -224,12 +224,14 @@ export default function SponsorActivitiesAddModal(props: Props) {
           options={sponsorOptions || undefined}
           setID={setFormDataSponsorID}
           noOptionMessage={NO_SPONSORS_MESSAGE}
+          placeholder={NO_SPONSORS_MESSAGE}
         />
       </div>
       <p className='text-black-600'>協賛スタイル</p>
       <div className='col-span-4 w-full'>
         <MultiSelect
           options={styleOotions}
+          placeholder={'協賛スタイルが登録されていません'}
           onChange={(value) => {
             setSelectedStyleIds(value.map((v) => Number(v.value)));
           }}

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -300,25 +300,25 @@ export default function SponsorActivities(props: Props) {
                 CSVダウンロード
               </PrimaryButton>
             </div>
-            <div className='hidden justify-end md:flex '>
-              <OpenModalButton
-                users={props.users}
-                sponsors={sponsors}
-                sponsorStyles={props.sponsorStyles}
-                yearPeriods={yearPeriods}
-              >
-                協賛活動登録
-              </OpenModalButton>
-            </div>
-            <div className='md:hidden'>
-              <OpenModalButton
-                users={props.users}
-                sponsors={props.sponsors}
-                sponsorStyles={props.sponsorStyles}
-                yearPeriods={yearPeriods}
-              />
-            </div>
           </div>
+        </div>
+        <div className='hidden justify-end md:flex'>
+          <OpenModalButton
+            users={props.users}
+            sponsors={sponsors}
+            sponsorStyles={props.sponsorStyles}
+            yearPeriods={yearPeriods}
+          >
+            協賛活動登録
+          </OpenModalButton>
+        </div>
+        <div className='md:hidden'>
+          <OpenModalButton
+            users={props.users}
+            sponsors={props.sponsors}
+            sponsorStyles={props.sponsorStyles}
+            yearPeriods={yearPeriods}
+          />
         </div>
         <div className='mb-7 md:hidden'>
           {sortedAndFilteredSponsorActivitiesViews &&


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #743 

# 概要
<!-- 開発内容の概要を記載 -->
- 協賛企業の増加に伴い、optionを選ぶことが大変になっているため、ドロップダウンに検索機能を追加した。
- react-selectがデフォルトで検索機能がついているため、selectタグを移行した。
- 協賛活動の登録と編集で実装した。
- 検索は文字列の部分一致である

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![スクリーンショット 2024-05-15 14 55 26](https://github.com/NUTFes/FinanSu/assets/115447919/f641f941-671a-4b32-960b-1a92b31a9e87)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 協賛活動の登録と編集で企業の検索ができるか確認する
- [x] 協賛活動の登録が正しいか確認する
- [x] 協賛活動の編集が正しくできる確認する
- [x] 年度などを変更してみて、企業の選択肢が正しい確認する

# 備考
