### PR TITLE
minioのディレクトリ整理&広告データが変更・削除された時minioのオブジェクトも削除

### DIFF
--- a/view/next-project/src/components/sponsoractivities/DetailModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailModal.tsx
@@ -13,9 +13,11 @@ interface ModalProps {
   id: React.ReactNode;
   sponsorActivitiesViewItem: SponsorActivityView;
   isDelete: boolean;
+  year: string;
 }
 
 const DetailModal: FC<ModalProps> = (props) => {
+  const { year } = props;
   const [isChange, setIsChange] = useState<boolean>(false);
   const [sponsorActivitiesView, setSponsorActivitiesView] = useState<SponsorActivityView>(
     props.sponsorActivitiesViewItem,
@@ -48,6 +50,7 @@ const DetailModal: FC<ModalProps> = (props) => {
           setSponsorActivitiesView={setSponsorActivitiesView}
           id={props.id}
           setIsChange={setIsChange}
+          year={year}
         />
       )}
     </Modal>

--- a/view/next-project/src/components/sponsoractivities/DetailPage2.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailPage2.tsx
@@ -24,11 +24,13 @@ interface ModalProps {
   children?: React.ReactNode;
   id: React.ReactNode;
   sponsorActivitiesViewItem: SponsorActivityView;
+  year: string;
   setIsChange: (isChange: boolean) => void;
   setSponsorActivitiesView: (sponsorActivitiesView: SponsorActivityView) => void;
 }
 
 const DetailPage2: FC<ModalProps> = (props) => {
+  const { year } = props;
   const toPage1 = () => {
     props.setPageNum(1);
   };
@@ -68,7 +70,7 @@ const DetailPage2: FC<ModalProps> = (props) => {
     sponsorActivityInformations.map((activityInformation) => {
       const bucketName = activityInformation.bucketName;
       const fileName = activityInformation.fileName;
-      return `${process.env.NEXT_PUBLIC_MINIO_ENDPONT}/${bucketName}/${fileName}`;
+      return `${process.env.NEXT_PUBLIC_MINIO_ENDPONT}/${bucketName}/${year}/advertisements/${fileName}`;
     });
 
   const download = async (url: string, fileName: string) => {
@@ -377,6 +379,7 @@ const DetailPage2: FC<ModalProps> = (props) => {
           sponsorActivityInformations={sponsorActivityInformations}
           setSponsorActivityInformations={setSponsorActivityInformations}
           setIsChange={props.setIsChange}
+          year={year}
         />
       )}
     </>

--- a/view/next-project/src/components/sponsoractivities/DetailPage2.tsx
+++ b/view/next-project/src/components/sponsoractivities/DetailPage2.tsx
@@ -35,7 +35,8 @@ const DetailPage2: FC<ModalProps> = (props) => {
     props.setPageNum(1);
   };
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const [editActivityInformationId, setEditActivityInformationId] = useState<number>(0);
+  const [editActivityInformation, setEditActivityInformation] =
+    useState<SponsorActivityInformation>();
   const [activityInformationData, setActivityInformationData] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -82,6 +83,11 @@ const DetailPage2: FC<ModalProps> = (props) => {
   };
 
   const handleDelete = async (id: number, activityInformation: SponsorActivityInformation) => {
+    //オブジェクト削除
+    const formData = new FormData();
+    formData.append('fileName', `${activityInformation.fileName}`);
+    formData.append('year', year);
+
     const deleteSponsorActivityInformationUrl =
       process.env.CSR_API_URI + '/activity_informations/' + String(id);
     const newSponsorActivityInformations = sponsorActivityInformations.filter(
@@ -92,6 +98,21 @@ const DetailPage2: FC<ModalProps> = (props) => {
     } else {
       const confirm = window.confirm('本当に削除してよろしいですか？');
       if (confirm) {
+        const response = await fetch('/api/advertisements', {
+          method: 'DELETE',
+          body: formData,
+        })
+          .then((response) => {
+            if (response.ok) {
+              return true;
+            } else {
+              alert('削除に失敗');
+              return false;
+            }
+          })
+          .catch((error) => {
+            console.error('Error:', error);
+          });
         const res = await del(deleteSponsorActivityInformationUrl);
       } else {
         window.alert('キャンセルしました');
@@ -327,7 +348,7 @@ const DetailPage2: FC<ModalProps> = (props) => {
                     <OutlinePrimaryButton
                       className='p-1'
                       onClick={() => {
-                        setEditActivityInformationId(index);
+                        setEditActivityInformation(activityInformation);
                         setIsOpen(true);
                       }}
                     >
@@ -348,7 +369,7 @@ const DetailPage2: FC<ModalProps> = (props) => {
                     <OutlinePrimaryButton
                       className='mx-auto my-2'
                       onClick={() => {
-                        setEditActivityInformationId(index);
+                        setEditActivityInformation(activityInformation);
                         setIsOpen(true);
                       }}
                     >
@@ -375,7 +396,7 @@ const DetailPage2: FC<ModalProps> = (props) => {
         <UplaodFileModal
           setIsOpen={setIsOpen}
           id={props.sponsorActivitiesViewItem.sponsorActivity.id || 0}
-          ActivityInformationId={editActivityInformationId}
+          activityInformation={editActivityInformation}
           sponsorActivityInformations={sponsorActivityInformations}
           setSponsorActivityInformations={setSponsorActivityInformations}
           setIsChange={props.setIsChange}

--- a/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
@@ -11,6 +11,7 @@ interface ModalProps {
   children?: React.ReactNode;
   id: number;
   ActivityInformationId: number;
+  year: string;
   sponsorActivityInformations?: SponsorActivityInformation[];
   setSponsorActivityInformations: (
     sponsorActivityInformations: SponsorActivityInformation[],
@@ -19,6 +20,7 @@ interface ModalProps {
 }
 
 const UplaodFileModal: FC<ModalProps> = (props) => {
+  const { year } = props;
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [preview, setPreview] = useState({ uploadImageURL: '', type: '' });
@@ -74,8 +76,9 @@ const UplaodFileModal: FC<ModalProps> = (props) => {
     formData.append('file', imageFile);
     const fileName = imageFile?.name || '';
     formData.append('fileName', fileName);
+    formData.append('year', year);
 
-    const response = await fetch('/api/minio', {
+    const response = await fetch('/api/advertisements', {
       method: 'POST',
       body: formData,
     })

--- a/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
@@ -10,7 +10,7 @@ interface ModalProps {
   setIsOpen: (isOpen: boolean) => void;
   children?: React.ReactNode;
   id: number;
-  ActivityInformationId: number;
+  activityInformation?: SponsorActivityInformation;
   year: string;
   sponsorActivityInformations?: SponsorActivityInformation[];
   setSponsorActivityInformations: (
@@ -20,21 +20,21 @@ interface ModalProps {
 }
 
 const UplaodFileModal: FC<ModalProps> = (props) => {
-  const { year } = props;
+  const { year, activityInformation } = props;
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [preview, setPreview] = useState({ uploadImageURL: '', type: '' });
-  const [activityInformation, setActivityInformation] = useState<SponsorActivityInformation>(
-    (props.sponsorActivityInformations &&
-      props.sponsorActivityInformations[props.ActivityInformationId]) || {
-      activityID: props.id,
-      bucketName: '',
-      fileName: '',
-      fileType: '',
-      designProgress: 1,
-      fileInformation: '',
-    },
-  );
+  const [registerActivityInformation, setRegisterActivityInformation] =
+    useState<SponsorActivityInformation>(
+      activityInformation || {
+        activityID: props.id,
+        bucketName: '',
+        fileName: '',
+        fileType: '',
+        designProgress: 1,
+        fileInformation: '',
+      },
+    );
 
   const sponsorActivityInformations = props.sponsorActivityInformations || [];
   // loadingの呼び出し
@@ -53,8 +53,8 @@ const UplaodFileModal: FC<ModalProps> = (props) => {
     const fileName = targetFile.name;
     const fileType = targetFile.type;
 
-    setActivityInformation({
-      ...activityInformation,
+    setRegisterActivityInformation({
+      ...registerActivityInformation,
       bucketName: bucketName || '',
       fileName: fileName,
       fileType: fileType,
@@ -67,10 +67,37 @@ const UplaodFileModal: FC<ModalProps> = (props) => {
     props.setIsOpen(false);
   };
 
+  const objectDeleteHandle = async () => {
+    const formData = new FormData();
+    formData.append('fileName', `${activityInformation?.fileName}`);
+    formData.append('year', year);
+    const response = await fetch('/api/advertisements', {
+      method: 'DELETE',
+      body: formData,
+    })
+      .then((response) => {
+        if (response.ok) {
+          return true;
+        } else {
+          alert('削除に失敗');
+          return false;
+        }
+      })
+      .catch((error) => {
+        console.error('Error:', error);
+      });
+  };
+
   const submit = async () => {
     if (!imageFile) {
       return;
     }
+
+    //更新の場合削除
+    if (activityInformation?.fileName !== '') {
+      objectDeleteHandle();
+    }
+
     setIsLoading(true);
     const formData = new FormData();
     formData.append('file', imageFile);
@@ -101,12 +128,12 @@ const UplaodFileModal: FC<ModalProps> = (props) => {
     }
 
     const sponsorActivitiesUrl =
-      process.env.CSR_API_URI + '/activity_informations/' + activityInformation.id;
-    const res = await put(sponsorActivitiesUrl, activityInformation);
+      process.env.CSR_API_URI + '/activity_informations/' + activityInformation?.id;
+    const res = await put(sponsorActivitiesUrl, registerActivityInformation);
     const newSponsorActivityInformations = sponsorActivityInformations.map(
       (sponsorActivityInformation) => {
-        if (sponsorActivityInformation.id === activityInformation.id) {
-          return activityInformation;
+        if (sponsorActivityInformation.id === registerActivityInformation.id) {
+          return registerActivityInformation;
         }
         return sponsorActivityInformation;
       },

--- a/view/next-project/src/pages/api/advertisements.tsx
+++ b/view/next-project/src/pages/api/advertisements.tsx
@@ -36,7 +36,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
 
       const bucketName = 'finansu';
-      const fileName = files.file[0].originalFilename;
+      const year = fields.year && fields.year[0];
+      const fileName = `${year}/advertisements/${files.file[0].originalFilename}`;
       const file = files.file[0];
       const mimetype = file.mimetype;
       const metaData = {

--- a/view/next-project/src/pages/api/advertisements.tsx
+++ b/view/next-project/src/pages/api/advertisements.tsx
@@ -58,6 +58,30 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(200).json({ message: '成功' });
     });
   }
+
+  // 変更の場合の画像を削除する
+  if (req.method === 'DELETE') {
+    const form = formidable();
+
+    form.parse(req, async (err, fields, files: any) => {
+      if (err) {
+        throw new Error('Error parsing form');
+      }
+
+      const year = fields.year && fields.year[0];
+      const fileName = fields.fileName && fields.fileName;
+      const filePath = `${year}/advertisements/${fileName}`;
+
+      try {
+        await minioClient.removeObject(BUCKET_NAME, filePath);
+        console.log('Removed the object');
+      } catch (err) {
+        res.status(400).json({ message: '失敗' });
+        throw new Error('Error uploading file (' + err + ')');
+      }
+      return res.status(200).json({ message: '成功' });
+    });
+  }
 }
 
 // バケットがない時に作成する関数(環境構築時のみ)

--- a/view/next-project/src/pages/sponsoractivities/index.tsx
+++ b/view/next-project/src/pages/sponsoractivities/index.tsx
@@ -628,6 +628,7 @@ export default function SponsorActivities(props: Props) {
           setIsOpen={setIsOpen}
           sponsorActivitiesViewItem={sponsorActivitiesItem}
           isDelete={false}
+          year={selectedYear}
         />
       )}
     </MainLayout>


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #862 

# 概要
<!-- 開発内容の概要を記載 -->
- minioのディレクトリ整理 /finansu/{年度}/advertisements/{filename}に格納される
- 広告データが変更・削除された時minioのオブジェクトも削除

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`

![スクリーンショット 2024-07-28 14 14 07](https://github.com/user-attachments/assets/4e1e0bce-919d-4b37-b64f-5e83cc967aef)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 新しく登録したデータが正しく表示されるか
- [ ] これまでに登録していたデータを
- [ ] {年度}/advertisements/に移動させて正しく表示されるか
- [x] 広告データを変更した際に、これまでのデータが削除されているか


# 備考
