### PR TITLE
学内募金の登録・編集時に登録済の教員を選択できないようにする

### DIFF
--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -87,7 +87,10 @@ const OpenAddModal: FC<ModalProps> = (props) => {
     const departmentTeachers = teachers.filter(
       (teacher) => teacher.departmentID === Number(e.target.value),
     );
-    setFormData({ ...formData, teacherID: departmentTeachers[0]?.id || 0 });
+    const firstNotRegisteredTeacher = departmentTeachers.find((teacher) => {
+      return !registeredTeacherIds.includes(teacher?.id || 0);
+    });
+    setFormData({ ...formData, teacherID: firstNotRegisteredTeacher?.id || 0 });
   };
 
   const addFundInformation = async (data: FundInformation) => {
@@ -101,10 +104,10 @@ const OpenAddModal: FC<ModalProps> = (props) => {
     const registeredTeachersURL = process.env.CSR_API_URI + '/teachers/fundRegistered/2024';
     const resData = await get(registeredTeachersURL);
     setRegisteredTeacherIds(resData);
-    const notRegisteredTeachers = teachers.find((teacher) => {
+    const firstNotRegisteredTeacher = teachers.find((teacher) => {
       return !resData.includes(teacher.id);
     });
-    setFormData({ ...formData, teacherID: notRegisteredTeachers?.id || 0 });
+    setFormData({ ...formData, teacherID: firstNotRegisteredTeacher?.id || 0 });
   }
 
   useEffect(() => {

--- a/view/next-project/src/components/fund_information/AddModal.tsx
+++ b/view/next-project/src/components/fund_information/AddModal.tsx
@@ -16,11 +16,12 @@ interface ModalProps {
   departments: Department[];
   users: User[];
   currentUser?: User;
+  currentYear: string;
 }
 
 const OpenAddModal: FC<ModalProps> = (props) => {
   const [user] = useRecoilState(userAtom);
-  const { teachers } = props;
+  const { teachers, currentYear } = props;
 
   const router = useRouter();
   const [departmentID, setDepartmentID] = useState<number | string>(1);
@@ -101,7 +102,8 @@ const OpenAddModal: FC<ModalProps> = (props) => {
   const isValid = !formData.userID || formData.teacherID == 0;
 
   async function getRegisteredTeachers() {
-    const registeredTeachersURL = process.env.CSR_API_URI + '/teachers/fundRegistered/2024';
+    const registeredTeachersURL =
+      process.env.CSR_API_URI + `/teachers/fundRegistered/${currentYear}`;
     const resData = await get(registeredTeachersURL);
     setRegisteredTeacherIds(resData);
     const firstNotRegisteredTeacher = teachers.find((teacher) => {

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -45,12 +45,18 @@ export default function EditModal(props: ModalProps) {
   useEffect(() => {
     if (teacher?.departmentID !== departmentID) {
       const relatedTeachers = teachers.filter((teacher) => teacher.departmentID === departmentID);
+      const firstNotRegisteredTeacher = relatedTeachers.find((teacher) => {
+        return (
+          !registeredTeacherIds.includes(teacher?.id || 0) ||
+          fundInformation.teacherID === teacher.id
+        );
+      });
       relatedTeachers &&
         setFormData({
           ...formData,
-          teacherID: relatedTeachers[0]?.id || 0,
+          teacherID: firstNotRegisteredTeacher?.id || 0,
         });
-      setTeacher(relatedTeachers[0]);
+      setTeacher(firstNotRegisteredTeacher);
     }
   }, [departmentID]);
 

--- a/view/next-project/src/components/fund_information/EditModal.tsx
+++ b/view/next-project/src/components/fund_information/EditModal.tsx
@@ -14,12 +14,13 @@ interface ModalProps {
   users: User[];
   departments: Department[];
   fundInformation: FundInformation;
+  currentYear: string;
 }
 
 export default function EditModal(props: ModalProps) {
   const router = useRouter();
 
-  const { teachers, fundInformation } = props;
+  const { teachers, fundInformation, currentYear } = props;
 
   const [formData, setFormData] = useState<FundInformation>({
     id: fundInformation.id,
@@ -101,7 +102,8 @@ export default function EditModal(props: ModalProps) {
   }, [bureauId]);
 
   async function getRegisteredTeachers() {
-    const registeredTeachersURL = process.env.CSR_API_URI + '/teachers/fundRegistered/2024';
+    const registeredTeachersURL =
+      process.env.CSR_API_URI + `/teachers/fundRegistered/${currentYear}`;
     const resData = await get(registeredTeachersURL);
     setRegisteredTeacherIds(resData);
   }

--- a/view/next-project/src/components/fund_information/OpenAddModalButton.tsx
+++ b/view/next-project/src/components/fund_information/OpenAddModalButton.tsx
@@ -10,6 +10,7 @@ interface Props {
   departments: Department[];
   users: User[];
   currentUser?: User;
+  currentYear: string;
 }
 
 export const OpenAddModalButton = (props: Props) => {
@@ -32,6 +33,7 @@ export const OpenAddModalButton = (props: Props) => {
           departments={props.departments}
           users={props.users}
           currentUser={props.currentUser}
+          currentYear={props.currentYear}
         />
       )}
     </>

--- a/view/next-project/src/components/fund_information/OpenEditModalButton.tsx
+++ b/view/next-project/src/components/fund_information/OpenEditModalButton.tsx
@@ -10,6 +10,7 @@ interface Props {
   users: User[];
   fundInformation: FundInformation;
   isDisabled: boolean;
+  currentYear: string;
 }
 
 export const OpenAddModalButton = (props: Props) => {
@@ -30,6 +31,7 @@ export const OpenAddModalButton = (props: Props) => {
           departments={props.departments}
           users={props.users}
           fundInformation={props.fundInformation}
+          currentYear={props.currentYear}
         />
       )}
     </>

--- a/view/next-project/src/pages/fund_informations/index.tsx
+++ b/view/next-project/src/pages/fund_informations/index.tsx
@@ -73,9 +73,10 @@ export default function FundInformations(props: Props) {
 
   //年の指定
   const yearPeriods = props.yearPeriods;
-  const [selectedYear, setSelectedYear] = useState<string>(
-    yearPeriods ? String(yearPeriods[yearPeriods.length - 1].year) : String(date.getFullYear()),
-  );
+  const currentYear = yearPeriods
+    ? String(yearPeriods[yearPeriods.length - 1].year)
+    : String(date.getFullYear());
+  const [selectedYear, setSelectedYear] = useState<string>(currentYear);
 
   //年度を指定して募金を取得し、fundInformationViewsにset
   const getFundInformations = async () => {
@@ -185,6 +186,7 @@ export default function FundInformations(props: Props) {
               departments={departments}
               users={users}
               currentUser={currentUser}
+              currentYear={currentYear}
             >
               学内募金登録
             </OpenAddModalButton>
@@ -195,6 +197,7 @@ export default function FundInformations(props: Props) {
               departments={departments}
               users={users}
               currentUser={currentUser}
+              currentYear={currentYear}
             ></OpenAddModalButton>
           </div>
         </div>
@@ -241,6 +244,7 @@ export default function FundInformations(props: Props) {
                       users={users}
                       departments={departments}
                       isDisabled={isDisabled(fundViewItem)}
+                      currentYear={currentYear}
                     />
                     <OpenDeleteModalButton
                       id={fundViewItem.fundInformation.id ? fundViewItem.fundInformation.id : 0}
@@ -358,6 +362,7 @@ export default function FundInformations(props: Props) {
                           users={users}
                           departments={departments}
                           isDisabled={isDisabled(fundViewItem)}
+                          currentYear={currentYear}
                         />
                         <OpenDeleteModalButton
                           id={fundViewItem.fundInformation.id ? fundViewItem.fundInformation.id : 0}


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #837 

# 概要
<!-- 開発内容の概要を記載 -->
- 登録済教員のid配列をAPIで取得し、学内募金の登録、編集時に選択不可にした
- 軽微なリファクタリング

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット
![スクリーンショット 2024-07-10 21 17 30](https://github.com/NUTFes/FinanSu/assets/115447919/773e4ae8-d7b7-4114-9841-c0f14f879b34)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- 募金の登録、編集を触って動作がおかしくないか検証する
- 登録済教員が選択不可になっているか

# 備考
