### PR TITLE
minioのバケット作成やキーの作成を不要にする

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,12 +12,6 @@ services:
     container_name: "nutfes-finansu-view"
     command: "npm run start"
     ports: ["3000:3000"]
-    environment:
-      NEXT_PUBLIC_APP_ENV: "production"
-      NEXT_PUBLIC_ENDPOINT: minio
-      NEXT_PUBLIC_PORT: 9000
-      NEXT_PUBLIC_BUCKET_NAME: finansu
-      NEXT_PUBLIC_MINIO_ENDPONT: http://localhost:9000
     depends_on: ["api"]
 
   api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,13 @@ services:
       - "6006:6006"
     stdin_open: true
     environment:
+      NEXT_PUBLIC_APP_ENV: development
       NEXT_PUBLIC_ENDPOINT: minio
       NEXT_PUBLIC_PORT: 9000
       NEXT_PUBLIC_BUCKET_NAME: finansu
       NEXT_PUBLIC_MINIO_ENDPONT: http://localhost:9000
+      NEXT_PUBLIC_ACCESS_KEY: user
+      NEXT_PUBLIC_SECRET_KEY: password
       RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED: false
     tty: true
 

--- a/view/next-project/src/pages/api/minio.tsx
+++ b/view/next-project/src/pages/api/minio.tsx
@@ -57,28 +57,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(200).json({ message: '成功' });
     });
   }
-
-  if (req.method === 'GET') {
-    try {
-      const size = 0;
-      const response = minioClient.fGetObject(
-        'finansu',
-        'go.png',
-        '/tmp/go.png',
-        function (err: any) {
-          if (err) {
-            return console.log(err);
-          }
-          console.log('success');
-        },
-      );
-
-      res.status(200).json({ response: response });
-    } catch (err) {
-      res.status(400);
-      throw new Error('Error uploading file (' + err + ')');
-    }
-  }
 }
 
 // バケットがない時に作成する関数(環境構築時のみ)


### PR DESCRIPTION
# 概要
<!-- 開発内容の概要を記載 -->
- finansuのバケットの作成(開発環境でない場合)
- バケット作成時にアクセスポリシーをpublicにする(FinanSu上で表示するため)
- 不必要なprodの環境変数の削除

# テスト項目(メンバー用)
<!-- テストしてほしい内容を記載 -->
- /tmpディレクトリを削除
- イメージとボリュームをけして、ビルドとアップ
- ログインして、協賛活動から画像をアップロードできればおけ

# 備考
- 新入生も入ってきて色々面倒な設定させるのが良くないのでしました

# 動作確認(新入生レビュー用)
- このブランチをローカルにpullしてください
  - `git pull`
  - `git switch initial-minio-settings` 
- `make del-vol-run`でボリュームを削除して、コンテナをビルド&起動してください
- 少し待つとlocalhost:3000でFinanSuにアクセスできると思います
- slackの#develop-finansuでピン留めされているでデフォルトユーザーでログインしてください
- (ここでログインできない時はapiとdbの接続がうまくいっていない場合があるので、その場合apiコンテナを再起動してください、docker destopでリロードボタンを押すのが楽です、apiコンテナのlogでechoと出たら問題ありません)
- ログインができたら購入申請一覧に行きます
- 左のメニューバーの渉外局の下の協賛活動をクリック

<img width="777" alt="スクリーンショット 2024-07-04 9 32 02" src="https://github.com/NUTFes/FinanSu/assets/115447919/2ffe299e-62bf-4314-a39f-a64eac08f732">


- テスト企業などのデータがあると思います、クリックするとその詳細が表示されます
↓この画面
<img width="777" alt="スクリーンショット 2024-07-04 9 28 41" src="https://github.com/NUTFes/FinanSu/assets/115447919/5aac5f2a-0bf2-4f1e-b989-a7e4499166f6">

- 右下の矢印ボタンをクリック
↓ このような画面になります

<img width="777" alt="スクリーンショット 2024-07-04 9 29 23" src="https://github.com/NUTFes/FinanSu/assets/115447919/21a87538-7660-4dae-b854-232d4a2ce26e">

- +ボタンをクリック
- 広告登録ボタンをクリック
- ファイルを選択からてきとうな画像ファイルをアップロードしてみてください
- 登録ボタンを押して「保存しました」と表示されたら動作確認オッケーです
- もし失敗するのようなメッセージが表示されたら教えてください！

