### PR TITLE
既存コンポーンネントをstorybook上で、確認できるようにする

### DIFF
--- a/view/next-project/src/components/users/DeleteModal.tsx
+++ b/view/next-project/src/components/users/DeleteModal.tsx
@@ -4,7 +4,7 @@ import { multiDel } from '@api/api_methods';
 import { Modal, CloseButton, OutlinePrimaryButton, PrimaryButton } from '@components/common';
 import { User } from '@type/common';
 
-interface ModalProps {
+export interface ModalProps {
   setShowModal: Dispatch<SetStateAction<boolean>>;
   children?: React.ReactNode;
   deleteUsers?: { users: User[]; ids: number[] };

--- a/view/next-project/src/components/users/EditModal.tsx
+++ b/view/next-project/src/components/users/EditModal.tsx
@@ -6,7 +6,7 @@ import { ROLES } from '@/constants/role';
 import { put } from '@api/user';
 import { Bureau, User } from '@type/common';
 
-interface ModalProps {
+export interface ModalProps {
   setShowModal: Dispatch<SetStateAction<boolean>>;
   id: number | string;
   bureaus: Bureau[];

--- a/view/next-project/src/components/users/index.ts
+++ b/view/next-project/src/components/users/index.ts
@@ -1,0 +1,4 @@
+export { default as DeleteModal } from './DeleteModal';
+export { default as EditModal } from './EditModal';
+export { default as OpenDeleteModalButton } from './OpenDeleteModalButton';
+export { default as OpenEditModalButton } from './OpenEditModalButton';

--- a/view/next-project/src/stories/users/DeleteModal.stories.tsx
+++ b/view/next-project/src/stories/users/DeleteModal.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { DeleteModal } from '@components/users/';
+
+const meta: Meta<typeof DeleteModal> = {
+  title: 'FinanSu/users/DeleteModal',
+  component: DeleteModal,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/users/EditModal.stories.tsx
+++ b/view/next-project/src/stories/users/EditModal.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta, StoryFn } from '@storybook/react';
+import { EditModal } from '@components/users'; // 名前のインポートを修正
+
+const meta: Meta<typeof EditModal> = {
+  title: 'FinanSu/users/EditModal',
+  component: EditModal,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+const Template: StoryFn<typeof EditModal> = (args) => <EditModal {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  setShowModal: () => {
+    // Add your implementation here
+  },
+  id: 1,
+  bureaus: [
+    { id: 1, name: 'Bureau 1' },
+    { id: 2, name: 'Bureau 2' },
+  ],
+  user: {
+    id: 1,
+    name: 'John Doe',
+    bureauID: 1,
+    roleID: 1,
+  },
+};

--- a/view/next-project/src/stories/users/OpenDeleteModalButton.stories.tsx
+++ b/view/next-project/src/stories/users/OpenDeleteModalButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { OpenDeleteModalButton } from '@components/users';
+
+const meta: Meta<typeof OpenDeleteModalButton> = {
+  title: 'FinanSu/users/OpenDeleteModalButton',
+  component: OpenDeleteModalButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};

--- a/view/next-project/src/stories/users/OpenEditModalButton.stories.tsx
+++ b/view/next-project/src/stories/users/OpenEditModalButton.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta } from '@storybook/react';
+import { OpenEditModalButton } from '@components/users';
+
+const meta: Meta<typeof OpenEditModalButton> = {
+  title: 'FinanSu/users/OpenEditModalButton',
+  component: OpenEditModalButton,
+  tags: ['autodocs'],
+  argTypes: {},
+};
+
+export default meta;
+
+export const Primary = {
+  args: {
+    className: 'm-10',
+    children: <h1>children</h1>,
+  },
+};


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #809 

# 概要
<!-- 開発内容の概要を記載 -->
FinanSu/view/next-project/src/components/usersに直接入っている.tsxファイルに対応した.stories.tsxファイルを作成する

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="353" alt="スクリーンショット 2024-07-18 18 46 41" src="https://github.com/user-attachments/assets/92923036-2efb-4f14-a20d-4c60f0a43ed6">


# テスト項目
<!-- テストしてほしい内容を記載 -->
- .tsxファイルが.stories.tsxに対応しているか
- usersの各項目が既存コンポーネント通り表示させているか
- 他に悪影響のエラーがあるかどうか

# 備考
なし