### PR TITLE
レシート登録時にファイル名を動的生成

### DIFF
--- a/view/next-project/src/components/purchasereports/UploadFileModal.tsx
+++ b/view/next-project/src/components/purchasereports/UploadFileModal.tsx
@@ -54,6 +54,11 @@ const UplaodFileModal: FC<ModalProps> = (props) => {
       });
   };
 
+  const generateRandomString = (charCount = 7): string => {
+    const str = Math.random().toString(36).substring(2).slice(-charCount);
+    return str.length < charCount ? str + 'a'.repeat(charCount - str.length) : str;
+  };
+
   const submit = async () => {
     if (!imageFile) {
       return;
@@ -65,9 +70,23 @@ const UplaodFileModal: FC<ModalProps> = (props) => {
 
     setIsLoading(true);
     const formData = new FormData();
+
+    //拡張子取得
+    const uploadFileName = imageFile?.name || '';
+    const Extension = uploadFileName.split('.').pop();
+
+    // 日付取得
+    const date = new Date();
+    const month = date.getMonth() < 10 ? '0' + date.getMonth() : date.getMonth();
+    const day = date.getDate() < 10 ? '0' + date.getDate() : date.getDate();
+    const formattedDate = `${date.getFullYear()}${month}${day}`;
+    const randomStr = generateRandomString();
+
+    // ファイル名作成
+    const fileName = `receipt_${formattedDate}_${randomStr}.${Extension}`;
+
     formData.append('file', imageFile);
-    const fileName = imageFile?.name || '';
-    formData.append('fileName', `receipts/${fileName}`);
+    formData.append('fileName', fileName);
     formData.append('year', year);
 
     const response = await fetch('/api/receipts', {
@@ -94,7 +113,7 @@ const UplaodFileModal: FC<ModalProps> = (props) => {
     const sendReceipt: Receipt = {
       purchaseReportID: Number(id),
       bucketName: process.env.NEXT_PUBLIC_BUCKET_NAME || '',
-      fileName: imageFile.name,
+      fileName: fileName,
       fileType: imageFile.type,
       remark: '',
     };
@@ -176,7 +195,7 @@ const UplaodFileModal: FC<ModalProps> = (props) => {
         </div>
       </div>
       <div className='my-2 flex w-full flex-wrap justify-center'>
-        <PrimaryButton type='button' onClick={() => submit()} disabled={isLoading && !imageFile}>
+        <PrimaryButton type='button' onClick={() => submit()} disabled={isLoading || !imageFile}>
           登録
         </PrimaryButton>
       </div>

--- a/view/next-project/src/components/purchasereports/UploadFileModal.tsx
+++ b/view/next-project/src/components/purchasereports/UploadFileModal.tsx
@@ -77,7 +77,8 @@ const UplaodFileModal: FC<ModalProps> = (props) => {
 
     // 日付取得
     const date = new Date();
-    const month = date.getMonth() < 10 ? '0' + date.getMonth() : date.getMonth();
+    const thisMonth = date.getMonth() + 1;
+    const month = thisMonth < 10 ? '0' + thisMonth : thisMonth;
     const day = date.getDate() < 10 ? '0' + date.getDate() : date.getDate();
     const formattedDate = `${date.getFullYear()}${month}${day}`;
     const randomStr = generateRandomString();

--- a/view/next-project/src/pages/api/receipts.tsx
+++ b/view/next-project/src/pages/api/receipts.tsx
@@ -37,7 +37,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       const bucketName = 'finansu';
       const year = fields.year && fields.year[0];
-      const fileName = `${year}/receipts/${files.file[0].originalFilename}`;
+      const fileName = fields.fileName
+        ? `${year}/receipts/${fields.fileName}`
+        : `${year}/receipts/${files.file[0].originalFilename}`;
       const file = files.file[0];
       const mimetype = file.mimetype;
       const metaData = {


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #870

# 概要
<!-- 開発内容の概要を記載 -->
- レシート登録時にファイル名を動的に生成するようにした
- iphoneなどで写真を撮って登録する際、ファイル名はimage.pngになってしまうため、その対応

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- minio上でレシートのファイル名が統一されているか
- レシートの登録、変更、削除などの動作が問題ないか

# 備考
