### PR TITLE
sponsorStylesの削除方法を論理削除に変更した

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2182,7 +2182,7 @@ const docTemplate = `{
             },
             "delete": {
                 tags: ["sponsorstyle"],
-                "description": "IDを指定してsponsorstyleの削除",
+                "description": "IDを指定してsponsorstyleの論理削除",
                 "parameters": [
                     {
                         "name": "id",
@@ -2194,7 +2194,7 @@ const docTemplate = `{
                 ],
                 responses: {
                     "200": {
-                        "description": "sponsorstyleの削除完了",
+                        "description": "sponsorstyleの論理削除完了",
                     }
                 },
             },

--- a/api/externals/repository/sponsor_style_repository.go
+++ b/api/externals/repository/sponsor_style_repository.go
@@ -29,7 +29,7 @@ func NewSponsorStyleRepository(c db.Client, ac abstract.Crud) SponsorStyleReposi
 
 // 全件取得
 func (ssr *sponsorStyleRepository) All(c context.Context) (*sql.Rows, error) {
-	query := "SELECT * FROM sponsor_styles"
+	query := "SELECT * FROM sponsor_styles WHERE is_deleted IS FALSE"
 	return ssr.crud.Read(c, query)
 }
 
@@ -77,8 +77,10 @@ func (ssr *sponsorStyleRepository) Delete(
 	c context.Context,
 	id string,
 ) error {
-	query := "DELETE FROM sponsor_styles WHERE id =" + id
-	return ssr.crud.UpdateDB(c, query)
+	query := "UPDATE sponsor_styles SET is_deleted = TRUE WHERE id =" + id
+	err := ssr.crud.UpdateDB(c, query)
+
+	return err
 }
 
 func (ssr *sponsorStyleRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {

--- a/api/internals/domain/sponsor_style.go
+++ b/api/internals/domain/sponsor_style.go
@@ -9,7 +9,7 @@ type SponsorStyle struct {
 	Style     string    `json:"style"`
 	Feature   string    `json:"feature"`
 	Price     int       `json:"price"`
-	IsDeleted bool `json:"isDeleted"`
+	IsDeleted bool 			`json:"isDeleted"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }

--- a/api/internals/domain/sponsor_style.go
+++ b/api/internals/domain/sponsor_style.go
@@ -9,6 +9,7 @@ type SponsorStyle struct {
 	Style     string    `json:"style"`
 	Feature   string    `json:"feature"`
 	Price     int       `json:"price"`
+	IsDeleted bool `json:"isDeleted"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }

--- a/api/internals/usecase/activity_usecase.go
+++ b/api/internals/usecase/activity_usecase.go
@@ -244,6 +244,7 @@ func (a *activityUseCase) GetActivityDetail(c context.Context) ([]domain.Activit
 				&styleDetail.SponsorStyle.Style,
 				&styleDetail.SponsorStyle.Feature,
 				&styleDetail.SponsorStyle.Price,
+				&styleDetail.SponsorStyle.IsDeleted,
 				&styleDetail.SponsorStyle.CreatedAt,
 				&styleDetail.SponsorStyle.UpdatedAt,
 			)
@@ -341,6 +342,7 @@ func (a *activityUseCase) GetActivityDetailsByPeriod(c context.Context, year str
 				&styleDetail.SponsorStyle.Style,
 				&styleDetail.SponsorStyle.Feature,
 				&styleDetail.SponsorStyle.Price,
+				&styleDetail.SponsorStyle.IsDeleted,
 				&styleDetail.SponsorStyle.CreatedAt,
 				&styleDetail.SponsorStyle.UpdatedAt,
 			)
@@ -438,6 +440,7 @@ func (a *activityUseCase) GetFilteredActivityDetail(c context.Context, isDone st
 				&styleDetail.SponsorStyle.Style,
 				&styleDetail.SponsorStyle.Feature,
 				&styleDetail.SponsorStyle.Price,
+				&styleDetail.SponsorStyle.IsDeleted,
 				&styleDetail.SponsorStyle.CreatedAt,
 				&styleDetail.SponsorStyle.UpdatedAt,
 			)
@@ -535,6 +538,7 @@ func (a *activityUseCase) GetFilteredActivityDetailByPeriod(c context.Context, i
 				&styleDetail.SponsorStyle.Style,
 				&styleDetail.SponsorStyle.Feature,
 				&styleDetail.SponsorStyle.Price,
+				&styleDetail.SponsorStyle.IsDeleted,
 				&styleDetail.SponsorStyle.CreatedAt,
 				&styleDetail.SponsorStyle.UpdatedAt,
 			)

--- a/api/internals/usecase/sponsor_style_usecase.go
+++ b/api/internals/usecase/sponsor_style_usecase.go
@@ -37,6 +37,7 @@ func (s *sponsorStyleUseCase) GetSponsorStyles(c context.Context) ([]domain.Spon
 			&sponsorStyle.Style,
 			&sponsorStyle.Feature,
 			&sponsorStyle.Price,
+			&sponsorStyle.IsDeleted,
 			&sponsorStyle.CreatedAt,
 			&sponsorStyle.UpdatedAt,
 		)
@@ -57,6 +58,7 @@ func (s *sponsorStyleUseCase) GetSponsorStylesByID(c context.Context, id string)
 		&sponsorStyle.Style,
 		&sponsorStyle.Feature,
 		&sponsorStyle.Price,
+		&sponsorStyle.IsDeleted,
 		&sponsorStyle.CreatedAt,
 		&sponsorStyle.UpdatedAt,
 	)
@@ -81,6 +83,7 @@ func (s *sponsorStyleUseCase) CreateSponsorStyle(
 		&latastSponsorStyle.Style,
 		&latastSponsorStyle.Feature,
 		&latastSponsorStyle.Price,
+		&latastSponsorStyle.IsDeleted,
 		&latastSponsorStyle.CreatedAt,
 		&latastSponsorStyle.UpdatedAt,
 	)
@@ -106,6 +109,7 @@ func (s *sponsorStyleUseCase) UpdateSponsorStyle(
 		&updatedSponsorStyle.Style,
 		&updatedSponsorStyle.Feature,
 		&updatedSponsorStyle.Price,
+		&updatedSponsorStyle.IsDeleted,
 		&updatedSponsorStyle.CreatedAt,
 		&updatedSponsorStyle.UpdatedAt,
 	)

--- a/mysql/db/sponsor_styles.sql
+++ b/mysql/db/sponsor_styles.sql
@@ -5,6 +5,7 @@ CREATE TABLE sponsor_styles (
   style varchar(255) not null,
   feature varchar(255) not null,
   price int(10),
+  is_deleted boolean default false,
   created_at datetime not null default current_timestamp,
   updated_at datetime not null default current_timestamp on update current_timestamp,
   PRIMARY KEY (id)


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #850

# 概要
<!-- 開発内容の概要を記載 -->
sponsorStyleに論理削除を導入しました。
- sponsorStylesのカラムにis_Deletedを追加
- 削除のクエリ文をis_deletedをtrueに変えるように修正
- GETSのクエリ文をis_deletedがfalseのもののみに修正

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- swaggerでsponsorStylesの各操作を実行して、論理削除ができているか
- sponsorStylesを紐づけているところで500エラーが発生しないか
-
確認お願いします。
# 備考
