### PR TITLE
協賛活動、学内募金の表示をupdated_atの降順にした

### DIFF
--- a/api/externals/repository/activity_repository.go
+++ b/api/externals/repository/activity_repository.go
@@ -181,7 +181,7 @@ func (ar *activityRepository) AllDetailsByPeriod(c context.Context, year string)
 		year_periods.year_id = years.id
 	WHERE
 		years.year = ` + year +
-		" ORDER BY activities.id"
+		" ORDER BY activities.updated_at DESC"
 
 	return ar.crud.Read(c, query)
 }

--- a/api/externals/repository/fund_information_repository.go
+++ b/api/externals/repository/fund_information_repository.go
@@ -198,6 +198,6 @@ func (fir *fundInformationRepository) AllDetailsByPeriod(c context.Context, year
 			year_periods.year_id = years.id
 		WHERE
 			years.year = ` + year +
-			" ORDER BY fund_informations.id;"
+			" ORDER BY fund_informations.updated_at DESC;"
 	return fir.crud.Read(c, query)
 }

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -144,17 +144,6 @@ export default function SponsorActivities(props: Props) {
     }
 
     switch (selectedSort) {
-      case 'createDesSort':
-        if (!Array.isArray(filteredActivities)) {
-          return [];
-        }
-        return [...filteredActivities].sort(
-          (firstObject: SponsorActivityView, secondObject: SponsorActivityView) =>
-            new Date(firstObject.sponsorActivity.createdAt || 0).getTime() >
-            new Date(secondObject.sponsorActivity.createdAt || 0).getTime()
-              ? -1
-              : 1,
-        );
       case 'updateSort':
         if (!Array.isArray(filteredActivities)) {
           return [];
@@ -166,14 +155,25 @@ export default function SponsorActivities(props: Props) {
               ? 1
               : -1,
         );
-      case 'updateDesSort':
+      case 'createSort':
         if (!Array.isArray(filteredActivities)) {
           return [];
         }
         return [...filteredActivities].sort(
           (firstObject: SponsorActivityView, secondObject: SponsorActivityView) =>
-            new Date(firstObject.sponsorActivity.updatedAt || 0).getTime() >
-            new Date(secondObject.sponsorActivity.updatedAt || 0).getTime()
+            new Date(firstObject.sponsorActivity.createdAt || 0).getTime() <
+            new Date(secondObject.sponsorActivity.createdAt || 0).getTime()
+              ? -1
+              : 1,
+        );
+      case 'createDesSort':
+        if (!Array.isArray(filteredActivities)) {
+          return [];
+        }
+        return [...filteredActivities].sort(
+          (firstObject: SponsorActivityView, secondObject: SponsorActivityView) =>
+            new Date(firstObject.sponsorActivity.createdAt || 0).getTime() >
+            new Date(secondObject.sponsorActivity.createdAt || 0).getTime()
               ? -1
               : 1,
         );
@@ -278,12 +278,12 @@ export default function SponsorActivities(props: Props) {
                 defaultValue={'default'}
                 onChange={(e) => setSelectedSort(e.target.value)}
               >
-                <option value='default'>作成日時昇順</option>
-                <option value='createDesSort'>作成日時降順</option>
+                <option value='default'>更新日時降順</option>
                 <option value='updateSort'>更新日時昇順</option>
-                <option value='updateDesSort'>更新日時降順</option>
-                <option value='priceSort'>協賛金昇順</option>
+                <option value='createDesSort'>作成日時降順</option>
+                <option value='createSort'>作成日時昇順</option>
                 <option value='priceDesSort'>協賛金降順</option>
+                <option value='priceSort'>協賛金昇順</option>
               </select>
               <PrimaryButton
                 className='hidden md:block'


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #782

# 概要
<!-- 開発内容の概要を記載 -->
デフォルトの表示を降順にするためにsql文のorder byをidからupdated_at DESCに変更した。
ps.協賛活動のフィルターのデフォルトが作成日時昇順になっていたため下記の順番に変更した

> 更新日時降順
>  更新日時昇順
> 作成日時降順
> 作成日時昇順
> 協賛金降順
> 協賛金昇順

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- activity,fund_infomationのデータが降順で取得されているか
- ps.協賛活動のフィルターが正常に動作しているか
-

# 備考
協賛活動のフィルターがの作成日時の昇順降順動いてないかも修正します。→しました