### PR TITLE
APIがDBとの接続できない問題の解消

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,32 @@
+# アプリコンテナ=view,api、DBコンテナ=db,minio
+
+# アプリコンテナのイメージのビルド
 build:
 	docker compose build
 	docker compose run --rm view npm install
 
+# アプリコンテナの起動
 run:
 	docker compose up
 
+# アプリコンテナの停止
+down:
+	docker compose down
+
+# dbコンテナの起動(基本ずっと起動しておく)
+run-db:
+	docker compose -f docker-compose.db.yml up -d
+
+# dbコンテナの停止(ずっと起動したくない時はこっちで停止)
+stop-db:
+	docker compose -f docker-compose.db.yml down
+
 # ビルドと起動
 build-run:
+	docker compose -f docker-compose.db.yml up -d
 	docker compose up --build
 
-# ボリュームの削除
+# アプリコンテナボリュームの削除
 del-vol:
 	docker compose down -v
 
@@ -18,18 +35,16 @@ del-all:
 	docker-compose down --rmi all --volumes --remove-orphans
 
 # ボリューム削除→ビルド→起動
-del-vol-run:
+run-rebuild:
 	docker compose down -v
 	docker compose up --build
 
-# コンテナの停止
-down:
-	docker compose down
+# dbとminioの停止とボリューム削除(dbを初期化したい時)
+del-db:
+	docker-compose -f docker-compose.db.yml down --volumes
 
-# apiのみ起動
+# apiの起動(db起動後)
 run-api:
-	docker compose up -d db
-	sleep 4
 	docker compose up api
 
 # StoryBookの起動

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ deploy:
 	docker compose -f docker-compose.prod.yml build
 	docker compose -f docker-compose.prod.yml up -d
 
-# ローカル環境で本番用の設定で起動
-local-deploy:
+# ローカルで本番設定で起動
+run-prod:
 	docker compose -f docker-compose.local-prod.yml build
 	docker compose -f docker-compose.local-prod.yml up
 

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,28 @@
+services:
+  db:
+    image: mysql:8.0
+    container_name: "nutfes-finansu-db"
+    volumes:
+      - ./mysql/db:/docker-entrypoint-initdb.d # 初期データ
+      - ./my.cnf:/etc/mysql/conf.d/my.cnf
+    environment:
+      MYSQL_DATABASE: finansu_db
+      MYSQL_USER: finansu
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: root
+      TZ: "Asia/Tokyo"
+    ports:
+      - "3306:3306"
+    restart: always
+
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - ./tmp/minio/data:/data
+    command: "server /data --console-address :9001"
+    environment:
+      MINIO_ROOT_USER: user
+      MINIO_ROOT_PASSWORD: password

--- a/docker-compose.local-prod.yml
+++ b/docker-compose.local-prod.yml
@@ -1,32 +1,4 @@
 services:
-  db:
-    image: mysql:8.0
-    container_name: "nutfes-finansu-db"
-    volumes:
-      - ./mysql/db:/docker-entrypoint-initdb.d # 初期データ
-      - ./my.cnf:/etc/mysql/conf.d/my.cnf
-    environment:
-      MYSQL_DATABASE: finansu_db
-      MYSQL_USER: finansu
-      MYSQL_PASSWORD: password
-      MYSQL_ROOT_PASSWORD: root
-      TZ: "Asia/Tokyo"
-    ports:
-      - "3306:3306"
-    restart: always
-
-  minio:
-    image: minio/minio:latest
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    volumes:
-      - ./tmp/minio/data:/data
-    command: "server /data --console-address :9001"
-    environment:
-      MINIO_ROOT_USER: user
-      MINIO_ROOT_PASSWORD: password
-
   view:
     build:
       context: ./view
@@ -46,6 +18,3 @@ services:
     environment:
       ENV: "develop"
       RESET_PASSWORD_URL: "https://finansu.nutfes.net/reset_password"
-    depends_on:
-      db:
-        condition: service_started

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,4 @@
 services:
-  db:
-    image: mysql:8.0
-    container_name: "nutfes-finansu-db"
-    volumes:
-      - ./mysql/db:/docker-entrypoint-initdb.d # 初期データ
-      - ./my.cnf:/etc/mysql/conf.d/my.cnf
-    environment:
-      MYSQL_DATABASE: finansu_db
-      MYSQL_USER: finansu
-      MYSQL_PASSWORD: password
-      MYSQL_ROOT_PASSWORD: root
-      TZ: "Asia/Tokyo"
-    ports:
-      - "3306:3306"
-    restart: always
-
   view:
     build: ./view
     container_name: "nutfes-finansu-view"
@@ -49,18 +33,3 @@ services:
       - "1323:1323"
     stdin_open: true
     tty: true
-    depends_on:
-      db:
-        condition: service_started
-
-  minio:
-    image: minio/minio:latest
-    ports:
-      - "9000:9000"
-      - "9001:9001"
-    volumes:
-      - ./tmp/minio/data:/data
-    command: "server /data --console-address :9001"
-    environment:
-      MINIO_ROOT_USER: user
-      MINIO_ROOT_PASSWORD: password

--- a/view/local-prod.Dockerfile
+++ b/view/local-prod.Dockerfile
@@ -4,6 +4,13 @@ COPY ./next-project /app/next-project
 
 ENV NODE_ENV production
 ENV NEXT_PUBLIC_APP_ENV develop
+ENV NEXT_PUBLIC_ENDPOINT minio
+ENV NEXT_PUBLIC_PORT 9000
+ENV NEXT_PUBLIC_BUCKET_NAME finansu
+ENV NEXT_PUBLIC_MINIO_ENDPONT http://localhost:9000
+ENV NEXT_PUBLIC_ACCESS_KEY user
+ENV NEXT_PUBLIC_SECRET_KEY password
+
 
 RUN npm install --production
 RUN npm run build


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #821 

# 概要
<!-- 開発内容の概要を記載 -->
- apiとdbが接続できない時、apiコンテナを再起動する必要があったので対策をした

# 変更内容
アプリ(view, api)とDB(db, minio)でdocker-compose.ymlファイルを分割した
- 理由
  - apiが起動する際にdbが起動中で接続できないため
  - 現在はdocker compose downで全てのコンテナを閉じてしまう→再起動の度に負荷がかかる
- デメリット
  - dbの起動忘れなどが発生するかも
  - 起動するまでに `make run-db,  make build, make run`の3つのコマンドが必要になる

db側は基本ずっと立ち上げとくイメージ(閉じてもいい)
makeコマンドの修正(run-db, stop-dbなど)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 既存のdockcer ネットワーク、イメージ、ボリュームを削除
- ルートディレクトリにfinansu.envがあるか確認する
- `make run-db`、　`make build`、 `make run`でFinanSuが起動するか
- アプリ側を停止して、`make run`で起動するか(Goがdbと繋がるか)
- 色々動かして、変なエラーが出ないか

# 備考
