### PR TITLE
Feat/uchida/832 modal tap off screen

### DIFF
--- a/view/next-project/src/components/common/Modal.tsx
+++ b/view/next-project/src/components/common/Modal.tsx
@@ -18,6 +18,10 @@ export default function Modal(props: Props) {
 
   useEffect(stopScrollingBackContent, []);
 
+  const preventCloseModalEvent = (event: any) => {
+    event.stopPropagation();
+  };
+
   const className =
     'relative sm:my-6 mx-auto bg-white-0 rounded-lg p-5' +
     (props.className ? ` ${props.className}` : '');
@@ -28,7 +32,11 @@ export default function Modal(props: Props) {
         className='fixed inset-0 z-50 flex items-center justify-center overflow-y-auto overflow-x-hidden bg-black-300/50 outline-none focus:outline-none'
         onClick={props.onClick}
       >
-        <div className={clsx(className)} style={{ maxHeight: '90vh', overflowY: 'auto' }}>
+        <div
+          className={clsx(className)}
+          style={{ maxHeight: '90vh', overflowY: 'auto' }}
+          onClick={preventCloseModalEvent}
+        >
           {props.children}
         </div>
       </div>

--- a/view/next-project/src/components/sponsoractivities/DeleteModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DeleteModal.tsx
@@ -24,7 +24,7 @@ const SponsorActivitiesDeleteModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='md:w-1/2'>
+    <Modal className='md:w-1/2' onClick={() => props.setShowModal(false)}>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={() => props.setShowModal(false)} />

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -350,7 +350,7 @@ export default function EditModal(props: ModalProps) {
       </div>
     </div>
   );
-  
+
   const closeModal = () => {
     props.setIsOpen(false);
   };

--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -350,9 +350,13 @@ export default function EditModal(props: ModalProps) {
       </div>
     </div>
   );
+  
+  const closeModal = () => {
+    props.setIsOpen(false);
+  };
 
   return (
-    <Modal className='md:w-1/2'>
+    <Modal className='md:w-1/2' onClick={closeModal}>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -424,9 +424,13 @@ export default function SponsorActivitiesAddModal(props: Props) {
       </div>
     );
   };
+  
+  const closeModal = () => {
+    props.setIsOpen(false);
+  };
 
   return (
-    <Modal className='md:w-1/2'>
+    <Modal className='md:w-1/2' onClick={closeModal}>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton

--- a/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/SponsorActivitiesAddModal.tsx
@@ -424,7 +424,7 @@ export default function SponsorActivitiesAddModal(props: Props) {
       </div>
     );
   };
-  
+
   const closeModal = () => {
     props.setIsOpen(false);
   };

--- a/view/next-project/src/components/sponsors/DeleteModal.tsx
+++ b/view/next-project/src/components/sponsors/DeleteModal.tsx
@@ -24,7 +24,7 @@ const SponsorDeleteModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='md:w-1/2'>
+    <Modal className='md:w-1/2' onClick={() => props.setShowModal(false)}>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={() => props.setShowModal(false)} />

--- a/view/next-project/src/components/sponsors/SponsorAddModal.tsx
+++ b/view/next-project/src/components/sponsors/SponsorAddModal.tsx
@@ -38,7 +38,7 @@ export default function SponsorAddModal() {
   };
 
   return (
-    <Modal className='md:w-1/2'>
+    <Modal className='md:w-1/2' onClick={closeModal}>
       <div className='w-full'>
         <div className='ml-auto mr-5 w-fit'>
           <CloseButton onClick={closeModal} />

--- a/view/next-project/src/components/sponsors/SponsorEditModal.tsx
+++ b/view/next-project/src/components/sponsors/SponsorEditModal.tsx
@@ -35,8 +35,12 @@ export default function SponsorEditModal(props: Props) {
 
   const [isChecked, setIsChecked] = useState<boolean>(true);
 
+  const closeModal = () => {
+    props.setIsOpen(false);
+  };
+
   return (
-    <Modal className='md:w-1/2'>
+    <Modal className='md:w-1/2' onClick={closeModal}>
       <div className='w-full'>
         <div className='ml-auto mr-5 w-fit'>
           <CloseButton onClick={() => props.setIsOpen(false)} />

--- a/view/next-project/src/components/sponsorstyles/DeleteModal.tsx
+++ b/view/next-project/src/components/sponsorstyles/DeleteModal.tsx
@@ -24,7 +24,7 @@ const SponsorStyleDeleteModal: FC<ModalProps> = (props) => {
   };
 
   return (
-    <Modal className='md:w-1/2'>
+    <Modal className='md:w-1/2' onClick={() => props.setShowModal(false)}>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton onClick={() => props.setShowModal(false)} />

--- a/view/next-project/src/components/sponsorstyles/EditModal.tsx
+++ b/view/next-project/src/components/sponsorstyles/EditModal.tsx
@@ -72,9 +72,13 @@ export default function EditModal(props: ModalProps) {
       </div>
     </div>
   );
+  
+  const closeModal = () => {
+    props.setIsOpen(false);
+  };
 
   return (
-    <Modal className='md:w-1/2'>
+    <Modal className='md:w-1/2' onClick={closeModal}>
       <div className='w-full'>
         <div className='ml-auto w-fit'>
           <CloseButton

--- a/view/next-project/src/components/sponsorstyles/EditModal.tsx
+++ b/view/next-project/src/components/sponsorstyles/EditModal.tsx
@@ -72,7 +72,7 @@ export default function EditModal(props: ModalProps) {
       </div>
     </div>
   );
-  
+
   const closeModal = () => {
     props.setIsOpen(false);
   };

--- a/view/next-project/src/components/sponsorstyles/SponsorStyleAddModal.tsx
+++ b/view/next-project/src/components/sponsorstyles/SponsorStyleAddModal.tsx
@@ -38,7 +38,7 @@ export default function SponsorAddModal(props: ModalProps) {
     props.setIsOpen(false);
     router.reload();
   };
-  
+
   const closeModal = () => {
     props.setIsOpen(false);
   };

--- a/view/next-project/src/components/sponsorstyles/SponsorStyleAddModal.tsx
+++ b/view/next-project/src/components/sponsorstyles/SponsorStyleAddModal.tsx
@@ -38,9 +38,13 @@ export default function SponsorAddModal(props: ModalProps) {
     props.setIsOpen(false);
     router.reload();
   };
+  
+  const closeModal = () => {
+    props.setIsOpen(false);
+  };
 
   return (
-    <Modal className='md:w-1/2'>
+    <Modal className='md:w-1/2' onClick={closeModal}>
       <div className='w-full'>
         <div className='ml-auto mr-5 w-fit'>
           <CloseButton onClick={() => props.setIsOpen(false)} />


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 協賛企業のモーダルをクリックで閉じるようにする #832
<!-- 対応したIssue番号を記載 -->
resolve #832 

# 概要
<!-- 開発内容の概要を記載 -->
ページでモーダルを閉じるときに✖︎ボタンを押さないと閉じれないから、モーダル外を押すと閉じるようにする

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 企業スタイルと企業活動のページで、modalが画面外のクリックで閉じるようになっているか
-
-

# 備考
