### PR TITLE
Feat/kobayashi/creatingstories file/common

### DIFF
--- a/view/next-project/src/components/common/index.ts
+++ b/view/next-project/src/components/common/index.ts
@@ -10,6 +10,7 @@ export { default as EditButton } from './EditButton';
 export { default as Input } from './Input';
 export { default as Modal } from './Modal';
 export { default as OutlinePrimaryButton } from './OutlinePrimaryButton';
+export { default as OpenModalButton } from './OpenModalButton';
 export { default as PrimaryButton } from './PrimaryButton';
 export { default as PullDown } from './PullDown';
 export { default as Radio } from './Radio';

--- a/view/next-project/src/components/common/index.ts
+++ b/view/next-project/src/components/common/index.ts
@@ -15,6 +15,7 @@ export { default as PrimaryButton } from './PrimaryButton';
 export { default as PullDown } from './PullDown';
 export { default as Radio } from './Radio';
 export { default as RedButton } from './RedButton';
+export { default as RegistButton } from './RegistButton';
 export { default as Select } from './Select';
 export { default as Stepper } from './Stepper';
 export { default as Textarea } from './Textarea';

--- a/view/next-project/src/components/common/index.ts
+++ b/view/next-project/src/components/common/index.ts
@@ -23,6 +23,7 @@ export { default as Title } from './Title';
 export { default as Tooltip } from './Tooltip';
 export { default as UnderlinePrimaryButton } from './UnderlinePrimaryButton';
 export { default as Label } from './Label';
+export { default as LoadingButton } from './LoadingButton';
 export { default as BureauLabel } from './BureauLabel';
 export { default as Header } from './Header';
 export { default as SideNav } from './SideNav';

--- a/view/next-project/src/stories/EditButton.stories.tsx
+++ b/view/next-project/src/stories/EditButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { EditButton } from '@components/common';
+
+const meta: Meta<typeof EditButton> = {
+  title: 'FinanSu/EditButton',
+  component: EditButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/LoadingButton.stories.tsx
+++ b/view/next-project/src/stories/LoadingButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { LoadingButton } from '@components/common';
+
+const meta: Meta<typeof LoadingButton> = {
+  title: 'FinanSu/LoadingButton',
+  component: LoadingButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/OpenModalButton.stories.tsx
+++ b/view/next-project/src/stories/OpenModalButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { OpenModalButton } from '@components/common';
+
+const meta: Meta<typeof OpenModalButton> = {
+  title: 'FinanSu/OpenModalButton',
+  component: OpenModalButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/RegistButton.stories.tsx
+++ b/view/next-project/src/stories/RegistButton.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta } from '@storybook/react';
+import { RegistButton } from '@components/common';
+const meta: Meta<typeof RegistButton> = {
+  title: 'FinanSu/RegistButton',
+  component: RegistButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/SideNav.stories.tsx
+++ b/view/next-project/src/stories/SideNav.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { SideNav } from '@components/common';
+
+const meta: Meta<typeof SideNav> = {
+  title: 'FinanSu/SideNav',
+  component: SideNav,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/Stepper.stories.tsx
+++ b/view/next-project/src/stories/Stepper.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { Stepper } from '@components/common';
+
+const meta: Meta<typeof Stepper> = {
+  title: 'FinanSu/Stepper',
+  component: Stepper,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/Title.stories.tsx
+++ b/view/next-project/src/stories/Title.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { Title } from '@components/common';
+
+const meta: Meta<typeof Title> = {
+  title: 'FinanSu/Title',
+  component: Title,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->

<!-- 対応したIssue番号を記載 -->
resolve #786 

# 概要
<!-- 開発内容の概要を記載 -->
FinanSuでしようしているコンポーネントをStorybook上で表示できるようにする
今回は`FinanSu/view/next-project/src/components/common`の中に直接配置されていたコンポーネントに対応した.storiesファイルを作る。

今回作成したファイルは以下の通り。
- EditButton.tsx
- LoadingButton.tsx
- OpenModalButton.tsx
- RegistButton.tsx
- SideNav.tsx
- Stepper.tsx
- Title.tsx


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="289" alt="image" src="https://github.com/NUTFes/FinanSu/assets/66411240/44b6ad4a-44a4-43bf-97d3-64e483d57488">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- storybook上で今回追加したファイルを表示できるか
- 現状のFinanSuのフロントエンドに問題が生じるような変更がないか

# 備考
- commonの中でも以下のファイルは.storiesファイルを作ってません。
　- ChakraUlDropdown.tsx
　- RegistModal.tsx