### PR TITLE
[feat] 年度別で募金登録済みの教員Idを配列で返すAPIの作成

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2120,6 +2120,26 @@ const docTemplate = `{
                 },
             },
         },
+				"/teachers/fundRegistered/{year}": {
+            "get": {
+                tags: ["teacher"],
+                "description": "募金登録済みのteacherのidを取得",
+                "parameters": [
+                    {
+                        "name": "year",
+                        "in": "path",
+                        "description": "year",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "募金登録済みのteacherのidを取得",
+                    }
+                }
+            },
+				},
         "/users": {
             "get": {
                 tags: ["user"],
@@ -2448,7 +2468,6 @@ const docTemplate = `{
                 "feature":{
                     "type": "string",
                     "example": "なし",
-
                 },
                 "expense":{
                     "type": "int",

--- a/api/externals/controller/teacher_controller.go
+++ b/api/externals/controller/teacher_controller.go
@@ -14,6 +14,7 @@ type teacherController struct {
 
 type TeacherController interface {
 	IndexTeacher(echo.Context) error
+	IndexFundRegisteredTeacher(echo.Context) error
 	ShowTeacher(echo.Context) error
 	CreateTeacher(echo.Context) error
 	UpdateTeacher(echo.Context) error
@@ -32,6 +33,16 @@ func (t *teacherController) IndexTeacher(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, teachers)
+}
+
+// IndexFundRegistered
+func (t *teacherController) IndexFundRegisteredTeacher(c echo.Context) error {
+	year := c.Param("year")
+	fundRegisteredTeachers, err := t.u.GetFundRegisteredByPeriods(c.Request().Context(), year)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, fundRegisteredTeachers)
 }
 
 // Show

--- a/api/externals/repository/teacher_repository.go
+++ b/api/externals/repository/teacher_repository.go
@@ -16,6 +16,7 @@ type teacherRepository struct {
 
 type TeacherRepository interface {
 	All(context.Context) (*sql.Rows, error)
+	AllFundRegistered(context.Context, string) (*sql.Rows, error)
 	Find(context.Context, string) (*sql.Row, error)
 	Create(context.Context, string, string, string, string, string, string) error
 	Update(context.Context, string, string, string, string, string, string, string) error
@@ -30,6 +31,33 @@ func NewTeacherRepository(c db.Client, ac abstract.Crud) TeacherRepository {
 
 func (t *teacherRepository) All(c context.Context) (*sql.Rows, error) {
 	query := "SELECT * FROM teachers WHERE is_deleted IS FALSE ORDER BY department_id ASC "
+	return t.crud.Read(c, query)
+}
+
+func (t *teacherRepository) AllFundRegistered(c context.Context, year string) (*sql.Rows, error) {
+	query := `
+	SELECT
+    teachers.id
+	FROM
+    teachers
+	INNER JOIN
+    fund_informations
+	ON
+    teachers.id = fund_informations.teacher_id
+	INNER JOIN
+    year_periods
+	ON
+    fund_informations.created_at > year_periods.started_at
+	AND
+    fund_informations.created_at < year_periods.ended_at
+	INNER JOIN
+    years
+	ON
+    year_periods.year_id = years.id
+	WHERE
+    years.year = ` + year + `
+	ORDER BY
+    fund_informations.created_at ASC;`
 	return t.crud.Read(c, query)
 }
 

--- a/api/internals/usecase/teacher_usecase.go
+++ b/api/internals/usecase/teacher_usecase.go
@@ -14,6 +14,7 @@ type teacherUseCase struct {
 
 type TeacherUseCase interface {
 	GetTeachers(context.Context) ([]domain.Teacher, error)
+	GetFundRegisteredByPeriods(context.Context, string) ([]int, error)
 	GetTeacherByID(context.Context, string) (domain.Teacher, error)
 	CreateTeacher(context.Context, string, string, string, string, string, string) (domain.Teacher, error)
 	UpdateTeacher(context.Context, string, string, string, string, string, string, string) (domain.Teacher, error)
@@ -58,6 +59,29 @@ func (t *teacherUseCase) GetTeachers(c context.Context) ([]domain.Teacher, error
 		teachers = append(teachers, teacher)
 	}
 	return teachers, nil
+}
+
+func (t *teacherUseCase) GetFundRegisteredByPeriods(c context.Context, year string) ([]int, error) {
+
+	rows, err := t.rep.AllFundRegistered(c, year)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int
+	for rows.Next() {
+			var id int
+			if err := rows.Scan(&id); err != nil {
+					return nil, err
+			}
+			ids = append(ids, id)
+	}
+
+	if err := rows.Err(); err != nil {
+			return nil, err
+	}
+
+	return ids, nil
 }
 
 func (t *teacherUseCase) GetTeacherByID(c context.Context, id string) (domain.Teacher, error) {

--- a/api/internals/usecase/teacher_usecase.go
+++ b/api/internals/usecase/teacher_usecase.go
@@ -68,7 +68,8 @@ func (t *teacherUseCase) GetFundRegisteredByPeriods(c context.Context, year stri
 		return nil, err
 	}
 	defer rows.Close()
-	var ids []int
+
+	ids := []int{}
 	for rows.Next() {
 			var id int
 			if err := rows.Scan(&id); err != nil {

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -220,6 +220,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	// teacherのRoute
 	e.GET("/teachers", r.teacherController.IndexTeacher)
 	e.GET("/teachers/:id", r.teacherController.ShowTeacher)
+	e.GET("/teachers/fundRegistered/:year", r.teacherController.IndexFundRegisteredTeacher)
 	e.POST("/teachers", r.teacherController.CreateTeacher)
 	e.PUT("/teachers/:id", r.teacherController.UpdateTeacher)
 	e.DELETE("/teachers/:id", r.teacherController.DestroyTeacher)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #815 

# 概要
<!-- 開発内容の概要を記載 -->
disabledを掛けるためにfund_informationに登録されているteacher.idを取得しました。
取得したidは配列で返すようにしています。このままフロントで使えると思います。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![image](https://github.com/NUTFes/FinanSu/assets/106811268/c1a03ba7-b044-4829-ba4a-5f49b2b8cdd9)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- `swaggerを開いて、/teachers/fundRegistered/{year}`にとんでください
- yearパラメータに2024と入力して、スクショのような結果が返ってくるか
- 他のパラメータを指定してもシーズデータに存在しないためnullが返ってきます
-

# 備考
命名てきとうにしたので要確認でお願いします