### PR TITLE
購入申請ページで申請した局と期限日を編集可能にする。

### DIFF
--- a/view/next-project/src/components/purchaseorders/DetailEditModal.tsx
+++ b/view/next-project/src/components/purchaseorders/DetailEditModal.tsx
@@ -1,0 +1,114 @@
+import router from 'next/router';
+import { useEffect, useState } from 'react';
+import { Expense, PurchaseOrder, PurchaseReport } from '@/type/common';
+import { put } from '@/utils/api/purchaseOrder';
+import { get } from '@api/api_methods';
+import {
+  CloseButton,
+  Input,
+  Modal,
+  OutlinePrimaryButton,
+  PrimaryButton,
+  Select,
+} from '@components/common';
+
+export const DetailEditModal: React.FC<{
+  purchaseReportId: number;
+  isOpen: boolean;
+  setIsOpen: () => void;
+  onOpenInitial: () => void;
+}> = ({ purchaseReportId, setIsOpen, onOpenInitial }) => {
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+  const [purchaseOrder, setPurchaseOrder] = useState<PurchaseOrder>({
+    id: 0,
+    deadline: '',
+    userID: 0,
+    expenseID: 0,
+    financeCheck: false,
+  });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const purchaseReportRes: PurchaseReport = await get(
+          `${process.env.CSR_API_URI}/purchasereports/${purchaseReportId}`,
+        );
+        const purchaseOrderId = purchaseReportRes.purchaseOrderID;
+        const expensesRes: Expense[] = await get(`${process.env.CSR_API_URI}/expenses`);
+        const purchaseOrderRes: PurchaseOrder = await get(
+          `${process.env.CSR_API_URI}/purchaseorders/${purchaseOrderId}`,
+        );
+        setExpenses(expensesRes);
+        setPurchaseOrder(purchaseOrderRes);
+      } catch (error) {
+        console.error('Failed to fetch data:', error);
+      }
+    };
+    fetchData();
+  }, [purchaseReportId]);
+
+  const formatDate = (date: string) => {
+    const d = new Date(date);
+    const year = d.getFullYear();
+    const month = (1 + d.getMonth()).toString().padStart(2, '0');
+    const day = d.getDate().toString().padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  };
+
+  const submit = async () => {
+    try {
+      const updatePurchaseOrderUrl = `${process.env.CSR_API_URI}/purchaseorders/${purchaseOrder.id}`;
+      await put(updatePurchaseOrderUrl, purchaseOrder);
+    } finally {
+      router.reload();
+    }
+  };
+
+  const handleInputChange = (key: keyof PurchaseOrder, value: string | number) => {
+    setPurchaseOrder((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <Modal className='md:w-1/2'>
+      <div className='ml-auto w-fit'>
+        <CloseButton onClick={setIsOpen} />
+      </div>
+      <div className='mx-auto mb-10 w-fit text-xl text-black-600'>
+        <p>購入した局と期限日を修正</p>
+      </div>
+      <div className='mx-auto my-6 grid w-9/10 grid-cols-4 items-center justify-items-center gap-4'>
+        <p className='text-lg text-black-600'>購入した局</p>
+        <div className='col-span-3 w-full'>
+          <Select
+            value={purchaseOrder.expenseID}
+            onChange={(e) => handleInputChange('expenseID', Number(e.target.value))}
+          >
+            {expenses.map((data) => (
+              <option key={data.id} value={data.id}>
+                {data.name}
+              </option>
+            ))}
+            {!expenses.length && <option>局・団体が登録されていません</option>}
+          </Select>
+        </div>
+        <p className='text-lg text-black-600'>期限日</p>
+        <div className='col-span-3 w-full'>
+          <Input
+            type='date'
+            value={purchaseOrder.deadline ? formatDate(purchaseOrder.deadline) : ''}
+            onChange={(e) => handleInputChange('deadline', e.target.value)}
+            className='w-full'
+          />
+        </div>
+      </div>
+      <div className='flex justify-center'>
+        <OutlinePrimaryButton onClick={onOpenInitial} className='mx-2'>
+          戻る
+        </OutlinePrimaryButton>
+        <PrimaryButton onClick={submit} className='mx-2 px-4'>
+          編集完了
+        </PrimaryButton>
+      </div>
+    </Modal>
+  );
+};

--- a/view/next-project/src/components/purchaseorders/DetailEditModal.tsx
+++ b/view/next-project/src/components/purchaseorders/DetailEditModal.tsx
@@ -1,8 +1,7 @@
 import router from 'next/router';
-import { useEffect, useState } from 'react';
-import { Expense, PurchaseOrder, PurchaseReport } from '@/type/common';
+import { useState } from 'react';
+import { Expense, PurchaseOrder, PurchaseOrderView } from '@/type/common';
 import { put } from '@/utils/api/purchaseOrder';
-import { get } from '@api/api_methods';
 import {
   CloseButton,
   Input,
@@ -13,39 +12,14 @@ import {
 } from '@components/common';
 
 export const DetailEditModal: React.FC<{
-  purchaseReportId: number;
+  purchaseOrderId: number;
+  purchaseOrderViewItem: PurchaseOrderView;
+  expenses: Expense[];
   isOpen: boolean;
   setIsOpen: () => void;
   onOpenInitial: () => void;
-}> = ({ purchaseReportId, setIsOpen, onOpenInitial }) => {
-  const [expenses, setExpenses] = useState<Expense[]>([]);
-  const [purchaseOrder, setPurchaseOrder] = useState<PurchaseOrder>({
-    id: 0,
-    deadline: '',
-    userID: 0,
-    expenseID: 0,
-    financeCheck: false,
-  });
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const purchaseReportRes: PurchaseReport = await get(
-          `${process.env.CSR_API_URI}/purchasereports/${purchaseReportId}`,
-        );
-        const purchaseOrderId = purchaseReportRes.purchaseOrderID;
-        const expensesRes: Expense[] = await get(`${process.env.CSR_API_URI}/expenses`);
-        const purchaseOrderRes: PurchaseOrder = await get(
-          `${process.env.CSR_API_URI}/purchaseorders/${purchaseOrderId}`,
-        );
-        setExpenses(expensesRes);
-        setPurchaseOrder(purchaseOrderRes);
-      } catch (error) {
-        console.error('Failed to fetch data:', error);
-      }
-    };
-    fetchData();
-  }, [purchaseReportId]);
+}> = ({ purchaseOrderViewItem, expenses, setIsOpen, onOpenInitial }) => {
+  const [formData, setFormData] = useState<PurchaseOrder>(purchaseOrderViewItem.purchaseOrder);
 
   const formatDate = (date: string) => {
     const d = new Date(date);
@@ -57,15 +31,15 @@ export const DetailEditModal: React.FC<{
 
   const submit = async () => {
     try {
-      const updatePurchaseOrderUrl = `${process.env.CSR_API_URI}/purchaseorders/${purchaseOrder.id}`;
-      await put(updatePurchaseOrderUrl, purchaseOrder);
+      const updatePurchaseOrderUrl = `${process.env.CSR_API_URI}/purchaseorders/${formData.id}`;
+      await put(updatePurchaseOrderUrl, formData);
     } finally {
       router.reload();
     }
   };
 
   const handleInputChange = (key: keyof PurchaseOrder, value: string | number) => {
-    setPurchaseOrder((prev) => ({ ...prev, [key]: value }));
+    setFormData((prev) => ({ ...prev, [key]: value }));
   };
 
   return (
@@ -80,7 +54,7 @@ export const DetailEditModal: React.FC<{
         <p className='text-lg text-black-600'>購入した局</p>
         <div className='col-span-3 w-full'>
           <Select
-            value={purchaseOrder.expenseID}
+            value={formData.expenseID}
             onChange={(e) => handleInputChange('expenseID', Number(e.target.value))}
           >
             {expenses.map((data) => (
@@ -95,7 +69,7 @@ export const DetailEditModal: React.FC<{
         <div className='col-span-3 w-full'>
           <Input
             type='date'
-            value={purchaseOrder.deadline ? formatDate(purchaseOrder.deadline) : ''}
+            value={formData.deadline ? formatDate(formData.deadline) : ''}
             onChange={(e) => handleInputChange('deadline', e.target.value)}
             className='w-full'
           />

--- a/view/next-project/src/components/purchaseorders/EditModal.tsx
+++ b/view/next-project/src/components/purchaseorders/EditModal.tsx
@@ -20,6 +20,7 @@ interface ModalProps {
   purchaseItems: PurchaseItem[];
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
+  onOpenInitial: () => void;
 }
 
 export default function EditModal(props: ModalProps) {
@@ -33,8 +34,12 @@ export default function EditModal(props: ModalProps) {
     setActiveStep(activeStep - 1);
   };
   const reset = () => {
-    setActiveStep(1);
-    setIsDone(false);
+    if (activeStep === 1) {
+      props.onOpenInitial();
+    } else {
+      setActiveStep(1);
+      setIsDone(false);
+    }
   };
 
   // 購入報告を登録するかどうかのフラグ
@@ -206,9 +211,9 @@ export default function EditModal(props: ModalProps) {
             <div className='mb-5 mt-10 flex justify-center gap-5'>
               {formDataList && formDataList.length > 0 && (
                 <>
-                  {activeStep > 1 && (
-                    <OutlinePrimaryButton onClick={prevStep}>戻る</OutlinePrimaryButton>
-                  )}
+                  <OutlinePrimaryButton onClick={activeStep === 1 ? reset : prevStep}>
+                    戻る
+                  </OutlinePrimaryButton>
                   <PrimaryButton
                     onClick={() => {
                       {

--- a/view/next-project/src/components/purchaseorders/OpenEditModalButton.tsx
+++ b/view/next-project/src/components/purchaseorders/OpenEditModalButton.tsx
@@ -3,11 +3,12 @@ import React, { useState } from 'react';
 import { DetailEditModal } from './DetailEditModal';
 import { CloseButton, EditButton, Modal, PrimaryButton } from '@components/common';
 import EditModal from '@components/purchaseorders/EditModal';
-import { PurchaseItem } from '@type/common';
+import { Expense, PurchaseOrderView } from '@type/common';
 
 interface Props {
   children?: React.ReactNode;
-  purchaseItems: PurchaseItem[];
+  purchaseOrderViewItem: PurchaseOrderView;
+  expenses: Expense[];
   id: number;
   isDisabled: boolean;
 }
@@ -47,7 +48,9 @@ const OpenEditModalButton: React.FC<Props> = (props) => {
       {step === 'initial' && <InitialModal setStep={setStep} closeModal={closeModal} />}
       {step === 'editDetails' && (
         <DetailEditModal
-          purchaseReportId={props.id}
+          purchaseOrderId={props.id}
+          purchaseOrderViewItem={props.purchaseOrderViewItem}
+          expenses={props.expenses}
           isOpen={true}
           setIsOpen={closeModal}
           onOpenInitial={onOpenInitial}
@@ -58,7 +61,7 @@ const OpenEditModalButton: React.FC<Props> = (props) => {
           purchaseOrderId={props.id}
           isOpen={true}
           setIsOpen={closeModal}
-          purchaseItems={props.purchaseItems}
+          purchaseItems={props.purchaseOrderViewItem.purchaseItem}
           onOpenInitial={onOpenInitial}
         />
       )}

--- a/view/next-project/src/components/purchaseorders/OpenEditModalButton.tsx
+++ b/view/next-project/src/components/purchaseorders/OpenEditModalButton.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
-import { EditButton } from '@components/common';
+import { DetailEditModal } from './DetailEditModal';
+import { CloseButton, EditButton, Modal, PrimaryButton } from '@components/common';
 import EditModal from '@components/purchaseorders/EditModal';
 import { PurchaseItem } from '@type/common';
 
@@ -11,20 +12,54 @@ interface Props {
   isDisabled: boolean;
 }
 
+const InitialModal: React.FC<{ setStep: (step: string) => void; closeModal: () => void }> = ({
+  setStep,
+  closeModal,
+}) => (
+  <Modal className='md:w-1/2'>
+    <div className='ml-auto w-fit'>
+      <CloseButton onClick={closeModal} />
+    </div>
+    <div className='mx-auto mb-6 w-fit text-xl text-black-600'>
+      <p>購入申請の修正</p>
+    </div>
+    <div className='flex justify-center gap-2 pb-4'>
+      <PrimaryButton onClick={() => setStep('editDetails')}>局と期限日を編集</PrimaryButton>
+      <PrimaryButton onClick={() => setStep('editPurchases')}>購入物品を編集</PrimaryButton>
+    </div>
+  </Modal>
+);
+
 const OpenEditModalButton: React.FC<Props> = (props) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const onOpen = () => {
-    setIsOpen(true);
+  const [step, setStep] = useState<string | null>(null);
+
+  const onOpenInitial = () => {
+    setStep('initial');
   };
+
+  const closeModal = () => {
+    setStep(null);
+  };
+
   return (
     <>
-      <EditButton onClick={onOpen} isDisabled={props.isDisabled} />
-      {isOpen && (
+      <EditButton onClick={onOpenInitial} isDisabled={props.isDisabled} />
+      {step === 'initial' && <InitialModal setStep={setStep} closeModal={closeModal} />}
+      {step === 'editDetails' && (
+        <DetailEditModal
+          purchaseReportId={props.id}
+          isOpen={true}
+          setIsOpen={closeModal}
+          onOpenInitial={onOpenInitial}
+        />
+      )}
+      {step === 'editPurchases' && (
         <EditModal
           purchaseOrderId={props.id}
-          isOpen={isOpen}
-          setIsOpen={setIsOpen}
+          isOpen={true}
+          setIsOpen={closeModal}
           purchaseItems={props.purchaseItems}
+          onOpenInitial={onOpenInitial}
         />
       )}
     </>

--- a/view/next-project/src/pages/purchaseorders/index.tsx
+++ b/view/next-project/src/pages/purchaseorders/index.tsx
@@ -334,7 +334,8 @@ export default function PurchaseOrders(props: Props) {
                                 ? purchaseOrderViewItem.purchaseOrder.id
                                 : 0
                             }
-                            purchaseItems={purchaseOrderViewItem.purchaseItem}
+                            purchaseOrderViewItem={purchaseOrderViewItem}
+                            expenses={props.expenses}
                             isDisabled={isDisabled(purchaseOrderViewItem)}
                           />
                         </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #813 

# 概要
<!-- 開発内容の概要を記載 -->
購入申請ページにおいて、購入した局と期限日を変更できるモーダルを追加しました。
編集ボタンを押すと選択モーダルが開き、修正内容によってモーダル展開のボタンを選択する仕組みです。
#784 と同様に作成しています。

# 画面スクリーンショット等
| ![FireShot Capture 016 - 購入申請一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/2076dc80-fe69-4937-8929-579e19781bdf) | ![FireShot Capture 017 - 購入申請一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/9c2b41ee-89cb-44bc-a2bb-7a2d4063f95e) | ![FireShot Capture 018 - 購入申請一覧 - localhost](https://github.com/NUTFes/FinanSu/assets/131145590/8238d700-f46a-4700-9fa6-9c9456a44694) |
| -- | -- | -- |

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ]  `http://localhost:3000/purchaseorders`にアクセスできる。
- [ ] 修正ボタンを押すと「購入申請の修正」モーダルが表示される。
- [ ] 「局と期限日を編集」ボタンを押すと、局と期限日が編集でき、更新される。
- [ ] 「購入物品を編集」ボタンを押すと、購入物品が編集でき、更新される。
- [ ] 「購入物品を編集」ボタンを押すと「戻る」ボタンが表示され、選択モーダルへ戻れる。