### PR TITLE
100MB以上の広告データがアップロードできない問題を修正

### DIFF
--- a/view/next-project/src/components/common/Loading/Loading.tsx
+++ b/view/next-project/src/components/common/Loading/Loading.tsx
@@ -3,6 +3,8 @@ import React, { useEffect } from 'react';
 
 interface Props {
   text?: string;
+  value?: number;
+  isProgress?: boolean;
 }
 
 function Loading(props: Props) {
@@ -21,7 +23,13 @@ function Loading(props: Props) {
     <>
       <div className='fixed inset-0 z-50 flex items-center justify-center overflow-y-auto overflow-x-hidden bg-black-300/50 outline-none focus:outline-none'>
         <div className='relative mx-auto flex  items-center gap-2'>
-          <CircularProgress isIndeterminate color='blue.500' size='120px' thickness='4px' />
+          <CircularProgress
+            isIndeterminate={!props.isProgress}
+            color='blue.500'
+            size='120px'
+            thickness='4px'
+            value={props.value}
+          />
           <div className='text-white text-xl font-medium'>{props.text}</div>
         </div>
       </div>

--- a/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
@@ -81,7 +81,7 @@ const UploadFileModal: FC<ModalProps> = (props) => {
     props.setIsOpen(false);
   };
 
-    // オブジェクト削除処理
+  // オブジェクト削除処理
   const objectDeleteHandle = async () => {
     const formData = new FormData();
     formData.append('fileName', `${activityInformation?.fileName}`);
@@ -102,7 +102,7 @@ const UploadFileModal: FC<ModalProps> = (props) => {
     }
   };
 
-    // ファイルをチャンクに分割する関数
+  // ファイルをチャンクに分割する関数
   const splitFile = (file: File, chunkSize: number) => {
     const chunks = [];
     let offset = 0;

--- a/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
@@ -152,7 +152,6 @@ const UploadFileModal: FC<ModalProps> = (props) => {
 
         // 進捗状況を更新
         setUploadProgress(((i + 1) / chunks.length) * 100);
-
       } catch (error) {
         console.error(`チャンク${i + 1}/${chunks.length}のアップロード失敗:`, error);
         alert('登録に失敗しました');

--- a/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/UploadFileModal.tsx
@@ -197,8 +197,8 @@ const UploadFileModal: FC<ModalProps> = (props) => {
           className='file:mr-4 file:rounded-full file:border-0 file:px-4 file:py-2 file:text-sm hover:file:bg-grey-300'
         />
         {isLoading && (
-          <div className="w-full text-center mt-2">
-            <p className="text-sm text-gray-600">{uploadProgress}% アップロード中...</p>
+          <div className='mt-2 w-full text-center'>
+            <p className='text-gray-600 text-sm'>{uploadProgress}% アップロード中...</p>
           </div>
         )}
       </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #876 

# 概要
<!-- 開発内容の概要を記載 -->

- データを直接minioへ送信するのではなく，クライアント側でデータを分割し，サーバーで結合してからminioへ送信するように修正しました．

- Loadingコンポーネントに進捗属性を追加
- 1GB以上のファイルを防ぐバリデーションを追加

# 画面スクリーンショット等


![image](https://github.com/user-attachments/assets/3abe6b2d-0616-43e3-84ba-2df9ebb63794)
<img width="800" alt="image" src="https://github.com/user-attachments/assets/42bb45fa-5aae-4d57-bf05-2f31a2cd3073">



# テスト項目
<!-- テストしてほしい内容を記載 -->

- [ ]  Cloudflare Tunnel を経由してローカル環境をビルドし，公開する．
- [ ] http://localhost:3000/sponsoractivities にアクセスできること．
- [ ]  広告データとして100MB以上のファイルを追加できること．
(検証用に使った画像のサイト：https://sample-img.lb-product.com/)
- [ ] 送信中に％が増えていくこと．
- [ ]  画像のプレビューに表示され，minio上で追加したファイルが確認できること．
- [ ] ローディングの表示が確認できる．
- [ ] 1GB以上のファイルを送信できない

# 備考

Zeenの記事のようにしなくても解決できました！
アップロードするまで，ちょっと遅いかも...
~~FinanSuのCloudflare Tunnelを利用するためのjsonファイルとcert.pemファイルが見つからなかったため，`https://bingo.nutfes.net/`で検証しました．確認方法やFinanSuのを知りたいです．~~
(普通にsettingsに入ってた…)