### PR TITLE
報告未登録の申請取得APIの作成

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1504,6 +1504,26 @@ const docTemplate = `{
                 }
             },
         },
+        "/purchaseorders/details/unregistered/{year}": {
+            "get": {
+                tags: ["purchase_order"],
+                "description": "年度で指定されたreportsに未登録のpurchase_orderに紐づくuserとpurchase_itemを取得",
+                "parameters": [
+                    {
+                        "name": "year",
+                        "in": "path",
+                        "description": "year",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "IDで指定されたreportsに未登録のpurchase_orderに紐づくuserとpurchase_itemを取得",
+                    }
+                }
+            },
+        },
         "/purchasereports": {
             "get": {
                 tags: ["purchase_report"],

--- a/api/externals/controller/purhcase_order_controller.go
+++ b/api/externals/controller/purhcase_order_controller.go
@@ -20,6 +20,7 @@ type PurchaseOrderController interface {
 	IndexOrderDetail(echo.Context) error
 	ShowOrderDetail(echo.Context) error
 	IndexOrderDetailByYear(echo.Context) error
+	IndexUnregisteredOrderDetailByYear(echo.Context) error
 }
 
 func NewPurchaseOrderController(u usecase.PurchaseOrderUseCase) PurchaseOrderController {
@@ -104,6 +105,15 @@ func (p *purchaseOrderController) ShowOrderDetail(c echo.Context) error {
 func (p *purchaseOrderController) IndexOrderDetailByYear(c echo.Context) error {
 	year := c.Param("year")
 	orderDetails, err := p.u.GetPurchaseOrderDetailsByYear(c.Request().Context(), year)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, orderDetails)
+}
+
+func (p *purchaseOrderController) IndexUnregisteredOrderDetailByYear(c echo.Context) error {
+	year := c.Param("year")
+	orderDetails, err := p.u.GetUnregisteredPurchaseOrderDetailsByYear(c.Request().Context(), year)
 	if err != nil {
 		return err
 	}

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -184,6 +184,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.GET("/purchaseorders/details", r.purchaseOrderController.IndexOrderDetail)
 	e.GET("/purchaseorders/:id/details", r.purchaseOrderController.ShowOrderDetail)
 	e.GET("/purchaseorders/details/:year", r.purchaseOrderController.IndexOrderDetailByYear)
+	e.GET("/purchaseorders/details/unregistered/:year", r.purchaseOrderController.IndexUnregisteredOrderDetailByYear)
 
 	// purchasereportsのRoute
 	e.GET("/purchasereports", r.purchaseReportController.IndexPurchaseReport)

--- a/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
@@ -53,7 +53,7 @@ export default function PurchaseItemNumModal() {
   useEffect(() => {
     if (router.isReady) {
       const getPurchaseOrderViewUrl =
-        process.env.CSR_API_URI + '/purchaseorders/details/' + String(selectedYear);
+        process.env.CSR_API_URI + '/purchaseorders/details/unregistered/' + String(selectedYear);
       const getExpensesUrl = process.env.CSR_API_URI + '/expenses';
 
       const getPurchaseOrderView = async (url: string) => {

--- a/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
+++ b/view/next-project/src/components/purchasereports/PurchaseOrderListModal.tsx
@@ -98,7 +98,7 @@ export default function PurchaseItemNumModal() {
   };
 
   return (
-    <Modal className='mt-32 overflow-scroll md:m-0 md:h-5/6'>
+    <Modal className='mt-32 overflow-scroll md:h-5/6 md:w-3/4'>
       <div className={clsx('w-full ')}>
         <div className={clsx('mr-5 grid w-full justify-items-end')}>
           <CloseButton onClick={closeModal} />
@@ -128,7 +128,7 @@ export default function PurchaseItemNumModal() {
           </div>
         </div>
       </div>
-      <div className={clsx('mb-4 grid h-2/3 grid-cols-12 gap-4 overflow-scroll')}>
+      <div className={clsx('max-h-2/3 mb-4 grid grid-cols-12 gap-4 overflow-scroll')}>
         <div className={clsx('col-span-1 grid')} />
         <div className={clsx('col-span-10 grid')}>
           <div className={clsx('mb-2 w-full p-5')}>


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #822

# 概要
<!-- 開発内容の概要を記載 -->
- 購入報告に登録されていない購入申請のdetailsを取得するAPIを作成
- swaggerへの追加
- フロントのパス修正

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1170" alt="スクリーンショット 2024-07-04 13 52 13" src="https://github.com/NUTFes/FinanSu/assets/115447919/72fe9381-c452-4af6-a7e1-d99616bf4127">

# テスト項目
<!-- テストしてほしい内容を記載 -->

- [ ]  swaggerを立ち上げ、`/purchaseorders/details/unregistered/:year`の確認
- [ ] フロントの購入報告ページ→購入申請から登録→未登録のデータのみ表示されているか確認
- [ ] コードレビュー

# 備考
