### PR TITLE
既存コンポーネントをStorybookに表示する（/fund_information）

### DIFF
--- a/view/next-project/src/components/fund_information/index.ts
+++ b/view/next-project/src/components/fund_information/index.ts
@@ -1,0 +1,6 @@
+export { default as AddModal } from './AddModal';
+export { default as DeleteModal } from './DeleteModal';
+export { default as EditModal } from './EditModal';
+export { default as OpenAddModalButton } from './OpenAddModalButton';
+export { default as OpenDeleteModalButton } from './OpenDeleteModalButton';
+export { default as OpenEditModalButton } from './OpenEditModalButton';

--- a/view/next-project/src/stories/AddModal.stories.tsx
+++ b/view/next-project/src/stories/AddModal.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import { Meta } from '@storybook/react';
 import React from 'react';
 import { RecoilRoot } from 'recoil';
@@ -5,7 +6,7 @@ import AddModal from '../components/fund_information/AddModal';
 
 // Add your required props here for testing
 const sampleProps = {
-  setShowModal: () => {},
+  setShowModal: action('setShowModal'),
   teachers: [], // Add sample data as needed
   departments: [], // Add sample data as needed
   users: [], // Add sample data as needed
@@ -26,7 +27,7 @@ export const Primary = {
     ...sampleProps,
   },
   decorators: [
-    (Story) => (
+    (Story: React.ComponentType) => (
       <RecoilRoot>
         <Story />
       </RecoilRoot>

--- a/view/next-project/src/stories/AddModal.stories.tsx
+++ b/view/next-project/src/stories/AddModal.stories.tsx
@@ -1,0 +1,35 @@
+import { Meta } from '@storybook/react';
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import AddModal from '../components/fund_information/AddModal';
+
+// Add your required props here for testing
+const sampleProps = {
+  setShowModal: () => {},
+  teachers: [], // Add sample data as needed
+  departments: [], // Add sample data as needed
+  users: [], // Add sample data as needed
+  currentUser: {}, // Add sample data as needed
+};
+
+const meta: Meta<typeof AddModal> = {
+  title: 'FinanSu/fund_information/AddModal',
+  component: AddModal,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    ...sampleProps,
+  },
+  decorators: [
+    (Story) => (
+      <RecoilRoot>
+        <Story />
+      </RecoilRoot>
+    ),
+  ],
+};

--- a/view/next-project/src/stories/DeleteModal.stories.tsx
+++ b/view/next-project/src/stories/DeleteModal.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { DeleteModal } from '@components/fund_information';
+
+const meta: Meta<typeof DeleteModal> = {
+  title: 'FinanSu/fund_information/DeleteModal',
+  component: DeleteModal,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/EditModal.stories.tsx
+++ b/view/next-project/src/stories/EditModal.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from '@storybook/addon-actions';
 import { Meta } from '@storybook/react';
 import React from 'react';
 import { RecoilRoot } from 'recoil';
@@ -5,7 +6,7 @@ import EditModal from '../components/fund_information/EditModal';
 
 // Sample props for testing
 const sampleProps = {
-  setShowModal: () => {},
+  setShowModal: action('setShowModal'),
   teachers: [
     { id: 1, name: 'Teacher 1', departmentID: 1 },
     { id: 2, name: 'Teacher 2', departmentID: 2 },
@@ -44,7 +45,7 @@ export const Primary = {
     ...sampleProps,
   },
   decorators: [
-    (Story) => (
+    (Story: React.ComponentType) => (
       <RecoilRoot>
         <Story />
       </RecoilRoot>

--- a/view/next-project/src/stories/EditModal.stories.tsx
+++ b/view/next-project/src/stories/EditModal.stories.tsx
@@ -1,0 +1,53 @@
+import { Meta } from '@storybook/react';
+import React from 'react';
+import { RecoilRoot } from 'recoil';
+import EditModal from '../components/fund_information/EditModal';
+
+// Sample props for testing
+const sampleProps = {
+  setShowModal: () => {},
+  teachers: [
+    { id: 1, name: 'Teacher 1', departmentID: 1 },
+    { id: 2, name: 'Teacher 2', departmentID: 2 },
+  ],
+  users: [
+    { id: 1, name: 'User 1', bureauID: 1 },
+    { id: 2, name: 'User 2', bureauID: 2 },
+  ],
+  departments: [
+    { id: 1, name: 'Department 1' },
+    { id: 2, name: 'Department 2' },
+  ],
+  fundInformation: {
+    id: 1,
+    userID: 1,
+    teacherID: 1,
+    price: 1000,
+    remark: 'Sample remark',
+    isFirstCheck: false,
+    isLastCheck: false,
+    receivedAt: '2023-01-01',
+  },
+};
+
+const meta: Meta<typeof EditModal> = {
+  title: 'FinanSu/fund_information/EditModal',
+  component: EditModal,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    ...sampleProps,
+  },
+  decorators: [
+    (Story) => (
+      <RecoilRoot>
+        <Story />
+      </RecoilRoot>
+    ),
+  ],
+};

--- a/view/next-project/src/stories/OpenAddModalButton.stories.tsx
+++ b/view/next-project/src/stories/OpenAddModalButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { OpenAddModalButton } from '@components/fund_information';
+
+const meta: Meta<typeof OpenAddModalButton> = {
+  title: 'FinanSu/OpenAddModalButton',
+  component: OpenAddModalButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/OpenDeleteModalButton.stories.tsx
+++ b/view/next-project/src/stories/OpenDeleteModalButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { OpenAddModalButton } from '@components/fund_information';
+
+const meta: Meta<typeof OpenAddModalButton> = {
+  title: 'FinanSu/fund_information/OpenAddModalButton',
+  component: OpenAddModalButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/OpenEditModalButton.stories.tsx
+++ b/view/next-project/src/stories/OpenEditModalButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { OpenEditModalButton } from '@components/fund_information';
+
+const meta: Meta<typeof OpenEditModalButton> = {
+  title: 'FinanSu/fund_information/OpenEditModalButton',
+  component: OpenEditModalButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #797 

# 概要
<!-- 開発内容の概要を記載 -->
既存のコンポーネントをStoribookに表示する。
今回表示させたのは以下の通り。
- AddModal.stories.tsx
- DeleteModal.stories.tsx
- EditModal.stories.tsx
- OpenAddModalButton.stories.tsx
- OpenDeleteModalButton.stories.tsx
- OpenEditModalButton.stories.tsx

また、.storiesファイル側での呼び出し？を簡単にするために/fund_information内にindex.tsを作成した。


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![image](https://github.com/NUTFes/FinanSu/assets/66411240/b450eddc-25e5-469d-a713-6baa923646f7)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- Storybookを起動して上記のコンポーネントを見ることができるか
- index.tsの追加に問題はないか
- `AddModal.stories.tsx`と`EditModal.stories.tsx`はchatGPTを使って生成した。問題のあるコード・記述はないか

# 備考
`FinanSu/view/next-project/src/stories`内のファイルが多くなってきた。階層構造に分けた方がいいかも。

