### PR TITLE
Storybookの既存コンポーネントを表示する(/sponsors)

### DIFF
--- a/view/next-project/src/components/sponsors/index.ts
+++ b/view/next-project/src/components/sponsors/index.ts
@@ -1,0 +1,6 @@
+export { default as DeleteModal } from './DeleteModal';
+export { default as OpenAddModalButton } from './OpenAddModalButton';
+export { default as OpenDeleteModalButton } from './OpenDeleteModalButton';
+export { default as OpenEditModalButton } from './OpenEditModalButton';
+export { default as SponsorAddModal } from './SponsorAddModal';
+export { default as SponsorEditModal } from './SponsorEditModal';

--- a/view/next-project/src/stories/sponsors/DeleteModal.stories.tsx
+++ b/view/next-project/src/stories/sponsors/DeleteModal.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { DeleteModal } from '@components/sponsors';
+
+const meta: Meta<typeof DeleteModal> = {
+  title: 'FinanSu/sponsors/DeleteModal',
+  component: DeleteModal,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/sponsors/OpenAddModalButton.stories.tsx
+++ b/view/next-project/src/stories/sponsors/OpenAddModalButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { OpenAddModalButton } from '@components/sponsors';
+
+const meta: Meta<typeof OpenAddModalButton> = {
+  title: 'FinanSu/sponsors/OpenAddModalButton',
+  component: OpenAddModalButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/sponsors/OpenDeleteModalButton.stories.tsx
+++ b/view/next-project/src/stories/sponsors/OpenDeleteModalButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { OpenDeleteModalButton } from '@components/sponsors';
+
+const meta: Meta<typeof OpenDeleteModalButton> = {
+  title: 'FinanSu/sponsors/OpenDeleteModalButton',
+  component: OpenDeleteModalButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/sponsors/OpenEditModalButton.stories.tsx
+++ b/view/next-project/src/stories/sponsors/OpenEditModalButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { OpenEditModalButton } from '@components/sponsors';
+
+const meta: Meta<typeof OpenEditModalButton> = {
+  title: 'FinanSu/sponsors/OpenEditModalButton',
+  component: OpenEditModalButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/sponsors/SponsorAddModal.stories.tsx
+++ b/view/next-project/src/stories/sponsors/SponsorAddModal.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { SponsorAddModal } from '@components/sponsors';
+
+const meta: Meta<typeof SponsorAddModal> = {
+  title: 'FinanSu/sponsors/SponsorAddModal',
+  component: SponsorAddModal,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/sponsors/SponsorEditModal.stories.tsx
+++ b/view/next-project/src/stories/sponsors/SponsorEditModal.stories.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
 import { Meta, StoryFn } from '@storybook/react';
+import React, { useState } from 'react';
 import SponsorEditModal from '@components/sponsors/SponsorEditModal';
 import { Sponsor } from '@type/common';
 

--- a/view/next-project/src/stories/sponsors/SponsorEditModal.stories.tsx
+++ b/view/next-project/src/stories/sponsors/SponsorEditModal.stories.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import SponsorEditModal from '@components/sponsors/SponsorEditModal';
+import { Sponsor } from '@type/common';
+
+export default {
+  title: 'FinanSu/sponsors/SponsorEditModal',
+  component: SponsorEditModal,
+  argTypes: {},
+} as Meta<typeof SponsorEditModal>;
+
+const Template: StoryFn<typeof SponsorEditModal> = (args) => {
+  const [isOpen, setIsOpen] = useState(true);
+  return <SponsorEditModal {...args} setIsOpen={setIsOpen} />;
+};
+
+const mockSponsor: Sponsor = {
+  id: 0,
+  name: 'JOJO',
+  tel: '01234567',
+  email: 'jojojo@gmail.com',
+  address: 'test',
+  representative: 'aaa',
+  createdAt: 'aaa',
+  updatedAt: 'aaa',
+};
+
+export const Primary = Template.bind({});
+Primary.args = {
+  sponsor: mockSponsor,
+};


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #806 

# 概要
<!-- 開発内容の概要を記載 -->
以下のcomponents/sponsors/stories.tsxのファイルを追加
DeleteModal.stories.tsx
OpenAddModalButton.stories.tsx
OpenDeleteModalButton.stories.tsx
OpenEditModalButton.stories.tsx
SponsorAddModal.stories.tsx
SponsorEditModal.stories.tsx

以下のstories/sponsors/index.tsのファイルを追加
index.ts



# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="374" alt="スクリーンショット 2024-07-12 11 27 50" src="https://github.com/user-attachments/assets/ff4831b9-3e12-4bdc-a11b-904e1b40970f">

# テスト項目
<!-- テストしてほしい内容を記載 -->
- storybook上でsponsorsの各項目が既存コンポーネントの通り表示されているか
- 他のプログラムに悪影響があるエラーがないか
-

# 備考
