### PR TITLE
購入報告のレシート登録用のAPI作成

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1748,6 +1748,118 @@ const docTemplate = `{
                 }
             },
         },
+        "/receipts": {
+            "get": {
+                tags: ["receipt"],
+                "description": "receiptの一覧を取得",
+                "responses": {
+                    "200": {
+                        "description": "receiptの一覧の取得",
+                    }
+                }
+            },
+            "post": {
+                tags: ["receipt"],
+                "description": "receiptの作成",
+                responses: {
+                    "200": {
+                        "description": "create されたreceiptが返ってくる",
+                    }
+                },
+                "parameters": [
+                    {
+                        "in": "body",
+                        "name": "receipt",
+                        "schema":{
+                            "$ref": "#/definitions/receipt"
+                        },
+                    },
+                ],
+            },
+        },
+        "/receipts/{id}": {
+            "get": {
+                tags: ["receipt"],
+                "description": "IDで指定されたreceiptの取得",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "receiptの取得",
+                    }
+                }
+            },
+            "put": {
+                tags: ["receipt"],
+                "description": "receiptの更新",
+                responses: {
+                    "200": {
+                        "description": "更新されたreceiptが返ってくる",
+                    }
+                },
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    },
+                    {
+                        "in": "body",
+                        "name": "receipt",
+                        "schema":{
+                            "$ref": "#/definitions/receipt"
+                        },
+                    },
+                ],
+            },
+            "delete": {
+                tags: ["receipt"],
+                "description": "IDを指定してreceiptの削除",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                responses: {
+                    "200": {
+                        "description": "receiptの削除完了",
+                    }
+                },
+            },
+        },
+        "/receipts/reports/{id}": {
+            "get": {
+                tags: ["receipt"],
+                "description": "purchaseReportIDで指定されたreceiptの取得",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "id",
+                        "required": true,
+                        "type": "integer"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "reportsIDを指定してreceiptの取得",
+                    }
+                }
+            },
+        },
         "/sources": {
             "get": {
                 tags: ["source"],
@@ -2107,26 +2219,26 @@ const docTemplate = `{
                 ],
             },
         },
-				"/teachers/delete": {
-					"delete": {
-							tags: ["teacher"],
-							"description": "teacherの複数削除",
-							responses: {
-									"200": {
-											"description": "複数のteacherをidで削除できる",
-									}
-							},
-							"parameters": [
-									{
-											"in": "body",
-											"name": "destroyTeacherIDs",
-											"schema":{
-													"$ref": "#/definitions/destroyTeacherIDs"
-											},
-									},
-							],
+		"/teachers/delete": {
+			"delete": {
+					tags: ["teacher"],
+					"description": "teacherの複数削除",
+					responses: {
+							"200": {
+									"description": "複数のteacherをidで削除できる",
+							}
 					},
+					"parameters": [
+							{
+									"in": "body",
+									"name": "destroyTeacherIDs",
+									"schema":{
+											"$ref": "#/definitions/destroyTeacherIDs"
+									},
+							},
+					],
 			},
+		},
         "/teachers/{id}": {
             "get": {
                 tags: ["teacher"],
@@ -2758,34 +2870,61 @@ const docTemplate = `{
                     "purchaseOrderID"
             },
         },
-				"destroyTeacherIDs":{
-					"properties":{
-							"deleteIDs":{
-									"type": "array",
-									"items": {
-											"type": "number"
-									},
-									example: []
-							},
-					},
-					"required":{
-									"deleteIDs",
-					},
-				},
-				"destroyUserIDs":{
-					"properties":{
-							"deleteIDs":{
-									"type": "array",
-									"items": {
-											"type": "number"
-									},
-									example: []
-							},
-					},
-					"required":{
-									"deleteIDs",
-					},
-				},
+        "receipt":{
+            "properties":{
+                "purchaseReportID":{
+                    "type": "int",
+                    "example": 1,
+                },
+                "bucketName":{
+                    "type": "string",
+                    "example": "",
+                },
+                "fileName":{
+                    "type": "string",
+                    "example": "",
+                },
+                "fileType":{
+                    "type": "string",
+                    "example": "",
+                },
+                "remark":{
+                    "type": "string",
+                    "example": "",
+                },
+            },
+            "required":{
+                    "purchaseReportID",
+            },
+        },
+	    "destroyTeacherIDs":{
+	    	"properties":{
+	    			"deleteIDs":{
+	    					"type": "array",
+	    					"items": {
+	    							"type": "number"
+	    					},
+	    					example: []
+	    			},
+	    	},
+	    	"required":{
+	    					"deleteIDs",
+	    	},
+	    },
+	    "destroyUserIDs":{
+	    	"properties":{
+	    			"deleteIDs":{
+	    					"type": "array",
+	    					"items": {
+	    							"type": "number"
+	    					},
+	    					example: []
+	    			},
+	    	},
+	    	"required":{
+	    					"deleteIDs",
+	    	},
+	    },
         "year_periods":{
             "properties":{
                 "year":{

--- a/api/externals/controller/receipt_controller.go
+++ b/api/externals/controller/receipt_controller.go
@@ -1,0 +1,91 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/NUTFes/FinanSu/api/internals/domain"
+	"github.com/NUTFes/FinanSu/api/internals/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type receiptController struct {
+	u usecase.ReceiptUseCase
+}
+
+type ReceiptController interface {
+	IndexReceipt(echo.Context) error
+	ShowReceipt(echo.Context) error
+	FindReceiptsByReportID(echo.Context) error
+	CreateReceipt(echo.Context) error
+	UpdateReceipt(echo.Context) error
+	DestroyReceipt(echo.Context) error
+}
+
+func NewReceiptController(u usecase.ReceiptUseCase) ReceiptController {
+	return &receiptController{u}
+}
+
+func (r *receiptController) IndexReceipt(c echo.Context) error {
+	receipts, err := r.u.GetAllReceipts(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, receipts)
+}
+
+func (r *receiptController) ShowReceipt(c echo.Context) error {
+	id := c.Param("id")
+	receipt, err := r.u.GetReceiptByID(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, receipt)
+}
+
+func (r *receiptController) FindReceiptsByReportID(c echo.Context) error {
+	id := c.Param("id")
+	receipts, err := r.u.GetReceiptByPurchaseReportID(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, receipts)
+}
+
+
+func (r *receiptController) CreateReceipt(c echo.Context) error {
+	var receipt domain.Receipt
+	if err := c.Bind(&receipt); err != nil {
+		fmt.Println("err")
+		return err
+	}
+	latestReceipt, err := r.u.CreateReceipt(c.Request().Context(), receipt)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, latestReceipt)
+}
+
+func (r *receiptController) UpdateReceipt(c echo.Context) error {
+	id := c.Param("id")
+	var receipt domain.Receipt
+	if err := c.Bind(&receipt); err != nil {
+		fmt.Println("err")
+		return err
+	}
+	updatedReceipt, err := r.u.UpdateReceipt(c.Request().Context(), id, receipt)
+
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, updatedReceipt)
+}
+
+func (r *receiptController) DestroyReceipt(c echo.Context) error {
+	id := c.Param("id")
+	err := r.u.DestroyReceipt(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return c.String(http.StatusOK, "Destroy Receipt")
+}

--- a/api/externals/repository/receipt_repository.go
+++ b/api/externals/repository/receipt_repository.go
@@ -1,0 +1,86 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/NUTFes/FinanSu/api/drivers/db"
+	"github.com/NUTFes/FinanSu/api/externals/repository/abstract"
+	"github.com/NUTFes/FinanSu/api/internals/domain"
+)
+
+type receiptRepository struct {
+	client db.Client
+	crud   abstract.Crud
+}
+
+type ReceiptRepository interface {
+	All(context.Context) (*sql.Rows, error)
+	Find(context.Context, string) (*sql.Row, error)
+	FindByPurchaseReportID(context.Context, string) (*sql.Rows, error)
+	FindLatestRecord(context.Context) (*sql.Row, error)
+	Create(context.Context, domain.Receipt) error
+	Update(context.Context, string, domain.Receipt) error
+	Destroy(context.Context, string) error
+}
+
+func NewReceiptRepository(c db.Client, ac abstract.Crud) ReceiptRepository {
+	return &receiptRepository{c, ac}
+}
+
+// 全件取得
+func (r *receiptRepository) All(c context.Context) (*sql.Rows, error) {
+	query := "SELECT * FROM receipts"
+	return r.crud.Read(c, query)
+}
+
+// 1件取得
+func (r *receiptRepository) Find(c context.Context, id string) (*sql.Row, error) {
+	query := "SELECT * FROM receipts WHERE id =" + id
+	return r.crud.ReadByID(c, query)
+}
+
+// 購入報告IDに紐づいたレコードを全件取得
+func (r *receiptRepository) FindByPurchaseReportID(c context.Context, purchaseReportID string) (*sql.Rows, error) {
+	query := "SELECT * FROM receipts WHERE purchase_report_id =" + purchaseReportID
+	return r.crud.Read(c, query)
+}
+
+// 最新のレコード1件取得
+func (r *receiptRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
+	query := "SELECT * FROM receipts ORDER BY id DESC LIMIT 1"
+	return r.crud.ReadByID(c, query)
+}
+
+// 作成
+func (r *receiptRepository) Create(c context.Context, receipt domain.Receipt) error {
+	query := fmt.Sprintf(
+		`INSERT INTO
+			receipts (purchase_report_id, bucket_name, file_name, file_type, remark)
+		VALUES
+			(%d, "%s", "%s", "%s", "%s")`, receipt.PurchaseReportID, receipt.BucketName, receipt.FileName, receipt.FileType, receipt.Remark)
+	return r.crud.UpdateDB(c, query)
+}
+
+// 編集
+func (r *receiptRepository) Update(c context.Context, id string, receipt domain.Receipt) error {
+	query := fmt.Sprintf(`
+			UPDATE
+				receipts
+			SET
+				purchase_report_id = %d,
+				bucket_name = "%s",
+				file_name = "%s",
+				file_type = "%s",
+				remark = "%s"
+			WHERE
+				id = %s`,receipt.PurchaseReportID, receipt.BucketName, receipt.FileName, receipt.FileType, receipt.Remark, id)
+	return r.crud.UpdateDB(c, query)
+}
+
+// 削除
+func (r *receiptRepository) Destroy(c context.Context, id string) error {
+	query := "DELETE FROM receipts WHERE id =" + id
+	return r.crud.UpdateDB(c, query)
+}

--- a/api/internals/di/di.go
+++ b/api/internals/di/di.go
@@ -37,6 +37,7 @@ func InitializeServer() db.Client {
 	purchaseItemRepository := repository.NewPurchaseItemRepository(client, crud)
 	purchaseOrderRepository := repository.NewPurchaseOrderRepository(client, crud)
 	purchaseReportRepository := repository.NewPurchaseReportRepository(client, crud)
+	receiptRepository := repository.NewReceiptRepository(client, crud)
 	sessionRepository := repository.NewSessionRepository(client)
 	sourceRepository := repository.NewSourceRepository(client, crud)
 	sponsorRepository := repository.NewSponsorRepository(client, crud)
@@ -60,6 +61,7 @@ func InitializeServer() db.Client {
 	purchaseItemUseCase := usecase.NewPurchaseItemUseCase(purchaseItemRepository)
 	purchaseOrderUseCase := usecase.NewPurchaseOrderUseCase(purchaseOrderRepository)
 	purchaseReportUseCase := usecase.NewPurchaseReportUseCase(purchaseReportRepository)
+	receiptUseCase := usecase.NewReceiptUseCase(receiptRepository)
 	sourceUseCase := usecase.NewSourceUseCase(sourceRepository)
 	sponsorUseCase := usecase.NewSponsorUseCase(sponsorRepository)
 	sponsorStyleUseCase := usecase.NewSponsorStyleUseCase(sponsorStyleRepository)
@@ -83,6 +85,7 @@ func InitializeServer() db.Client {
 	purchaseItemController := controller.NewPurchaseItemController(purchaseItemUseCase)
 	purchaseOrderController := controller.NewPurchaseOrderController(purchaseOrderUseCase)
 	purchaseReportController := controller.NewPurchaseReportController(purchaseReportUseCase)
+	receiptController := controller.NewReceiptController(receiptUseCase)
 	sourceController := controller.NewSourceController(sourceUseCase)
 	sponsorController := controller.NewSponsorController(sponsorUseCase)
 	sponsorStyleController := controller.NewSponsorStyleController(sponsorStyleUseCase)
@@ -107,6 +110,7 @@ func InitializeServer() db.Client {
 		purchaseItemController,
 		purchaseOrderController,
 		purchaseReportController,
+		receiptController,
 		sourceController,
 		sponsorController,
 		sponsorStyleController,

--- a/api/internals/domain/receipt.go
+++ b/api/internals/domain/receipt.go
@@ -1,0 +1,17 @@
+package domain
+
+import (
+	"time"
+)
+
+type Receipt struct {
+	ID        			int       `json:"id"`
+	PurchaseReportID	uint      `json:"purchaseReportID"`
+	BucketName		    string    `json:"bucketName"`
+	FileName			string    `json:"fileName"`
+	FileType			string    `json:"fileType"`
+	Remark    			string    `json:"remark"`
+	CreatedAt 			time.Time `json:"createdAt"`
+	UpdatedAt 			time.Time `json:"updatedAt"`
+}
+

--- a/api/internals/usecase/receipt_usecase.go
+++ b/api/internals/usecase/receipt_usecase.go
@@ -1,0 +1,149 @@
+package usecase
+
+import (
+	"context"
+
+	rep "github.com/NUTFes/FinanSu/api/externals/repository"
+	"github.com/NUTFes/FinanSu/api/internals/domain"
+	"github.com/pkg/errors"
+)
+
+type receiptUseCase struct {
+	rep rep.ReceiptRepository
+}
+
+type ReceiptUseCase interface {
+	GetAllReceipts(context.Context) ([]domain.Receipt, error)
+	GetReceiptByID(context.Context, string) (domain.Receipt, error)
+	GetReceiptByPurchaseReportID(context.Context, string) ([]domain.Receipt, error)
+	CreateReceipt(context.Context, domain.Receipt) (domain.Receipt, error)
+	UpdateReceipt(context.Context, string, domain.Receipt) (domain.Receipt, error)
+	DestroyReceipt(context.Context, string) error
+}
+
+func NewReceiptUseCase(rep rep.ReceiptRepository) ReceiptUseCase {
+	return &receiptUseCase{rep}
+}
+
+func (r *receiptUseCase) GetAllReceipts(c context.Context) ([]domain.Receipt, error) {
+	receipt := domain.Receipt{}
+	var receipts []domain.Receipt
+
+	//クエリ実行
+	rows, err := r.rep.All(c)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		err := rows.Scan(
+			&receipt.ID,
+			&receipt.PurchaseReportID,
+			&receipt.BucketName,
+			&receipt.FileName,
+			&receipt.FileType,
+			&receipt.Remark,
+			&receipt.CreatedAt,
+			&receipt.UpdatedAt,
+		)
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "can not connect SQL")
+		}
+		receipts = append(receipts, receipt)
+	}
+	return receipts, nil
+}
+
+func (r *receiptUseCase) GetReceiptByID(c context.Context, id string) (domain.Receipt, error) {
+	var receipt domain.Receipt
+	row, err := r.rep.Find(c, id)
+	err = row.Scan(
+		&receipt.ID,
+		&receipt.PurchaseReportID,
+		&receipt.BucketName,
+		&receipt.FileName,
+		&receipt.FileType,
+		&receipt.Remark,
+		&receipt.CreatedAt,
+		&receipt.UpdatedAt,
+	)
+	if err != nil {
+		return receipt, err
+	}
+	return receipt, nil
+}
+
+func (r *receiptUseCase) GetReceiptByPurchaseReportID(c context.Context, PurchaseReportID string) ([]domain.Receipt, error) {
+	receipt := domain.Receipt{}
+	var receipts []domain.Receipt
+	rows, err := r.rep.FindByPurchaseReportID(c, PurchaseReportID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		err := rows.Scan(
+			&receipt.ID,
+			&receipt.PurchaseReportID,
+			&receipt.BucketName,
+			&receipt.FileName,
+			&receipt.FileType,
+			&receipt.Remark,
+			&receipt.CreatedAt,
+			&receipt.UpdatedAt,
+		)
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "can not connect SQL")
+		}
+		receipts = append(receipts, receipt)
+	}
+	return receipts, nil
+}
+
+func (r *receiptUseCase) CreateReceipt(c context.Context, receipt domain.Receipt) (domain.Receipt, error) {
+	var latestReceipt domain.Receipt
+	err := r.rep.Create(c, receipt)
+	row, err := r.rep.FindLatestRecord(c)
+
+	err = row.Scan(
+		&latestReceipt.ID,
+		&latestReceipt.PurchaseReportID,
+		&latestReceipt.BucketName,
+		&latestReceipt.FileName,
+		&latestReceipt.FileType,
+		&latestReceipt.Remark,
+		&latestReceipt.CreatedAt,
+		&latestReceipt.UpdatedAt,
+	)
+	if err != nil {
+		return latestReceipt, err
+	}
+	return latestReceipt, nil
+}
+
+func (r *receiptUseCase) UpdateReceipt(c context.Context, id string, receipt domain.Receipt) (domain.Receipt, error) {
+	updatedReceipt := domain.Receipt{}
+	err := r.rep.Update(c, id, receipt)
+	row, err := r.rep.Find(c,id)
+	err = row.Scan(
+		&updatedReceipt.ID,
+		&updatedReceipt.PurchaseReportID,
+		&updatedReceipt.BucketName,
+		&updatedReceipt.FileName,
+		&updatedReceipt.FileType,
+		&updatedReceipt.Remark,
+		&updatedReceipt.CreatedAt,
+		&updatedReceipt.UpdatedAt,
+	)
+	if err != nil {
+		return updatedReceipt, err
+	}
+	return updatedReceipt, nil
+}
+
+func (r *receiptUseCase) DestroyReceipt(c context.Context, id string) error {
+	err := r.rep.Destroy(c, id)
+	return err
+}

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -20,6 +20,7 @@ type router struct {
 	purchaseItemController    		controller.PurchaseItemController
 	purchaseOrderController   		controller.PurchaseOrderController
 	purchaseReportController  		controller.PurchaseReportController
+	receiptController				controller.ReceiptController
 	sourceController          		controller.SourceController
 	sponsorController         		controller.SponsorController
 	sponsorStyleController    		controller.SponsorStyleController
@@ -47,6 +48,7 @@ func NewRouter(
 	purchaseItemController controller.PurchaseItemController,
 	purchaseOrderController controller.PurchaseOrderController,
 	purchaseReportController controller.PurchaseReportController,
+	receiptController controller.ReceiptController,
 	sourceController controller.SourceController,
 	sponsorController controller.SponsorController,
 	sponsorStyleController controller.SponsorStyleController,
@@ -69,6 +71,7 @@ func NewRouter(
 		purchaseItemController,
 		purchaseOrderController,
 		purchaseReportController,
+		receiptController,
 		sourceController,
 		sponsorController,
 		sponsorStyleController,
@@ -196,6 +199,14 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.GET("/purchasereports/details", r.purchaseReportController.IndexPurchaseReportDetails)
 	e.GET("/purchasereports/:id/details", r.purchaseReportController.ShowPurchaseReportDetail)
 	e.GET("/purchasereports/details/:year", r.purchaseReportController.IndexPurchaseReportDetailsByYear)
+
+	// receiptsのRoute
+	e.GET("/receipts", r.receiptController.IndexReceipt)
+	e.GET("/receipts/:id", r.receiptController.ShowReceipt)
+	e.GET("/receipts/reports/:id", r.receiptController.FindReceiptsByReportID)
+	e.POST("/receipts", r.receiptController.CreateReceipt)
+	e.PUT("/receipts/:id", r.receiptController.UpdateReceipt)
+	e.DELETE("/receipts/:id", r.receiptController.DestroyReceipt)
 
 	// sources
 	e.GET("/sources", r.sourceController.IndexSource)

--- a/mysql/db/receipts.sql
+++ b/mysql/db/receipts.sql
@@ -1,0 +1,13 @@
+use finansu_db;
+
+CREATE TABLE receipts (
+  id int(10) unsigned not null auto_increment,
+  purchase_report_id int(10) not null,
+  bucket_name varchar(255),
+  file_name varchar(255),
+  file_type varchar(255),
+  remark varchar(255),
+  created_at datetime not null default current_timestamp,
+  updated_at datetime not null default current_timestamp on update current_timestamp,
+  PRIMARY KEY (id)
+);


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #842 

# 概要
<!-- 開発内容の概要を記載 -->
- receiptテーブルの作成 [レシートテーブルの作成](https://github.com/NUTFes/FinanSu/pull/843/commits/19d45c1adf655172b10e288947305a6e988063e5)
- APIの作成
  - 基本のCRUD操作
  - `/receipts/reports/{id}` 購入報告IDを指定してレコードのGET
- swaggerの追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
![スクリーンショット 2024-07-11 16 01 14](https://github.com/NUTFes/FinanSu/assets/115447919/eb3025ab-a0a6-485d-ae9d-5506c5857981)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- レシートテーブルを追加する
- swaggerでAPIが全て問題なく使えるか
- コードレビュー

# 備考
