### PR TITLE
goquの導入

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,4 +2,15 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "eslint.workingDirectories": ["./view/next-project"],
+  "[go]": {
+    "editor.defaultFormatter": "golang.go"
+  },
+  "emeraldwalk.runonsave": {
+    "commands": [
+      {
+        "match": "\\.go$",
+        "cmd": "golines ${file} -w"
+      }
+    ]
+  }
 }

--- a/api/externals/repository/abstract/abstract_repository.go
+++ b/api/externals/repository/abstract/abstract_repository.go
@@ -25,6 +25,7 @@ func NewCrud(client db.Client) Crud {
 
 func (a abstractRepository) Read(ctx context.Context, query string) (*sql.Rows, error) {
 	rows, err := a.client.DB().QueryContext(ctx, query)
+	fmt.Printf("\x1b[36m%s\n", err)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot connect SQL")
 	}

--- a/api/externals/repository/dialect_repository.go
+++ b/api/externals/repository/dialect_repository.go
@@ -1,0 +1,8 @@
+package repository
+
+import (
+	goqu "github.com/doug-martin/goqu/v9"
+	_ "github.com/doug-martin/goqu/v9/dialect/mysql"
+)
+
+var dialect = goqu.Dialect("mysql")

--- a/api/externals/repository/sponsor_repository.go
+++ b/api/externals/repository/sponsor_repository.go
@@ -3,9 +3,12 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/NUTFes/FinanSu/api/drivers/db"
 	"github.com/NUTFes/FinanSu/api/externals/repository/abstract"
+	goqu "github.com/doug-martin/goqu/v9"
+	_ "github.com/doug-martin/goqu/v9/dialect/mysql"
 )
 
 type sponsorRepository struct {
@@ -29,13 +32,22 @@ func NewSponsorRepository(c db.Client, ac abstract.Crud) SponsorRepository {
 
 // 全件取得
 func (sr *sponsorRepository) All(c context.Context) (*sql.Rows, error) {
-	query := "SELECT * FROM sponsors"
+	dialect := goqu.Dialect("mysql")
+	query, _, err := dialect.From("sponsors").ToSQL()
+	if err != nil {
+		return nil, err
+	}
 	return sr.crud.Read(c, query)
 }
 
 // 1件取得
 func (sr *sponsorRepository) Find(c context.Context, id string) (*sql.Row, error) {
-	query := "SELECT * FROM sponsors WHERE id = " + id
+	dialect := goqu.Dialect("mysql")
+	query, _, err := dialect.From("sponsors").Where(goqu.Ex{"id": id}).ToSQL()
+	fmt.Println(query)
+	if err != nil {
+		return nil, err
+	}
 	return sr.crud.ReadByID(c, query)
 }
 
@@ -48,10 +60,12 @@ func (sr *sponsorRepository) Create(
 	address string,
 	representative string,
 ) error {
-	query := `
-		INSERT  INTO
-			sponsors (name, tel, email, address, representative)
-		VALUES ("` + name + `","` + tel + `","` + email + `","` + address + `","` + representative + `")`
+	dialect := goqu.Dialect("mysql")
+	ds := dialect.Insert("sponsors").Rows(goqu.Record{"name": name, "tel": tel, "email": email, "address": address, "representative": representative})
+	query, _, err := ds.ToSQL()
+	if err != nil {
+		return err
+	}
 	return sr.crud.UpdateDB(c, query)
 }
 
@@ -65,16 +79,12 @@ func (sr *sponsorRepository) Update(
 	address string,
 	representative string,
 ) error {
-	query := `
-		UPDATE
-			sponsors
-		SET
-			name = "` + name +
-		`", tel="` + tel +
-		`", email = "` + email +
-		`", address = "` + address +
-		`", representative = "` + representative +
-		`" WHERE id = ` + id
+	dialect := goqu.Dialect("mysql")
+	ds := dialect.Update("sponsors").Set(goqu.Record{"name": name, "tel": tel, "email": email, "address": address, "representative": representative}).Where(goqu.Ex{"id": id})
+	query, _, err := ds.ToSQL()
+	if err != nil {
+		return err
+	}
 	return sr.crud.UpdateDB(c, query)
 }
 
@@ -83,36 +93,32 @@ func (sr *sponsorRepository) Delete(
 	c context.Context,
 	id string,
 ) error {
-	query := "DELETE FROM sponsors WHERE id =" + id
+	dialect := goqu.Dialect("mysql")
+	ds := dialect.Delete("sponsors").Where(goqu.Ex{"id": id})
+	query, _, err := ds.ToSQL()
+	if err != nil {
+		return err
+	}
 	return sr.crud.UpdateDB(c, query)
 
 }
 
 // 最新のsponcerを取得する
 func (sr *sponsorRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
-	query := `SELECT * FROM sponsors ORDER BY id DESC LIMIT 1`
+	dialect := goqu.Dialect("mysql")
+	query, _, err := dialect.From("sponsors").Order(goqu.I("id").Desc()).Limit(1).ToSQL()
+	if err != nil {
+		return nil, err
+	}
 	return sr.crud.ReadByID(c, query)
 }
 
 // 年度別に取得
 func (sr *sponsorRepository) AllByPeriod(c context.Context, year string) (*sql.Rows, error) {
-	query := `
-	SELECT
-		sponsors.*
-	FROM
-		sponsors
-	INNER JOIN
-		year_periods
-	ON
-		sponsors.created_at > year_periods.started_at
-	AND
-		sponsors.created_at < year_periods.ended_at
-	INNER JOIN
-		years
-	ON
-		year_periods.year_id = years.id
-	WHERE
-		years.year = ` + year +
-		" ORDER BY sponsors.id;"
+	dialect := goqu.Dialect("mysql")
+	query, _, err := dialect.Select("sponsors.*").From("sponsors").InnerJoin(goqu.I("year_periods"), goqu.On(goqu.I("sponsors.created_at").Gt(goqu.I("year_periods.started_at")), goqu.I("sponsors.created_at").Lt(goqu.I("year_periods.ended_at")))).InnerJoin(goqu.I("years"), goqu.On(goqu.I("year_periods.year_id").Eq(goqu.I("years.id")))).Where(goqu.Ex{"years.year": year}).Order(goqu.I("sponsors.id").Desc()).ToSQL()
+	if err != nil {
+		return nil, err
+	}
 	return sr.crud.Read(c, query)
 }

--- a/api/externals/repository/sponsor_repository.go
+++ b/api/externals/repository/sponsor_repository.go
@@ -55,7 +55,8 @@ func (sr *sponsorRepository) Create(
 	address string,
 	representative string,
 ) error {
-	ds := dialect.Insert("sponsors").Rows(goqu.Record{"name": name, "tel": tel, "email": email, "address": address, "representative": representative})
+	ds := dialect.Insert("sponsors").
+		Rows(goqu.Record{"name": name, "tel": tel, "email": email, "address": address, "representative": representative})
 	query, _, err := ds.ToSQL()
 	if err != nil {
 		return err
@@ -73,7 +74,9 @@ func (sr *sponsorRepository) Update(
 	address string,
 	representative string,
 ) error {
-	ds := dialect.Update("sponsors").Set(goqu.Record{"name": name, "tel": tel, "email": email, "address": address, "representative": representative}).Where(goqu.Ex{"id": id})
+	ds := dialect.Update("sponsors").
+		Set(goqu.Record{"name": name, "tel": tel, "email": email, "address": address, "representative": representative}).
+		Where(goqu.Ex{"id": id})
 	query, _, err := ds.ToSQL()
 	if err != nil {
 		return err
@@ -106,7 +109,13 @@ func (sr *sponsorRepository) FindLatestRecord(c context.Context) (*sql.Row, erro
 
 // 年度別に取得
 func (sr *sponsorRepository) AllByPeriod(c context.Context, year string) (*sql.Rows, error) {
-	query, _, err := dialect.Select("sponsors.*").From("sponsors").InnerJoin(goqu.I("year_periods"), goqu.On(goqu.I("sponsors.created_at").Gt(goqu.I("year_periods.started_at")), goqu.I("sponsors.created_at").Lt(goqu.I("year_periods.ended_at")))).InnerJoin(goqu.I("years"), goqu.On(goqu.I("year_periods.year_id").Eq(goqu.I("years.id")))).Where(goqu.Ex{"years.year": year}).Order(goqu.I("sponsors.id").Desc()).ToSQL()
+	query, _, err := dialect.Select("sponsors.*").
+		From("sponsors").
+		InnerJoin(goqu.I("year_periods"), goqu.On(goqu.I("sponsors.created_at").Gt(goqu.I("year_periods.started_at")), goqu.I("sponsors.created_at").Lt(goqu.I("year_periods.ended_at")))).
+		InnerJoin(goqu.I("years"), goqu.On(goqu.I("year_periods.year_id").Eq(goqu.I("years.id")))).
+		Where(goqu.Ex{"years.year": year}).
+		Order(goqu.I("sponsors.id").Desc()).
+		ToSQL()
 	if err != nil {
 		return nil, err
 	}

--- a/api/externals/repository/sponsor_repository.go
+++ b/api/externals/repository/sponsor_repository.go
@@ -3,12 +3,10 @@ package repository
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/NUTFes/FinanSu/api/drivers/db"
 	"github.com/NUTFes/FinanSu/api/externals/repository/abstract"
 	goqu "github.com/doug-martin/goqu/v9"
-	_ "github.com/doug-martin/goqu/v9/dialect/mysql"
 )
 
 type sponsorRepository struct {
@@ -32,7 +30,6 @@ func NewSponsorRepository(c db.Client, ac abstract.Crud) SponsorRepository {
 
 // 全件取得
 func (sr *sponsorRepository) All(c context.Context) (*sql.Rows, error) {
-	dialect := goqu.Dialect("mysql")
 	query, _, err := dialect.From("sponsors").ToSQL()
 	if err != nil {
 		return nil, err
@@ -42,9 +39,7 @@ func (sr *sponsorRepository) All(c context.Context) (*sql.Rows, error) {
 
 // 1件取得
 func (sr *sponsorRepository) Find(c context.Context, id string) (*sql.Row, error) {
-	dialect := goqu.Dialect("mysql")
 	query, _, err := dialect.From("sponsors").Where(goqu.Ex{"id": id}).ToSQL()
-	fmt.Println(query)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +55,6 @@ func (sr *sponsorRepository) Create(
 	address string,
 	representative string,
 ) error {
-	dialect := goqu.Dialect("mysql")
 	ds := dialect.Insert("sponsors").Rows(goqu.Record{"name": name, "tel": tel, "email": email, "address": address, "representative": representative})
 	query, _, err := ds.ToSQL()
 	if err != nil {
@@ -79,7 +73,6 @@ func (sr *sponsorRepository) Update(
 	address string,
 	representative string,
 ) error {
-	dialect := goqu.Dialect("mysql")
 	ds := dialect.Update("sponsors").Set(goqu.Record{"name": name, "tel": tel, "email": email, "address": address, "representative": representative}).Where(goqu.Ex{"id": id})
 	query, _, err := ds.ToSQL()
 	if err != nil {
@@ -93,7 +86,6 @@ func (sr *sponsorRepository) Delete(
 	c context.Context,
 	id string,
 ) error {
-	dialect := goqu.Dialect("mysql")
 	ds := dialect.Delete("sponsors").Where(goqu.Ex{"id": id})
 	query, _, err := ds.ToSQL()
 	if err != nil {
@@ -105,7 +97,6 @@ func (sr *sponsorRepository) Delete(
 
 // 最新のsponcerを取得する
 func (sr *sponsorRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
-	dialect := goqu.Dialect("mysql")
 	query, _, err := dialect.From("sponsors").Order(goqu.I("id").Desc()).Limit(1).ToSQL()
 	if err != nil {
 		return nil, err
@@ -115,7 +106,6 @@ func (sr *sponsorRepository) FindLatestRecord(c context.Context) (*sql.Row, erro
 
 // 年度別に取得
 func (sr *sponsorRepository) AllByPeriod(c context.Context, year string) (*sql.Rows, error) {
-	dialect := goqu.Dialect("mysql")
 	query, _, err := dialect.Select("sponsors.*").From("sponsors").InnerJoin(goqu.I("year_periods"), goqu.On(goqu.I("sponsors.created_at").Gt(goqu.I("year_periods.started_at")), goqu.I("sponsors.created_at").Lt(goqu.I("year_periods.ended_at")))).InnerJoin(goqu.I("years"), goqu.On(goqu.I("year_periods.year_id").Eq(goqu.I("years.id")))).Where(goqu.Ex{"years.year": year}).Order(goqu.I("sponsors.id").Desc()).ToSQL()
 	if err != nil {
 		return nil, err

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,6 +3,7 @@ module github.com/NUTFes/FinanSu/api
 go 1.16
 
 require (
+	github.com/doug-martin/goqu/v9 v9.19.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/go-test/deep v1.0.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -2,6 +2,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
 github.com/CloudyKit/jet/v6 v6.2.0/go.mod h1:d3ypHeIRNo2+XyqnGA8s+aphtcVpjP5hPwP/Lzo7Ro4=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.1.3/go.mod h1:T+2WLyt7VH6Lp0TRxQrUYEs64nRc83wkMQrfeIQKduM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -39,11 +40,14 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgraph-io/badger/v2 v2.2007.4/go.mod h1:vSw/ax2qojzbN6eXHIx6KPKtCSHJN/Uz0X0VPruTIhk=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/djherbis/atime v1.1.0/go.mod h1:28OF6Y8s3NQWwacXc5eZTsEsiMzp7LF8MbXE+XJPdBE=
+github.com/doug-martin/goqu/v9 v9.19.0 h1:PD7t1X3tRcUiSdc5TEyOFKujZA5gs3VSA7wxSvBx7qo=
+github.com/doug-martin/goqu/v9 v9.19.0/go.mod h1:nf0Wc2/hV3gYK9LiyqIrzBEVGlI8qW3GuDCEobC4wBQ=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
@@ -77,6 +81,7 @@ github.com/gobwas/ws v1.3.0/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/K
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
@@ -156,6 +161,7 @@ github.com/labstack/echo/v4 v4.11.4/go.mod h1:noh7EvLwqDsmh/X/HWKPUl1AjzJrhyptRy
 github.com/labstack/gommon v0.4.2 h1:F8qTUNXgG1+6WQmqoUWnz8WiEU60mXVVw0P4ht1WRA0=
 github.com/labstack/gommon v0.4.2/go.mod h1:QlUFxVM+SNXhDL/Z7YhocGIBYOiwB0mXm1+1bAPHPyU=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
+github.com/lib/pq v1.10.1/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailgun/raymond/v2 v2.0.48/go.mod h1:lsgvL50kgt1ylcFJYZiULi5fjPBkkhNfj4KA0W54Z18=
@@ -168,6 +174,7 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mediocregopher/radix/v3 v3.8.1/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.25/go.mod h1:ZIOjCQp1OrzBBPIJmfX4qDYFuhU02nx4bn030ixfHLE=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
@@ -315,6 +322,8 @@ golang.org/x/arch v0.3.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.4.0/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
https://nut-m-e-g.slack.com/archives/C020WQ3GY07/p1734923921611839

# 概要
<!-- 開発内容の概要を記載 -->
- sqlを直接記述するのは、sqlインジェクションなどセキュリティ的にも良くないので、クエリビルダーgoquを導入しました。
- ORMを使うことも有用だったが、既存コードのリファクタリング箇所が大きくなる（dbの接続周りなど）ので、クエリビルダーを使うことで対応します。
- クエリビルダーには[goqu](https://github.com/doug-martin/goqu)を使いました
- sponsorsのみリファクタリングしました

goquの採用理由
- この記事参考にした　https://zenn.dev/kmrok/articles/e306daeb936e78
- ダイアレクトサポート（MySQL対応）
- 複雑なクエリも構築可能
- など

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 変更箇所（/sponsors）のapiが機能するか確認してください

# 備考
- golinesという自動整形ツールを導入しました
[run on save](https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave)拡張機能をインストールしてください
https://github.com/segmentio/golines
