### PR TITLE
[予算管理]購入物品APIの作成

### DIFF
--- a/api/drivers/db/db.go
+++ b/api/drivers/db/db.go
@@ -3,9 +3,10 @@ package db
 import (
 	"database/sql"
 	"fmt"
+	"os"
+
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/joho/godotenv"
-	"os"
 )
 
 type client struct {

--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -28,25 +28,8 @@ func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
 	year := c.QueryParam("year")
 	divisionId := c.QueryParam("division_id")
 	var festivalItemDetails FestivalItemDetails
-	var err error
 
-	if year != "" && divisionId != "" {
-		festivalItemDetails, err = f.u.GetFestivalItemsByYearAndDivision(ctx, year, divisionId)
-		if err != nil {
-			return err
-		}
-		return c.JSON(http.StatusOK, festivalItemDetails)
-	}
-
-	if year != "" {
-		festivalItemDetails, err = f.u.GetFestivalItemsByYear(ctx, year)
-		if err != nil {
-			return err
-		}
-		return c.JSON(http.StatusOK, festivalItemDetails)
-	}
-
-	festivalItemDetails, err = f.u.GetFestivalItems(ctx)
+	festivalItemDetails, err := f.u.GetFestivalItems(ctx, year, divisionId)
 	if err != nil {
 		return err
 	}

--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -25,8 +25,17 @@ func NewFestivalItemController(u usecase.FestivalItemUseCase) FestivalItemContro
 
 func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
 	year := c.QueryParam("year")
+	division_id := c.QueryParam("division_id")
 	var festivalItemDetails generated.FestivalItemDetails
 	var err error
+
+	if year != "" && division_id != "" {
+		festivalItemDetails, err = f.u.GetFestivalItemsByYearsAndDivision(c.Request().Context(), year, division_id)
+		if err != nil {
+			return err
+		}
+		return c.JSON(http.StatusOK, festivalItemDetails)
+	}
 
 	if year != "" {
 		festivalItemDetails, err = f.u.GetFestivalItemsByYears(c.Request().Context(), year)

--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -24,13 +24,14 @@ func NewFestivalItemController(u usecase.FestivalItemUseCase) FestivalItemContro
 }
 
 func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
+	ctx := c.Request().Context()
 	year := c.QueryParam("year")
 	divisionId := c.QueryParam("division_id")
 	var festivalItemDetails FestivalItemDetails
 	var err error
 
 	if year != "" && divisionId != "" {
-		festivalItemDetails, err = f.u.GetFestivalItemsByYearAndDivision(c.Request().Context(), year, divisionId)
+		festivalItemDetails, err = f.u.GetFestivalItemsByYearAndDivision(ctx, year, divisionId)
 		if err != nil {
 			return err
 		}
@@ -38,14 +39,14 @@ func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
 	}
 
 	if year != "" {
-		festivalItemDetails, err = f.u.GetFestivalItemsByYear(c.Request().Context(), year)
+		festivalItemDetails, err = f.u.GetFestivalItemsByYear(ctx, year)
 		if err != nil {
 			return err
 		}
 		return c.JSON(http.StatusOK, festivalItemDetails)
 	}
 
-	festivalItemDetails, err = f.u.GetFestivalItems(c.Request().Context())
+	festivalItemDetails, err = f.u.GetFestivalItems(ctx)
 	if err != nil {
 		return err
 	}

--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -1,0 +1,82 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/NUTFes/FinanSu/api/generated"
+	"github.com/NUTFes/FinanSu/api/internals/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type festivalItemController struct {
+	u usecase.FestivalItemUseCase
+}
+
+type FestivalItemController interface {
+	IndexFestivalItems(echo.Context) error
+	CreateFestivalItem(echo.Context) error
+	UpdateFestivalItem(echo.Context) error
+	DestroyFestivalItem(echo.Context) error
+}
+
+func NewFestivalItemController(u usecase.FestivalItemUseCase) FestivalItemController {
+	return &festivalItemController{u}
+}
+
+func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
+	year := c.QueryParam("year")
+	var festivalItemDetails generated.FestivalItemDetails
+	var err error
+
+	if year != "" {
+		festivalItemDetails, err = f.u.GetFestivalItemsByYears(c.Request().Context(), year)
+		if err != nil {
+			return err
+		}
+		return c.JSON(http.StatusOK, festivalItemDetails)
+	}
+
+	festivalItemDetails, err = f.u.GetFestivalItems(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, festivalItemDetails)
+}
+
+func (f *festivalItemController) CreateFestivalItem(c echo.Context) error {
+	festivalItem := new(generated.FestivalItem)
+	if err := c.Bind(festivalItem); err != nil {
+		return c.String(http.StatusBadRequest, "Bad Request")
+	}
+	latastFestivalItem, err := f.u.CreateFestivalItem(c.Request().Context(), *festivalItem)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, latastFestivalItem)
+}
+
+func (f *festivalItemController) UpdateFestivalItem(c echo.Context) error {
+	id := c.Param("id")
+	festivalItem := new(generated.FestivalItem)
+	if err := c.Bind(festivalItem); err != nil {
+		return c.String(http.StatusBadRequest, "Bad Request")
+	}
+	updatedFestivalItem, err := f.u.UpdateFestivalItem(
+		c.Request().Context(),
+		id,
+		*festivalItem,
+	)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, updatedFestivalItem)
+}
+
+func (f *festivalItemController) DestroyFestivalItem(c echo.Context) error {
+	id := c.Param("id")
+	err := f.u.DestroyFestivalItem(c.Request().Context(), id)
+	if err != nil {
+		return err
+	}
+	return c.String(http.StatusOK, "Destroy Festival Item")
+}

--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -26,7 +26,7 @@ func NewFestivalItemController(u usecase.FestivalItemUseCase) FestivalItemContro
 func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
 	year := c.QueryParam("year")
 	division_id := c.QueryParam("division_id")
-	var festivalItemDetails generated.FestivalItemDetails
+	var festivalItemDetails FestivalItemDetails
 	var err error
 
 	if year != "" && division_id != "" {
@@ -53,7 +53,7 @@ func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
 }
 
 func (f *festivalItemController) CreateFestivalItem(c echo.Context) error {
-	festivalItem := new(generated.FestivalItem)
+	festivalItem := new(FestivalItem)
 	if err := c.Bind(festivalItem); err != nil {
 		return c.String(http.StatusBadRequest, "Bad Request")
 	}
@@ -66,7 +66,7 @@ func (f *festivalItemController) CreateFestivalItem(c echo.Context) error {
 
 func (f *festivalItemController) UpdateFestivalItem(c echo.Context) error {
 	id := c.Param("id")
-	festivalItem := new(generated.FestivalItem)
+	festivalItem := new(FestivalItem)
 	if err := c.Bind(festivalItem); err != nil {
 		return c.String(http.StatusBadRequest, "Bad Request")
 	}
@@ -89,3 +89,6 @@ func (f *festivalItemController) DestroyFestivalItem(c echo.Context) error {
 	}
 	return c.String(http.StatusOK, "Destroy Festival Item")
 }
+
+type FestivalItemDetails = generated.FestivalItemDetails
+type FestivalItem = generated.FestivalItem

--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -25,12 +25,12 @@ func NewFestivalItemController(u usecase.FestivalItemUseCase) FestivalItemContro
 
 func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
 	year := c.QueryParam("year")
-	division_id := c.QueryParam("division_id")
+	divisionId := c.QueryParam("division_id")
 	var festivalItemDetails FestivalItemDetails
 	var err error
 
-	if year != "" && division_id != "" {
-		festivalItemDetails, err = f.u.GetFestivalItemsByYearsAndDivision(c.Request().Context(), year, division_id)
+	if year != "" && divisionId != "" {
+		festivalItemDetails, err = f.u.GetFestivalItemsByYearsAndDivision(c.Request().Context(), year, divisionId)
 		if err != nil {
 			return err
 		}

--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -30,7 +30,7 @@ func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
 	var err error
 
 	if year != "" && divisionId != "" {
-		festivalItemDetails, err = f.u.GetFestivalItemsByYearsAndDivision(c.Request().Context(), year, divisionId)
+		festivalItemDetails, err = f.u.GetFestivalItemsByYearAndDivision(c.Request().Context(), year, divisionId)
 		if err != nil {
 			return err
 		}
@@ -38,7 +38,7 @@ func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
 	}
 
 	if year != "" {
-		festivalItemDetails, err = f.u.GetFestivalItemsByYears(c.Request().Context(), year)
+		festivalItemDetails, err = f.u.GetFestivalItemsByYear(c.Request().Context(), year)
 		if err != nil {
 			return err
 		}

--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -41,11 +41,11 @@ func (f *festivalItemController) CreateFestivalItem(c echo.Context) error {
 	if err := c.Bind(festivalItem); err != nil {
 		return c.String(http.StatusBadRequest, "Bad Request")
 	}
-	latastFestivalItem, err := f.u.CreateFestivalItem(c.Request().Context(), *festivalItem)
+	latestFestivalItem, err := f.u.CreateFestivalItem(c.Request().Context(), *festivalItem)
 	if err != nil {
 		return err
 	}
-	return c.JSON(http.StatusOK, latastFestivalItem)
+	return c.JSON(http.StatusOK, latestFestivalItem)
 }
 
 func (f *festivalItemController) UpdateFestivalItem(c echo.Context) error {

--- a/api/externals/controller/financial_record_controller.go
+++ b/api/externals/controller/financial_record_controller.go
@@ -48,11 +48,11 @@ func (f *financialRecordController) CreateFinancialRecord(c echo.Context) error 
 	if err := c.Bind(financialRecord); err != nil {
 		return c.String(http.StatusBadRequest, "Bad Request")
 	}
-	latastFinancialRecord, err := f.u.CreateFinancialRecord(c.Request().Context(), *financialRecord)
+	latestFinancialRecord, err := f.u.CreateFinancialRecord(c.Request().Context(), *financialRecord)
 	if err != nil {
 		return err
 	}
-	return c.JSON(http.StatusOK, latastFinancialRecord)
+	return c.JSON(http.StatusOK, latestFinancialRecord)
 }
 
 func (f *financialRecordController) UpdateFinancialRecord(c echo.Context) error {

--- a/api/externals/controller/financial_record_controller.go
+++ b/api/externals/controller/financial_record_controller.go
@@ -25,7 +25,7 @@ func NewFinancialRecordController(u usecase.FinancialRecordUseCase) FinancialRec
 
 func (f *financialRecordController) IndexFinancialRecords(c echo.Context) error {
 	year := c.QueryParam("year")
-	var financialRecordDetails generated.FinancialRecordDetails
+	var financialRecordDetails FinancialRecordDetails
 	var err error
 
 	if year != "" {
@@ -44,7 +44,7 @@ func (f *financialRecordController) IndexFinancialRecords(c echo.Context) error 
 }
 
 func (f *financialRecordController) CreateFinancialRecord(c echo.Context) error {
-	financialRecord := new(generated.FinancialRecord)
+	financialRecord := new(FinancialRecord)
 	if err := c.Bind(financialRecord); err != nil {
 		return c.String(http.StatusBadRequest, "Bad Request")
 	}
@@ -57,7 +57,7 @@ func (f *financialRecordController) CreateFinancialRecord(c echo.Context) error 
 
 func (f *financialRecordController) UpdateFinancialRecord(c echo.Context) error {
 	id := c.Param("id")
-	financialRecord := new(generated.FinancialRecord)
+	financialRecord := new(FinancialRecord)
 	if err := c.Bind(financialRecord); err != nil {
 		return c.String(http.StatusBadRequest, "Bad Request")
 	}
@@ -80,3 +80,6 @@ func (f *financialRecordController) DestroyFinancialRecord(c echo.Context) error
 	}
 	return c.String(http.StatusOK, "Destroy FinancialRecord")
 }
+
+type FinancialRecordDetails = generated.FinancialRecordDetails
+type FinancialRecord = generated.FinancialRecord

--- a/api/externals/repository/abstract/abstract_repository.go
+++ b/api/externals/repository/abstract/abstract_repository.go
@@ -18,7 +18,9 @@ type Crud interface {
 	ReadByID(context.Context, string) (*sql.Row, error)
 	UpdateDB(context.Context, string) error
 	StartTransaction(context.Context) (*sql.Tx, error)
+	TransactionExec(context.Context, *sql.Tx, string) error
 	Commit(context.Context, *sql.Tx) error
+	RollBack(context.Context, *sql.Tx) error
 }
 
 func NewCrud(client db.Client) Crud {
@@ -51,9 +53,23 @@ func (a abstractRepository) UpdateDB(ctx context.Context, query string) error {
 }
 
 func (a abstractRepository) StartTransaction(ctx context.Context) (*sql.Tx, error) {
+	fmt.Printf("\x1b[36m%s\n", "TransactionStart")
 	return a.client.DB().BeginTx(ctx, nil)
 }
 
+func (a abstractRepository) TransactionExec(ctx context.Context, tx *sql.Tx, query string) error {
+	fmt.Printf("\x1b[36m%s\n", "TransactionExec")
+	_, err := tx.ExecContext(ctx, query)
+	fmt.Printf("\x1b[36m%s\n", query)
+	return err
+}
+
 func (a abstractRepository) Commit(ctx context.Context, tx *sql.Tx) error {
+	fmt.Printf("\x1b[36m%s\n", "Commit")
 	return tx.Commit()
+}
+
+func (a abstractRepository) RollBack(ctx context.Context, tx *sql.Tx) error {
+	fmt.Printf("\x1b[36m%s\n", "RollBack")
+	return tx.Rollback()
 }

--- a/api/externals/repository/abstract/abstract_repository.go
+++ b/api/externals/repository/abstract/abstract_repository.go
@@ -17,6 +17,8 @@ type Crud interface {
 	Read(context.Context, string) (*sql.Rows, error)
 	ReadByID(context.Context, string) (*sql.Row, error)
 	UpdateDB(context.Context, string) error
+	StartTransaction(context.Context) (*sql.Tx, error)
+	Commit(context.Context, *sql.Tx) error
 }
 
 func NewCrud(client db.Client) Crud {
@@ -46,4 +48,12 @@ func (a abstractRepository) UpdateDB(ctx context.Context, query string) error {
 	}
 	fmt.Printf("\x1b[36m%s\n", query)
 	return err
+}
+
+func (a abstractRepository) StartTransaction(ctx context.Context) (*sql.Tx, error) {
+	return a.client.DB().BeginTx(ctx, nil)
+}
+
+func (a abstractRepository) Commit(ctx context.Context, tx *sql.Tx) error {
+	return tx.Commit()
 }

--- a/api/externals/repository/festival_item_repository.go
+++ b/api/externals/repository/festival_item_repository.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/NUTFes/FinanSu/api/drivers/db"
 	"github.com/NUTFes/FinanSu/api/externals/repository/abstract"
@@ -30,7 +29,7 @@ type FestivalItemRepository interface {
 	DeleteItemBudget(context.Context, *sql.Tx, string) error
 	FindLatestRecord(context.Context) (*sql.Row, error)
 	StartTransaction(context.Context) (*sql.Tx, error)
-	RollBack(context.Context, *sql.Tx)
+	RollBack(context.Context, *sql.Tx) error
 	Commit(context.Context, *sql.Tx) error
 }
 
@@ -179,8 +178,7 @@ func (fir *festivalItemRepository) CreateFestivalItem(
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(query)
-
+	err = fir.crud.TransactionExec(c, tx, query)
 	return err
 }
 
@@ -195,8 +193,7 @@ func (fir *festivalItemRepository) CreateItemBudget(
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(query)
-
+	err = fir.crud.TransactionExec(c, tx, query)
 	return err
 }
 
@@ -214,7 +211,7 @@ func (fir *festivalItemRepository) UpdateFestivalItem(
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(query)
+	err = fir.crud.TransactionExec(c, tx, query)
 	return err
 }
 
@@ -229,11 +226,10 @@ func (fir *festivalItemRepository) UpdateItemBudget(
 		Set(goqu.Record{"amount": festivalItem.Amount}).
 		Where(goqu.Ex{"festival_item_id": id})
 	query, _, err := ds.ToSQL()
-	fmt.Println(query)
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(query)
+	err = fir.crud.TransactionExec(c, tx, query)
 	return err
 }
 
@@ -248,8 +244,7 @@ func (fir *festivalItemRepository) DeleteFestivalItem(
 	if err != nil {
 		return err
 	}
-	fmt.Println(query)
-	_, err = tx.Exec(query)
+	err = fir.crud.TransactionExec(c, tx, query)
 	return err
 }
 
@@ -264,7 +259,7 @@ func (fir *festivalItemRepository) DeleteItemBudget(
 	if err != nil {
 		return err
 	}
-	_, err = tx.Exec(query)
+	err = fir.crud.TransactionExec(c, tx, query)
 	return err
 }
 
@@ -300,10 +295,10 @@ func (fir *festivalItemRepository) StartTransaction(c context.Context) (*sql.Tx,
 	return fir.crud.StartTransaction(c)
 }
 
-func (fir *festivalItemRepository) RollBack(c context.Context, tx *sql.Tx) {
-	tx.Rollback()
+func (fir *festivalItemRepository) RollBack(c context.Context, tx *sql.Tx) error {
+	return fir.crud.RollBack(c, tx)
 }
 
 func (fir *festivalItemRepository) Commit(c context.Context, tx *sql.Tx) error {
-	return tx.Commit()
+	return fir.crud.Commit(c, tx)
 }

--- a/api/externals/repository/festival_item_repository.go
+++ b/api/externals/repository/festival_item_repository.go
@@ -24,7 +24,8 @@ type FestivalItemRepository interface {
 	CreateItemBudget(context.Context, *sql.Tx, generated.FestivalItem) error
 	UpdateFestivalItem(context.Context, *sql.Tx, string, generated.FestivalItem) error
 	UpdateItemBudget(context.Context, *sql.Tx, string, generated.FestivalItem) error
-	DeleteFestivalItem(context.Context, string) error
+	DeleteFestivalItem(context.Context, *sql.Tx, string) error
+	DeleteItemBudget(context.Context, *sql.Tx, string) error
 	FindLatestRecord(context.Context) (*sql.Row, error)
 	StartTransaction(context.Context) (*sql.Tx, error)
 	RollBack(context.Context, *sql.Tx)
@@ -186,18 +187,35 @@ func (fir *festivalItemRepository) UpdateItemBudget(
 	return err
 }
 
-// 削除
+// 購入物品削除
 func (fir *festivalItemRepository) DeleteFestivalItem(
 	c context.Context,
+	tx *sql.Tx,
 	id string,
 ) error {
-	ds := dialect.Delete("financial_records").Where(goqu.Ex{"id": id})
+	ds := dialect.Delete("festival_items").Where(goqu.Ex{"id": id})
 	query, _, err := ds.ToSQL()
 	if err != nil {
 		return err
 	}
-	return fir.crud.UpdateDB(c, query)
+	fmt.Println(query)
+	_, err = tx.Exec(query)
+	return err
+}
 
+// 予算削除
+func (fir *festivalItemRepository) DeleteItemBudget(
+	c context.Context,
+	tx *sql.Tx,
+	id string,
+) error {
+	ds := dialect.Delete("item_budgets").Where(goqu.Ex{"festival_item_id": id})
+	query, _, err := ds.ToSQL()
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(query)
+	return err
 }
 
 // 最新のfestivalItemを取得する

--- a/api/externals/repository/festival_item_repository.go
+++ b/api/externals/repository/festival_item_repository.go
@@ -19,10 +19,14 @@ type FestivalItemRepository interface {
 	All(context.Context) (*sql.Rows, error)
 	AllByPeriod(context.Context, string) (*sql.Rows, error)
 	GetById(context.Context, string) (*sql.Row, error)
-	Create(context.Context, generated.FestivalItem) error
-	Update(context.Context, string, generated.FestivalItem) error
-	Delete(context.Context, string) error
+	CreateFestivalItem(context.Context, *sql.Tx, generated.FestivalItem) error
+	CreateItemBudget(context.Context, *sql.Tx, generated.FestivalItem) error
+	UpdateFestivalItem(context.Context, string, generated.FestivalItem) error
+	DeleteFestivalItem(context.Context, string) error
 	FindLatestRecord(context.Context) (*sql.Row, error)
+	StartTransaction(context.Context) (*sql.Tx, error)
+	RollBack(context.Context, *sql.Tx)
+	Commit(context.Context, *sql.Tx) error
 }
 
 func NewFestivalItemRepository(c db.Client, ac abstract.Crud) FestivalItemRepository {
@@ -106,22 +110,41 @@ func (fir *festivalItemRepository) GetById(
 	return fir.crud.ReadByID(c, query)
 }
 
-// 作成
-func (fir *festivalItemRepository) Create(
+// 購入物品作成
+func (fir *festivalItemRepository) CreateFestivalItem(
 	c context.Context,
+	tx *sql.Tx,
 	festivalItem generated.FestivalItem,
 ) error {
-	ds := dialect.Insert("financial_records").
-		Rows(goqu.Record{"name": festivalItem.Name, "year_id": festivalItem.Memo})
+	ds := dialect.Insert("festival_items").
+		Rows(goqu.Record{"name": festivalItem.Name, "memo": festivalItem.Memo, "division_id": festivalItem.DivisionId})
 	query, _, err := ds.ToSQL()
 	if err != nil {
 		return err
 	}
-	return fir.crud.UpdateDB(c, query)
+	_, err = tx.Exec(query)
+
+	return err
+}
+
+func (fir *festivalItemRepository) CreateItemBudget(
+	c context.Context,
+	tx *sql.Tx,
+	festivalItem generated.FestivalItem,
+) error {
+	ds := dialect.Insert("item_budgets").
+		Rows(goqu.Record{"amount": festivalItem.Amount, "festival_item_id": goqu.L("LAST_INSERT_ID()")})
+	query, _, err := ds.ToSQL()
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(query)
+
+	return err
 }
 
 // 編集
-func (fir *festivalItemRepository) Update(
+func (fir *festivalItemRepository) UpdateFestivalItem(
 	c context.Context,
 	id string,
 	festivalItem generated.FestivalItem,
@@ -137,7 +160,7 @@ func (fir *festivalItemRepository) Update(
 }
 
 // 削除
-func (fir *festivalItemRepository) Delete(
+func (fir *festivalItemRepository) DeleteFestivalItem(
 	c context.Context,
 	id string,
 ) error {
@@ -153,23 +176,39 @@ func (fir *festivalItemRepository) Delete(
 // 最新のfestivalItemを取得する
 func (fir *festivalItemRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
 	query, _, err := dialect.Select(
-		"financial_records.id",
-		"financial_records.name", "years.year",
-		goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
+		"festival_items.id",
+		"festival_items.name",
+		"festival_items.memo",
+		"financial_records.name",
+		"divisions.name",
+		"item_budgets.amount",
 		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("SUM(item_budgets.amount) - SUM(buy_reports.amount)"), 0).As("balance")).
-		From("financial_records").
+		goqu.COALESCE(goqu.L("item_budgets.amount - COALESCE(SUM(`buy_reports`.`amount`), 0)"), 0).As("balance")).
+		From("festival_items").
+		InnerJoin(goqu.I("divisions"), goqu.On(goqu.I("festival_items.division_id").Eq(goqu.I("divisions.id")))).
+		InnerJoin(goqu.I("financial_records"), goqu.On(goqu.I("divisions.financial_record_id").Eq(goqu.I("financial_records.id")))).
 		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
-		LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
 		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
 		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("financial_records.id").
-		Order(goqu.I("id").Desc()).
+		GroupBy("festival_items.id", "item_budgets.amount").
+		Order(goqu.I("festival_items.id").Desc()).
 		Limit(1).
 		ToSQL()
+
 	if err != nil {
 		return nil, err
 	}
 	return fir.crud.ReadByID(c, query)
+}
+
+func (fir *festivalItemRepository) StartTransaction(c context.Context) (*sql.Tx, error) {
+	return fir.crud.StartTransaction(c)
+}
+
+func (fir *festivalItemRepository) RollBack(c context.Context, tx *sql.Tx) {
+	tx.Rollback()
+}
+
+func (fir *festivalItemRepository) Commit(c context.Context, tx *sql.Tx) error {
+	return tx.Commit()
 }

--- a/api/externals/repository/festival_item_repository.go
+++ b/api/externals/repository/festival_item_repository.go
@@ -1,0 +1,175 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/NUTFes/FinanSu/api/drivers/db"
+	"github.com/NUTFes/FinanSu/api/externals/repository/abstract"
+	"github.com/NUTFes/FinanSu/api/generated"
+	goqu "github.com/doug-martin/goqu/v9"
+)
+
+type festivalItemRepository struct {
+	client db.Client
+	crud   abstract.Crud
+}
+
+type FestivalItemRepository interface {
+	All(context.Context) (*sql.Rows, error)
+	AllByPeriod(context.Context, string) (*sql.Rows, error)
+	GetById(context.Context, string) (*sql.Row, error)
+	Create(context.Context, generated.FestivalItem) error
+	Update(context.Context, string, generated.FestivalItem) error
+	Delete(context.Context, string) error
+	FindLatestRecord(context.Context) (*sql.Row, error)
+}
+
+func NewFestivalItemRepository(c db.Client, ac abstract.Crud) FestivalItemRepository {
+	return &festivalItemRepository{c, ac}
+}
+
+// 年度別に取得
+func (fir *festivalItemRepository) All(
+	c context.Context,
+) (*sql.Rows, error) {
+	query, _, err := dialect.Select(
+		"financial_records.id",
+		"financial_records.name", "years.year",
+		goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
+		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
+		goqu.COALESCE(goqu.L("SUM(item_budgets.amount) - SUM(buy_reports.amount)"), 0).As("balance")).
+		From("financial_records").
+		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
+		LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
+		LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
+		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
+		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
+		GroupBy("financial_records.id").
+		ToSQL()
+
+	if err != nil {
+		return nil, err
+	}
+	return fir.crud.Read(c, query)
+}
+
+// 年度別に取得
+func (fir *festivalItemRepository) AllByPeriod(
+	c context.Context,
+	year string,
+) (*sql.Rows, error) {
+	query, _, err := dialect.Select(
+		"financial_records.id",
+		"financial_records.name", "years.year",
+		goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
+		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
+		goqu.COALESCE(goqu.L("SUM(item_budgets.amount) - SUM(buy_reports.amount)"), 0).As("balance")).
+		From("financial_records").
+		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
+		LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
+		LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
+		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
+		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
+		GroupBy("financial_records.id").
+		Where(goqu.Ex{"years.year": year}).
+		ToSQL()
+	if err != nil {
+		return nil, err
+	}
+	return fir.crud.Read(c, query)
+}
+
+// IDで取得
+func (fir *festivalItemRepository) GetById(
+	c context.Context,
+	id string,
+) (*sql.Row, error) {
+	query, _, err := dialect.Select(
+		"financial_records.id",
+		"financial_records.name", "years.year",
+		goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
+		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
+		goqu.COALESCE(goqu.L("SUM(item_budgets.amount) - SUM(buy_reports.amount)"), 0).As("balance")).
+		From("financial_records").
+		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
+		LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
+		LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
+		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
+		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
+		GroupBy("financial_records.id").
+		Where(goqu.Ex{"financial_records.id": id}).
+		ToSQL()
+	if err != nil {
+		return nil, err
+	}
+	return fir.crud.ReadByID(c, query)
+}
+
+// 作成
+func (fir *festivalItemRepository) Create(
+	c context.Context,
+	festivalItem generated.FestivalItem,
+) error {
+	ds := dialect.Insert("financial_records").
+		Rows(goqu.Record{"name": festivalItem.Name, "year_id": festivalItem.Memo})
+	query, _, err := ds.ToSQL()
+	if err != nil {
+		return err
+	}
+	return fir.crud.UpdateDB(c, query)
+}
+
+// 編集
+func (fir *festivalItemRepository) Update(
+	c context.Context,
+	id string,
+	festivalItem generated.FestivalItem,
+) error {
+	ds := dialect.Update("financial_records").
+		Set(goqu.Record{"name": festivalItem.Name, "year_id": festivalItem.Memo}).
+		Where(goqu.Ex{"id": id})
+	query, _, err := ds.ToSQL()
+	if err != nil {
+		return err
+	}
+	return fir.crud.UpdateDB(c, query)
+}
+
+// 削除
+func (fir *festivalItemRepository) Delete(
+	c context.Context,
+	id string,
+) error {
+	ds := dialect.Delete("financial_records").Where(goqu.Ex{"id": id})
+	query, _, err := ds.ToSQL()
+	if err != nil {
+		return err
+	}
+	return fir.crud.UpdateDB(c, query)
+
+}
+
+// 最新のfestivalItemを取得する
+func (fir *festivalItemRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
+	query, _, err := dialect.Select(
+		"financial_records.id",
+		"financial_records.name", "years.year",
+		goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
+		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
+		goqu.COALESCE(goqu.L("SUM(item_budgets.amount) - SUM(buy_reports.amount)"), 0).As("balance")).
+		From("financial_records").
+		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
+		LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
+		LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
+		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
+		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
+		GroupBy("financial_records.id").
+		Order(goqu.I("id").Desc()).
+		Limit(1).
+		ToSQL()
+	if err != nil {
+		return nil, err
+	}
+	return fir.crud.ReadByID(c, query)
+}

--- a/api/externals/repository/festival_item_repository.go
+++ b/api/externals/repository/festival_item_repository.go
@@ -199,7 +199,7 @@ var selectFestivalItemQuery = dialect.Select(
 	"divisions.name",
 	goqu.L("COALESCE(`item_budgets`.`amount`, 0)").As("budget"),
 	goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-	goqu.COALESCE(goqu.L("item_budgets.amount - COALESCE(SUM(`buy_reports`.`amount`), 0)"), 0).As("balance")).
+	goqu.L("COALESCE(SUM(item_budgets.amount), 0) - COALESCE(SUM(buy_reports.amount), 0)").As("balance")).
 	From("festival_items").
 	InnerJoin(goqu.I("divisions"), goqu.On(goqu.I("festival_items.division_id").Eq(goqu.I("divisions.id")))).
 	InnerJoin(goqu.I("financial_records"), goqu.On(goqu.I("divisions.financial_record_id").Eq(goqu.I("financial_records.id")))).

--- a/api/externals/repository/festival_item_repository.go
+++ b/api/externals/repository/festival_item_repository.go
@@ -16,15 +16,16 @@ type festivalItemRepository struct {
 	crud   abstract.Crud
 }
 
+type FestivalItem = generated.FestivalItem
 type FestivalItemRepository interface {
 	All(context.Context) (*sql.Rows, error)
 	AllByPeriod(context.Context, string) (*sql.Rows, error)
 	AllByPeriodAndDivision(context.Context, string, string) (*sql.Rows, error)
 	GetById(context.Context, string) (*sql.Row, error)
-	CreateFestivalItem(context.Context, *sql.Tx, generated.FestivalItem) error
-	CreateItemBudget(context.Context, *sql.Tx, generated.FestivalItem) error
-	UpdateFestivalItem(context.Context, *sql.Tx, string, generated.FestivalItem) error
-	UpdateItemBudget(context.Context, *sql.Tx, string, generated.FestivalItem) error
+	CreateFestivalItem(context.Context, *sql.Tx, FestivalItem) error
+	CreateItemBudget(context.Context, *sql.Tx, FestivalItem) error
+	UpdateFestivalItem(context.Context, *sql.Tx, string, FestivalItem) error
+	UpdateItemBudget(context.Context, *sql.Tx, string, FestivalItem) error
 	DeleteFestivalItem(context.Context, *sql.Tx, string) error
 	DeleteItemBudget(context.Context, *sql.Tx, string) error
 	FindLatestRecord(context.Context) (*sql.Row, error)
@@ -162,7 +163,7 @@ func (fir *festivalItemRepository) GetById(
 func (fir *festivalItemRepository) CreateFestivalItem(
 	c context.Context,
 	tx *sql.Tx,
-	festivalItem generated.FestivalItem,
+	festivalItem FestivalItem,
 ) error {
 	ds := dialect.Insert("festival_items").
 		Rows(goqu.Record{"name": festivalItem.Name, "memo": festivalItem.Memo, "division_id": festivalItem.DivisionId})
@@ -178,7 +179,7 @@ func (fir *festivalItemRepository) CreateFestivalItem(
 func (fir *festivalItemRepository) CreateItemBudget(
 	c context.Context,
 	tx *sql.Tx,
-	festivalItem generated.FestivalItem,
+	festivalItem FestivalItem,
 ) error {
 	ds := dialect.Insert("item_budgets").
 		Rows(goqu.Record{"amount": festivalItem.Amount, "festival_item_id": goqu.L("LAST_INSERT_ID()")})
@@ -196,7 +197,7 @@ func (fir *festivalItemRepository) UpdateFestivalItem(
 	c context.Context,
 	tx *sql.Tx,
 	id string,
-	festivalItem generated.FestivalItem,
+	festivalItem FestivalItem,
 ) error {
 	ds := dialect.Update("festival_items").
 		Set(goqu.Record{"name": festivalItem.Name, "memo": festivalItem.Memo, "division_id": festivalItem.DivisionId}).
@@ -214,7 +215,7 @@ func (fir *festivalItemRepository) UpdateItemBudget(
 	c context.Context,
 	tx *sql.Tx,
 	id string,
-	festivalItem generated.FestivalItem,
+	festivalItem FestivalItem,
 ) error {
 	ds := dialect.Update("item_budgets").
 		Set(goqu.Record{"amount": festivalItem.Amount}).

--- a/api/externals/repository/festival_item_repository.go
+++ b/api/externals/repository/festival_item_repository.go
@@ -17,8 +17,6 @@ type festivalItemRepository struct {
 
 type FestivalItem = generated.FestivalItem
 type FestivalItemRepository interface {
-	All(context.Context) (*sql.Rows, error)
-	AllByPeriod(context.Context, string) (*sql.Rows, error)
 	AllByPeriodAndDivision(context.Context, string, string) (*sql.Rows, error)
 	GetById(context.Context, string) (*sql.Row, error)
 	CreateFestivalItem(context.Context, *sql.Tx, FestivalItem) error
@@ -37,88 +35,13 @@ func NewFestivalItemRepository(c db.Client, ac abstract.Crud) FestivalItemReposi
 	return &festivalItemRepository{c, ac}
 }
 
-// 年度別に取得
-func (fir *festivalItemRepository) All(
-	c context.Context,
-) (*sql.Rows, error) {
-	query, _, err := dialect.Select(
-		"festival_items.id",
-		"festival_items.name",
-		"festival_items.memo",
-		"financial_records.name",
-		"divisions.name",
-		goqu.L("COALESCE(`item_budgets`.`amount`, 0)").As("budget"),
-		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("item_budgets.amount - COALESCE(SUM(`buy_reports`.`amount`), 0)"), 0).As("balance")).
-		From("festival_items").
-		InnerJoin(goqu.I("divisions"), goqu.On(goqu.I("festival_items.division_id").Eq(goqu.I("divisions.id")))).
-		InnerJoin(goqu.I("financial_records"), goqu.On(goqu.I("divisions.financial_record_id").Eq(goqu.I("financial_records.id")))).
-		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
-		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("festival_items.id", "item_budgets.amount").
-		Order(goqu.I("festival_items.id").Desc()).
-		ToSQL()
-	if err != nil {
-		return nil, err
-	}
-	return fir.crud.Read(c, query)
-}
-
-// 年度別に取得
-func (fir *festivalItemRepository) AllByPeriod(
-	c context.Context,
-	year string,
-) (*sql.Rows, error) {
-	query, _, err := dialect.Select(
-		"festival_items.id",
-		"festival_items.name",
-		"festival_items.memo",
-		"financial_records.name",
-		"divisions.name",
-		goqu.L("COALESCE(`item_budgets`.`amount`, 0)").As("budget"),
-		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("item_budgets.amount - COALESCE(SUM(`buy_reports`.`amount`), 0)"), 0).As("balance")).
-		From("festival_items").
-		InnerJoin(goqu.I("divisions"), goqu.On(goqu.I("festival_items.division_id").Eq(goqu.I("divisions.id")))).
-		InnerJoin(goqu.I("financial_records"), goqu.On(goqu.I("divisions.financial_record_id").Eq(goqu.I("financial_records.id")))).
-		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
-		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("festival_items.id", "item_budgets.amount").
-		Order(goqu.I("festival_items.id").Desc()).
-		Where(goqu.Ex{"years.year": year}).
-		ToSQL()
-	if err != nil {
-		return nil, err
-	}
-	return fir.crud.Read(c, query)
-}
-
 // 年度別と部門で取得
 func (fir *festivalItemRepository) AllByPeriodAndDivision(
 	c context.Context,
 	year string,
 	divisionId string,
 ) (*sql.Rows, error) {
-	ds := dialect.Select(
-		"festival_items.id",
-		"festival_items.name",
-		"festival_items.memo",
-		"financial_records.name",
-		"divisions.name",
-		goqu.L("COALESCE(`item_budgets`.`amount`, 0)").As("budget"),
-		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("item_budgets.amount - COALESCE(SUM(`buy_reports`.`amount`), 0)"), 0).As("balance")).
-		From("festival_items").
-		InnerJoin(goqu.I("divisions"), goqu.On(goqu.I("festival_items.division_id").Eq(goqu.I("divisions.id")))).
-		InnerJoin(goqu.I("financial_records"), goqu.On(goqu.I("divisions.financial_record_id").Eq(goqu.I("financial_records.id")))).
-		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
-		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("festival_items.id", "item_budgets.amount").
-		Order(goqu.I("festival_items.id").Desc())
-
+	ds := selectFestivalItemQuery
 	if divisionId != "" {
 		ds = ds.Where(goqu.Ex{"divisions.id": divisionId})
 	}
@@ -141,24 +64,7 @@ func (fir *festivalItemRepository) GetById(
 	c context.Context,
 	id string,
 ) (*sql.Row, error) {
-	query, _, err := dialect.Select(
-		"festival_items.id",
-		"festival_items.name",
-		"festival_items.memo",
-		"financial_records.name",
-		"divisions.name",
-		"item_budgets.amount",
-		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("item_budgets.amount - COALESCE(SUM(`buy_reports`.`amount`), 0)"), 0).As("balance")).
-		From("festival_items").
-		InnerJoin(goqu.I("divisions"), goqu.On(goqu.I("festival_items.division_id").Eq(goqu.I("divisions.id")))).
-		InnerJoin(goqu.I("financial_records"), goqu.On(goqu.I("divisions.financial_record_id").Eq(goqu.I("financial_records.id")))).
-		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
-		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("festival_items.id", "item_budgets.amount").
-		Where(goqu.Ex{"festival_items.id": id}).
-		ToSQL()
+	query, _, err := selectFestivalItemQuery.Where(goqu.Ex{"festival_items.id": id}).ToSQL()
 
 	if err != nil {
 		return nil, err
@@ -265,25 +171,7 @@ func (fir *festivalItemRepository) DeleteItemBudget(
 
 // 最新のfestivalItemを取得する
 func (fir *festivalItemRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
-	query, _, err := dialect.Select(
-		"festival_items.id",
-		"festival_items.name",
-		"festival_items.memo",
-		"financial_records.name",
-		"divisions.name",
-		"item_budgets.amount",
-		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("item_budgets.amount - COALESCE(SUM(`buy_reports`.`amount`), 0)"), 0).As("balance")).
-		From("festival_items").
-		InnerJoin(goqu.I("divisions"), goqu.On(goqu.I("festival_items.division_id").Eq(goqu.I("divisions.id")))).
-		InnerJoin(goqu.I("financial_records"), goqu.On(goqu.I("divisions.financial_record_id").Eq(goqu.I("financial_records.id")))).
-		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
-		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("festival_items.id", "item_budgets.amount").
-		Order(goqu.I("festival_items.id").Desc()).
-		Limit(1).
-		ToSQL()
+	query, _, err := selectFestivalItemQuery.Limit(1).ToSQL()
 
 	if err != nil {
 		return nil, err
@@ -302,3 +190,21 @@ func (fir *festivalItemRepository) RollBack(c context.Context, tx *sql.Tx) error
 func (fir *festivalItemRepository) Commit(c context.Context, tx *sql.Tx) error {
 	return fir.crud.Commit(c, tx)
 }
+
+var selectFestivalItemQuery = dialect.Select(
+	"festival_items.id",
+	"festival_items.name",
+	"festival_items.memo",
+	"financial_records.name",
+	"divisions.name",
+	goqu.L("COALESCE(`item_budgets`.`amount`, 0)").As("budget"),
+	goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
+	goqu.COALESCE(goqu.L("item_budgets.amount - COALESCE(SUM(`buy_reports`.`amount`), 0)"), 0).As("balance")).
+	From("festival_items").
+	InnerJoin(goqu.I("divisions"), goqu.On(goqu.I("festival_items.division_id").Eq(goqu.I("divisions.id")))).
+	InnerJoin(goqu.I("financial_records"), goqu.On(goqu.I("divisions.financial_record_id").Eq(goqu.I("financial_records.id")))).
+	InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
+	LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
+	LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
+	GroupBy("festival_items.id", "item_budgets.amount").
+	Order(goqu.I("festival_items.id").Desc())

--- a/api/externals/repository/financial_record_repository.go
+++ b/api/externals/repository/financial_record_repository.go
@@ -33,19 +33,7 @@ func NewFinancialRecordRepository(c db.Client, ac abstract.Crud) FinancialRecord
 func (frr *financialRecordRepository) All(
 	c context.Context,
 ) (*sql.Rows, error) {
-	query, _, err := dialect.Select(
-		"financial_records.id",
-		"financial_records.name", "years.year",
-		goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
-		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("SUM(item_budgets.amount) - SUM(buy_reports.amount)"), 0).As("balance")).
-		From("financial_records").
-		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
-		LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
-		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
-		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("financial_records.id").
+	query, _, err := selectFinancialRecordQuery.
 		ToSQL()
 
 	if err != nil {
@@ -59,19 +47,7 @@ func (frr *financialRecordRepository) AllByPeriod(
 	c context.Context,
 	year string,
 ) (*sql.Rows, error) {
-	query, _, err := dialect.Select(
-		"financial_records.id",
-		"financial_records.name", "years.year",
-		goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
-		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("SUM(item_budgets.amount) - SUM(buy_reports.amount)"), 0).As("balance")).
-		From("financial_records").
-		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
-		LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
-		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
-		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("financial_records.id").
+	query, _, err := selectFinancialRecordQuery.
 		Where(goqu.Ex{"years.year": year}).
 		ToSQL()
 	if err != nil {
@@ -85,19 +61,7 @@ func (frr *financialRecordRepository) GetById(
 	c context.Context,
 	id string,
 ) (*sql.Row, error) {
-	query, _, err := dialect.Select(
-		"financial_records.id",
-		"financial_records.name", "years.year",
-		goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
-		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("SUM(item_budgets.amount) - SUM(buy_reports.amount)"), 0).As("balance")).
-		From("financial_records").
-		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
-		LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
-		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
-		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("financial_records.id").
+	query, _, err := selectFinancialRecordQuery.
 		Where(goqu.Ex{"financial_records.id": id}).
 		ToSQL()
 	if err != nil {
@@ -152,19 +116,7 @@ func (frr *financialRecordRepository) Delete(
 
 // 最新のsponcerを取得する
 func (frr *financialRecordRepository) FindLatestRecord(c context.Context) (*sql.Row, error) {
-	query, _, err := dialect.Select(
-		"financial_records.id",
-		"financial_records.name", "years.year",
-		goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
-		goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
-		goqu.COALESCE(goqu.L("SUM(item_budgets.amount) - SUM(buy_reports.amount)"), 0).As("balance")).
-		From("financial_records").
-		InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
-		LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
-		LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
-		LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
-		LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
-		GroupBy("financial_records.id").
+	query, _, err := selectFinancialRecordQuery.
 		Order(goqu.I("id").Desc()).
 		Limit(1).
 		ToSQL()
@@ -173,3 +125,17 @@ func (frr *financialRecordRepository) FindLatestRecord(c context.Context) (*sql.
 	}
 	return frr.crud.ReadByID(c, query)
 }
+
+var selectFinancialRecordQuery = dialect.Select(
+	"financial_records.id",
+	"financial_records.name", "years.year",
+	goqu.COALESCE(goqu.SUM("item_budgets.amount"), 0).As("budget"),
+	goqu.COALESCE(goqu.SUM("buy_reports.amount"), 0).As("expense"),
+	goqu.L("COALESCE(SUM(item_budgets.amount), 0) - COALESCE(SUM(buy_reports.amount), 0)").As("balance")).
+	From("financial_records").
+	InnerJoin(goqu.I("years"), goqu.On(goqu.I("financial_records.year_id").Eq(goqu.I("years.id")))).
+	LeftJoin(goqu.I("divisions"), goqu.On(goqu.I("financial_records.id").Eq(goqu.I("divisions.financial_record_id")))).
+	LeftJoin(goqu.I("festival_items"), goqu.On(goqu.I("divisions.id").Eq(goqu.I("festival_items.division_id")))).
+	LeftJoin(goqu.I("item_budgets"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("item_budgets.festival_item_id")))).
+	LeftJoin(goqu.I("buy_reports"), goqu.On(goqu.I("festival_items.id").Eq(goqu.I("buy_reports.festival_item_id")))).
+	GroupBy("financial_records.id")

--- a/api/generated/openapi_gen.go
+++ b/api/generated/openapi_gen.go
@@ -276,6 +276,12 @@ type PutExpensesIdParams struct {
 	YearId *string `form:"year_id,omitempty" json:"year_id,omitempty"`
 }
 
+// GetFestivalItemsParams defines parameters for GetFestivalItems.
+type GetFestivalItemsParams struct {
+	// Year year
+	Year *int `form:"year,omitempty" json:"year,omitempty"`
+}
+
 // GetFinancialRecordsParams defines parameters for GetFinancialRecords.
 type GetFinancialRecordsParams struct {
 	// Year year
@@ -652,7 +658,7 @@ type ServerInterface interface {
 	GetExpensesIdDetails(ctx echo.Context, id int) error
 
 	// (GET /festival_items)
-	GetFestivalItems(ctx echo.Context) error
+	GetFestivalItems(ctx echo.Context, params GetFestivalItemsParams) error
 
 	// (POST /festival_items)
 	PostFestivalItems(ctx echo.Context) error
@@ -1670,8 +1676,17 @@ func (w *ServerInterfaceWrapper) GetExpensesIdDetails(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) GetFestivalItems(ctx echo.Context) error {
 	var err error
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetFestivalItemsParams
+	// ------------- Optional query parameter "year" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "year", ctx.QueryParams(), &params.Year)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter year: %s", err))
+	}
+
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetFestivalItems(ctx)
+	err = w.Handler.GetFestivalItems(ctx, params)
 	return err
 }
 

--- a/api/generated/openapi_gen.go
+++ b/api/generated/openapi_gen.go
@@ -280,6 +280,9 @@ type PutExpensesIdParams struct {
 type GetFestivalItemsParams struct {
 	// Year year
 	Year *int `form:"year,omitempty" json:"year,omitempty"`
+
+	// DivisionId division_id
+	DivisionId *int `form:"division_id,omitempty" json:"division_id,omitempty"`
 }
 
 // GetFinancialRecordsParams defines parameters for GetFinancialRecords.
@@ -1683,6 +1686,13 @@ func (w *ServerInterfaceWrapper) GetFestivalItems(ctx echo.Context) error {
 	err = runtime.BindQueryParameter("form", true, false, "year", ctx.QueryParams(), &params.Year)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter year: %s", err))
+	}
+
+	// ------------- Optional query parameter "division_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "division_id", ctx.QueryParams(), &params.DivisionId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter division_id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/api/internals/di/di.go
+++ b/api/internals/di/di.go
@@ -31,6 +31,7 @@ func InitializeServer() db.Client {
 	bureauRepository := repository.NewBureauRepository(client, crud)
 	departmentRepository := repository.NewDepartmentRepository(client, crud)
 	expenseRepository := repository.NewExpenseRepository(client, crud)
+	festivalItemRepository := repository.NewFestivalItemRepository(client, crud)
 	financialRecordRepository := repository.NewFinancialRecordRepository(client, crud)
 	fundInformationRepository := repository.NewFundInformationRepository(client, crud)
 	mailAuthRepository := repository.NewMailAuthRepository(client, crud)
@@ -58,6 +59,7 @@ func InitializeServer() db.Client {
 	bureauUseCase := usecase.NewBureauUseCase(bureauRepository)
 	departmentUseCase := usecase.NewDepartmentUseCase(departmentRepository)
 	expenseUseCase := usecase.NewExpenseUseCase(expenseRepository)
+	festivalUseCase := usecase.NewFestivalItemUseCase(festivalItemRepository)
 	financialRecordUseCase := usecase.NewFinancialRecordUseCase(financialRecordRepository)
 	fundInformationUseCase := usecase.NewFundInformationUseCase(fundInformationRepository)
 	mailAuthUseCase := usecase.NewMailAuthUseCase(mailAuthRepository, sessionRepository)
@@ -92,6 +94,7 @@ func InitializeServer() db.Client {
 	bureauController := controller.NewBureauController(bureauUseCase)
 	departmentController := controller.NewDepartmentController(departmentUseCase)
 	expenseController := controller.NewExpenseController(expenseUseCase)
+	festivalItemController := controller.NewFestivalItemController(festivalUseCase)
 	financialRecordController := controller.NewFinancialRecordController(financialRecordUseCase)
 	fundInformationController := controller.NewFundInformationController(fundInformationUseCase)
 	healthcheckController := controller.NewHealthCheckController()
@@ -120,6 +123,7 @@ func InitializeServer() db.Client {
 		bureauController,
 		departmentController,
 		expenseController,
+		festivalItemController,
 		financialRecordController,
 		fundInformationController,
 		healthcheckController,

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -7,10 +7,6 @@ import (
 	"github.com/NUTFes/FinanSu/api/generated"
 )
 
-type FestivalItemDetails = generated.FestivalItemDetails
-type FestivalItem = generated.FestivalItem
-type FestivalItemWithBalance = generated.FestivalItemWithBalance
-
 type festivalItemUseCase struct {
 	rep rep.FestivalItemRepository
 }
@@ -313,3 +309,7 @@ func (fiu *festivalItemUseCase) DestroyFestivalItem(c context.Context, id string
 
 	return nil
 }
+
+type FestivalItemDetails = generated.FestivalItemDetails
+type FestivalItem = generated.FestivalItem
+type FestivalItemWithBalance = generated.FestivalItemWithBalance

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -87,7 +87,7 @@ func (fiu *festivalItemUseCase) CreateFestivalItem(
 	c context.Context,
 	festivalItem FestivalItem,
 ) (FestivalItemWithBalance, error) {
-	latastFestivalItemWithBalance := FestivalItemWithBalance{}
+	latestFestivalItemWithBalance := FestivalItemWithBalance{}
 
 	// トランザクションスタート
 	tx, _ := fiu.rep.StartTransaction(c)
@@ -95,39 +95,39 @@ func (fiu *festivalItemUseCase) CreateFestivalItem(
 	if err := fiu.rep.CreateFestivalItem(c, tx, festivalItem); err != nil {
 		// エラーが発生時はロールバック
 		fiu.rep.RollBack(c, tx)
-		return latastFestivalItemWithBalance, err
+		return latestFestivalItemWithBalance, err
 	}
 
 	if err := fiu.rep.CreateItemBudget(c, tx, festivalItem); err != nil {
 		// エラーが発生時はロールバック
 		fiu.rep.RollBack(c, tx)
-		return latastFestivalItemWithBalance, err
+		return latestFestivalItemWithBalance, err
 	}
 
 	// コミットしてトランザクション終了
 	if err := fiu.rep.Commit(c, tx); err != nil {
-		return latastFestivalItemWithBalance, err
+		return latestFestivalItemWithBalance, err
 	}
 
 	row, err := fiu.rep.FindLatestRecord(c)
 	if err != nil {
-		return latastFestivalItemWithBalance, err
+		return latestFestivalItemWithBalance, err
 	}
 	err = row.Scan(
-		&latastFestivalItemWithBalance.Id,
-		&latastFestivalItemWithBalance.Name,
-		&latastFestivalItemWithBalance.Memo,
-		&latastFestivalItemWithBalance.FinancialRecord,
-		&latastFestivalItemWithBalance.Division,
-		&latastFestivalItemWithBalance.Budget,
-		&latastFestivalItemWithBalance.Expense,
-		&latastFestivalItemWithBalance.Balance,
+		&latestFestivalItemWithBalance.Id,
+		&latestFestivalItemWithBalance.Name,
+		&latestFestivalItemWithBalance.Memo,
+		&latestFestivalItemWithBalance.FinancialRecord,
+		&latestFestivalItemWithBalance.Division,
+		&latestFestivalItemWithBalance.Budget,
+		&latestFestivalItemWithBalance.Expense,
+		&latestFestivalItemWithBalance.Balance,
 	)
 	if err != nil {
-		return latastFestivalItemWithBalance, err
+		return latestFestivalItemWithBalance, err
 	}
 
-	return latastFestivalItemWithBalance, nil
+	return latestFestivalItemWithBalance, nil
 }
 
 func (fiu *festivalItemUseCase) UpdateFestivalItem(

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -13,8 +13,8 @@ type festivalItemUseCase struct {
 
 type FestivalItemUseCase interface {
 	GetFestivalItems(context.Context) (FestivalItemDetails, error)
-	GetFestivalItemsByYears(context.Context, string) (FestivalItemDetails, error)
-	GetFestivalItemsByYearsAndDivision(context.Context, string, string) (FestivalItemDetails, error)
+	GetFestivalItemsByYear(context.Context, string) (FestivalItemDetails, error)
+	GetFestivalItemsByYearAndDivision(context.Context, string, string) (FestivalItemDetails, error)
 	CreateFestivalItem(
 		context.Context,
 		FestivalItem,
@@ -83,7 +83,7 @@ func (fiu *festivalItemUseCase) GetFestivalItems(
 	return festivalItemDetails, nil
 }
 
-func (fiu *festivalItemUseCase) GetFestivalItemsByYears(
+func (fiu *festivalItemUseCase) GetFestivalItemsByYear(
 	c context.Context,
 	year string,
 ) (FestivalItemDetails, error) {
@@ -136,7 +136,7 @@ func (fiu *festivalItemUseCase) GetFestivalItemsByYears(
 	return festivalItemDetails, nil
 }
 
-func (fiu *festivalItemUseCase) GetFestivalItemsByYearsAndDivision(
+func (fiu *festivalItemUseCase) GetFestivalItemsByYearAndDivision(
 	c context.Context,
 	year string,
 	divisionId string,

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -7,23 +7,27 @@ import (
 	"github.com/NUTFes/FinanSu/api/generated"
 )
 
+type FestivalItemDetails = generated.FestivalItemDetails
+type FestivalItem = generated.FestivalItem
+type FestivalItemWithBalance = generated.FestivalItemWithBalance
+
 type festivalItemUseCase struct {
 	rep rep.FestivalItemRepository
 }
 
 type FestivalItemUseCase interface {
-	GetFestivalItems(context.Context) (generated.FestivalItemDetails, error)
-	GetFestivalItemsByYears(context.Context, string) (generated.FestivalItemDetails, error)
-	GetFestivalItemsByYearsAndDivision(context.Context, string, string) (generated.FestivalItemDetails, error)
+	GetFestivalItems(context.Context) (FestivalItemDetails, error)
+	GetFestivalItemsByYears(context.Context, string) (FestivalItemDetails, error)
+	GetFestivalItemsByYearsAndDivision(context.Context, string, string) (FestivalItemDetails, error)
 	CreateFestivalItem(
 		context.Context,
-		generated.FestivalItem,
-	) (generated.FestivalItemWithBalance, error)
+		FestivalItem,
+	) (FestivalItemWithBalance, error)
 	UpdateFestivalItem(
 		context.Context,
 		string,
-		generated.FestivalItem,
-	) (generated.FestivalItemWithBalance, error)
+		FestivalItem,
+	) (FestivalItemWithBalance, error)
 	DestroyFestivalItem(context.Context, string) error
 }
 
@@ -33,9 +37,9 @@ func NewFestivalItemUseCase(rep rep.FestivalItemRepository) FestivalItemUseCase 
 
 func (fiu *festivalItemUseCase) GetFestivalItems(
 	c context.Context,
-) (generated.FestivalItemDetails, error) {
-	var festivalItemDetails generated.FestivalItemDetails
-	var festivalItems []generated.FestivalItemWithBalance
+) (FestivalItemDetails, error) {
+	var festivalItemDetails FestivalItemDetails
+	var festivalItems []FestivalItemWithBalance
 
 	rows, err := fiu.rep.All(c)
 	if err != nil {
@@ -44,7 +48,7 @@ func (fiu *festivalItemUseCase) GetFestivalItems(
 
 	defer rows.Close()
 	for rows.Next() {
-		var festivalItem generated.FestivalItemWithBalance
+		var festivalItem FestivalItemWithBalance
 		err := rows.Scan(
 			&festivalItem.Id,
 			&festivalItem.Name,
@@ -62,7 +66,7 @@ func (fiu *festivalItemUseCase) GetFestivalItems(
 	}
 	festivalItemDetails.FestivalItems = &festivalItems
 
-	var total generated.Total
+	var total Total
 
 	// totalを求める
 	budgetTotal := 0
@@ -86,9 +90,9 @@ func (fiu *festivalItemUseCase) GetFestivalItems(
 func (fiu *festivalItemUseCase) GetFestivalItemsByYears(
 	c context.Context,
 	year string,
-) (generated.FestivalItemDetails, error) {
-	var festivalItemDetails generated.FestivalItemDetails
-	var festivalItems []generated.FestivalItemWithBalance
+) (FestivalItemDetails, error) {
+	var festivalItemDetails FestivalItemDetails
+	var festivalItems []FestivalItemWithBalance
 
 	rows, err := fiu.rep.AllByPeriod(c, year)
 	if err != nil {
@@ -97,7 +101,7 @@ func (fiu *festivalItemUseCase) GetFestivalItemsByYears(
 
 	defer rows.Close()
 	for rows.Next() {
-		var festivalItem generated.FestivalItemWithBalance
+		var festivalItem FestivalItemWithBalance
 		err := rows.Scan(
 			&festivalItem.Id,
 			&festivalItem.Name,
@@ -115,7 +119,7 @@ func (fiu *festivalItemUseCase) GetFestivalItemsByYears(
 	}
 	festivalItemDetails.FestivalItems = &festivalItems
 
-	var total generated.Total
+	var total Total
 
 	// totalを求める
 	budgetTotal := 0
@@ -140,9 +144,9 @@ func (fiu *festivalItemUseCase) GetFestivalItemsByYearsAndDivision(
 	c context.Context,
 	year string,
 	divisionId string,
-) (generated.FestivalItemDetails, error) {
-	var festivalItemDetails generated.FestivalItemDetails
-	var festivalItems []generated.FestivalItemWithBalance
+) (FestivalItemDetails, error) {
+	var festivalItemDetails FestivalItemDetails
+	var festivalItems []FestivalItemWithBalance
 
 	rows, err := fiu.rep.AllByPeriodAndDivision(c, year, divisionId)
 	if err != nil {
@@ -151,7 +155,7 @@ func (fiu *festivalItemUseCase) GetFestivalItemsByYearsAndDivision(
 
 	defer rows.Close()
 	for rows.Next() {
-		var festivalItem generated.FestivalItemWithBalance
+		var festivalItem FestivalItemWithBalance
 		err := rows.Scan(
 			&festivalItem.Id,
 			&festivalItem.Name,
@@ -169,7 +173,7 @@ func (fiu *festivalItemUseCase) GetFestivalItemsByYearsAndDivision(
 	}
 	festivalItemDetails.FestivalItems = &festivalItems
 
-	var total generated.Total
+	var total Total
 
 	// totalを求める
 	budgetTotal := 0
@@ -192,9 +196,9 @@ func (fiu *festivalItemUseCase) GetFestivalItemsByYearsAndDivision(
 
 func (fiu *festivalItemUseCase) CreateFestivalItem(
 	c context.Context,
-	festivalItem generated.FestivalItem,
-) (generated.FestivalItemWithBalance, error) {
-	latastFestivalItemWithBalance := generated.FestivalItemWithBalance{}
+	festivalItem FestivalItem,
+) (FestivalItemWithBalance, error) {
+	latastFestivalItemWithBalance := FestivalItemWithBalance{}
 
 	// トランザクションスタート
 	tx, _ := fiu.rep.StartTransaction(c)
@@ -240,9 +244,9 @@ func (fiu *festivalItemUseCase) CreateFestivalItem(
 func (fiu *festivalItemUseCase) UpdateFestivalItem(
 	c context.Context,
 	id string,
-	festivalItem generated.FestivalItem,
-) (generated.FestivalItemWithBalance, error) {
-	updateFestivalItemWithBalance := generated.FestivalItemWithBalance{}
+	festivalItem FestivalItem,
+) (FestivalItemWithBalance, error) {
+	updateFestivalItemWithBalance := FestivalItemWithBalance{}
 
 	// トランザクションスタート
 	tx, _ := fiu.rep.StartTransaction(c)

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -1,0 +1,108 @@
+package usecase
+
+import (
+	"context"
+
+	rep "github.com/NUTFes/FinanSu/api/externals/repository"
+	"github.com/NUTFes/FinanSu/api/generated"
+)
+
+type festivalItemUseCase struct {
+	rep rep.FestivalItemRepository
+}
+
+type FestivalItemUseCase interface {
+	GetFestivalItems(context.Context) (generated.FestivalItemDetails, error)
+	GetFestivalItemsByYears(context.Context, string) (generated.FestivalItemDetails, error)
+	CreateFestivalItem(
+		context.Context,
+		generated.FestivalItem,
+	) (generated.FestivalItemWithBalance, error)
+	UpdateFestivalItem(
+		context.Context,
+		string,
+		generated.FestivalItem,
+	) (generated.FestivalItemWithBalance, error)
+	DestroyFestivalItem(context.Context, string) error
+}
+
+func NewFestivalItemUseCase(rep rep.FestivalItemRepository) FestivalItemUseCase {
+	return &festivalItemUseCase{rep}
+}
+
+func (fiu *festivalItemUseCase) GetFestivalItems(
+	c context.Context,
+) (generated.FestivalItemDetails, error) {
+	var festivalItemDetails generated.FestivalItemDetails
+	return festivalItemDetails, nil
+}
+
+func (fiu *festivalItemUseCase) GetFestivalItemsByYears(
+	c context.Context,
+	year string,
+) (generated.FestivalItemDetails, error) {
+	var festivalItemDetails generated.FestivalItemDetails
+	return festivalItemDetails, nil
+}
+
+func (fiu *festivalItemUseCase) CreateFestivalItem(
+	c context.Context,
+	festivalItem generated.FestivalItem,
+) (generated.FestivalItemWithBalance, error) {
+	latastFestivalItemWithBalance := generated.FestivalItemWithBalance{}
+	// err := fiu.rep.Create(c, financialRecord)
+	// if err != nil {
+	// 	return latastFinancialRecordWithBalance, err
+	// }
+	// row, err := fiu.rep.FindLatestRecord(c)
+	// if err != nil {
+	// 	return latastFinancialRecordWithBalance, err
+	// }
+	// err = row.Scan(
+	// 	&latastFinancialRecordWithBalance.Id,
+	// 	&latastFinancialRecordWithBalance.Name,
+	// 	&latastFinancialRecordWithBalance.Year,
+	// 	&latastFinancialRecordWithBalance.Budget,
+	// 	&latastFinancialRecordWithBalance.Expense,
+	// 	&latastFinancialRecordWithBalance.Balance,
+	// )
+	// if err != nil {
+	// 	return latastFinancialRecordWithBalance, err
+	// }
+	return latastFestivalItemWithBalance, nil
+}
+
+func (fiu *festivalItemUseCase) UpdateFestivalItem(
+	c context.Context,
+	id string,
+	festivalItem generated.FestivalItem,
+) (generated.FestivalItemWithBalance, error) {
+	updateFestivalItem := generated.FestivalItemWithBalance{}
+
+	// if err := fiu.rep.Update(c, id, festivalItem); err != nil {
+	// 	return updateFestivalItem, err
+	// }
+
+	// row, err := fiu.rep.GetById(c, id)
+	// if err != nil {
+	// 	return updateFestivalItem, err
+	// }
+
+	// if err = row.Scan(
+	// 	&updateFinancialRecord.Id,
+	// 	&updateFinancialRecord.Name,
+	// 	&updateFinancialRecord.Year,
+	// 	&updateFinancialRecord.Budget,
+	// 	&updateFinancialRecord.Expense,
+	// 	&updateFinancialRecord.Balance,
+	// ); err != nil {
+	// 	return updateFinancialRecord, err
+	// }
+
+	return updateFestivalItem, nil
+}
+
+func (fiu *festivalItemUseCase) DestroyFestivalItem(c context.Context, id string) error {
+	err := fiu.rep.Delete(c, id)
+	return err
+}

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -34,6 +34,51 @@ func (fiu *festivalItemUseCase) GetFestivalItems(
 	c context.Context,
 ) (generated.FestivalItemDetails, error) {
 	var festivalItemDetails generated.FestivalItemDetails
+	var festivalItems []generated.FestivalItemWithBalance
+
+	rows, err := fiu.rep.All(c)
+	if err != nil {
+		return festivalItemDetails, err
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		var festivalItem generated.FestivalItemWithBalance
+		err := rows.Scan(
+			&festivalItem.Id,
+			&festivalItem.Name,
+			&festivalItem.Memo,
+			&festivalItem.FinancialRecord,
+			&festivalItem.Division,
+			&festivalItem.Budget,
+			&festivalItem.Expense,
+			&festivalItem.Balance,
+		)
+		if err != nil {
+			return festivalItemDetails, err
+		}
+		festivalItems = append(festivalItems, festivalItem)
+	}
+	festivalItemDetails.FestivalItems = &festivalItems
+
+	var total generated.Total
+
+	// totalを求める
+	budgetTotal := 0
+	expenseTotal := 0
+	balanceTotal := 0
+
+	for _, festivalItem := range festivalItems {
+		budgetTotal += *festivalItem.Budget
+		expenseTotal += *festivalItem.Expense
+		balanceTotal += *festivalItem.Balance
+	}
+
+	total.Budget = &budgetTotal
+	total.Expense = &expenseTotal
+	total.Balance = &balanceTotal
+
+	festivalItemDetails.Total = &total
 	return festivalItemDetails, nil
 }
 
@@ -42,6 +87,51 @@ func (fiu *festivalItemUseCase) GetFestivalItemsByYears(
 	year string,
 ) (generated.FestivalItemDetails, error) {
 	var festivalItemDetails generated.FestivalItemDetails
+	var festivalItems []generated.FestivalItemWithBalance
+
+	rows, err := fiu.rep.AllByPeriod(c, year)
+	if err != nil {
+		return festivalItemDetails, err
+	}
+
+	defer rows.Close()
+	for rows.Next() {
+		var festivalItem generated.FestivalItemWithBalance
+		err := rows.Scan(
+			&festivalItem.Id,
+			&festivalItem.Name,
+			&festivalItem.Memo,
+			&festivalItem.FinancialRecord,
+			&festivalItem.Division,
+			&festivalItem.Budget,
+			&festivalItem.Expense,
+			&festivalItem.Balance,
+		)
+		if err != nil {
+			return festivalItemDetails, err
+		}
+		festivalItems = append(festivalItems, festivalItem)
+	}
+	festivalItemDetails.FestivalItems = &festivalItems
+
+	var total generated.Total
+
+	// totalを求める
+	budgetTotal := 0
+	expenseTotal := 0
+	balanceTotal := 0
+
+	for _, festivalItem := range festivalItems {
+		budgetTotal += *festivalItem.Budget
+		expenseTotal += *festivalItem.Expense
+		balanceTotal += *festivalItem.Balance
+	}
+
+	total.Budget = &budgetTotal
+	total.Expense = &expenseTotal
+	total.Balance = &balanceTotal
+
+	festivalItemDetails.Total = &total
 	return festivalItemDetails, nil
 }
 

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -12,9 +12,7 @@ type festivalItemUseCase struct {
 }
 
 type FestivalItemUseCase interface {
-	GetFestivalItems(context.Context) (FestivalItemDetails, error)
-	GetFestivalItemsByYear(context.Context, string) (FestivalItemDetails, error)
-	GetFestivalItemsByYearAndDivision(context.Context, string, string) (FestivalItemDetails, error)
+	GetFestivalItems(context.Context, string, string) (FestivalItemDetails, error)
 	CreateFestivalItem(
 		context.Context,
 		FestivalItem,
@@ -32,111 +30,6 @@ func NewFestivalItemUseCase(rep rep.FestivalItemRepository) FestivalItemUseCase 
 }
 
 func (fiu *festivalItemUseCase) GetFestivalItems(
-	c context.Context,
-) (FestivalItemDetails, error) {
-	var festivalItemDetails FestivalItemDetails
-	var festivalItems []FestivalItemWithBalance
-
-	rows, err := fiu.rep.All(c)
-	if err != nil {
-		return festivalItemDetails, err
-	}
-
-	defer rows.Close()
-	for rows.Next() {
-		var festivalItem FestivalItemWithBalance
-		err := rows.Scan(
-			&festivalItem.Id,
-			&festivalItem.Name,
-			&festivalItem.Memo,
-			&festivalItem.FinancialRecord,
-			&festivalItem.Division,
-			&festivalItem.Budget,
-			&festivalItem.Expense,
-			&festivalItem.Balance,
-		)
-		if err != nil {
-			return festivalItemDetails, err
-		}
-		festivalItems = append(festivalItems, festivalItem)
-	}
-	festivalItemDetails.FestivalItems = &festivalItems
-
-	var total Total
-
-	// totalを求める
-	budgetTotal := 0
-	expenseTotal := 0
-	balanceTotal := 0
-
-	for _, festivalItem := range festivalItems {
-		budgetTotal += *festivalItem.Budget
-		expenseTotal += *festivalItem.Expense
-		balanceTotal += *festivalItem.Balance
-	}
-
-	total.Budget = &budgetTotal
-	total.Expense = &expenseTotal
-	total.Balance = &balanceTotal
-
-	festivalItemDetails.Total = &total
-	return festivalItemDetails, nil
-}
-
-func (fiu *festivalItemUseCase) GetFestivalItemsByYear(
-	c context.Context,
-	year string,
-) (FestivalItemDetails, error) {
-	var festivalItemDetails FestivalItemDetails
-	var festivalItems []FestivalItemWithBalance
-
-	rows, err := fiu.rep.AllByPeriod(c, year)
-	if err != nil {
-		return festivalItemDetails, err
-	}
-
-	defer rows.Close()
-	for rows.Next() {
-		var festivalItem FestivalItemWithBalance
-		err := rows.Scan(
-			&festivalItem.Id,
-			&festivalItem.Name,
-			&festivalItem.Memo,
-			&festivalItem.FinancialRecord,
-			&festivalItem.Division,
-			&festivalItem.Budget,
-			&festivalItem.Expense,
-			&festivalItem.Balance,
-		)
-		if err != nil {
-			return festivalItemDetails, err
-		}
-		festivalItems = append(festivalItems, festivalItem)
-	}
-	festivalItemDetails.FestivalItems = &festivalItems
-
-	var total Total
-
-	// totalを求める
-	budgetTotal := 0
-	expenseTotal := 0
-	balanceTotal := 0
-
-	for _, festivalItem := range festivalItems {
-		budgetTotal += *festivalItem.Budget
-		expenseTotal += *festivalItem.Expense
-		balanceTotal += *festivalItem.Balance
-	}
-
-	total.Budget = &budgetTotal
-	total.Expense = &expenseTotal
-	total.Balance = &balanceTotal
-
-	festivalItemDetails.Total = &total
-	return festivalItemDetails, nil
-}
-
-func (fiu *festivalItemUseCase) GetFestivalItemsByYearAndDivision(
 	c context.Context,
 	year string,
 	divisionId string,

--- a/api/internals/usecase/financial_record_usecase.go
+++ b/api/internals/usecase/financial_record_usecase.go
@@ -12,11 +12,6 @@ type financialRecordUseCase struct {
 	rep rep.FinancialRecordRepository
 }
 
-type FinancialRecordDetails = generated.FinancialRecordDetails
-type FinancialRecord = generated.FinancialRecord
-type FinancialRecordWithBalance = generated.FinancialRecordWithBalance
-type Total = generated.Total
-
 type FinancialRecordUseCase interface {
 	GetFinancialRecords(context.Context) (FinancialRecordDetails, error)
 	GetFinancialRecordsByYears(context.Context, string) (FinancialRecordDetails, error)
@@ -202,3 +197,8 @@ func (fru *financialRecordUseCase) DestroyFinancialRecord(c context.Context, id 
 	err := fru.rep.Delete(c, id)
 	return err
 }
+
+type FinancialRecordDetails = generated.FinancialRecordDetails
+type FinancialRecord = generated.FinancialRecord
+type FinancialRecordWithBalance = generated.FinancialRecordWithBalance
+type Total = generated.Total

--- a/api/internals/usecase/financial_record_usecase.go
+++ b/api/internals/usecase/financial_record_usecase.go
@@ -12,18 +12,23 @@ type financialRecordUseCase struct {
 	rep rep.FinancialRecordRepository
 }
 
+type FinancialRecordDetails = generated.FinancialRecordDetails
+type FinancialRecord = generated.FinancialRecord
+type FinancialRecordWithBalance = generated.FinancialRecordWithBalance
+type Total = generated.Total
+
 type FinancialRecordUseCase interface {
-	GetFinancialRecords(context.Context) (generated.FinancialRecordDetails, error)
-	GetFinancialRecordsByYears(context.Context, string) (generated.FinancialRecordDetails, error)
+	GetFinancialRecords(context.Context) (FinancialRecordDetails, error)
+	GetFinancialRecordsByYears(context.Context, string) (FinancialRecordDetails, error)
 	CreateFinancialRecord(
 		context.Context,
-		generated.FinancialRecord,
-	) (generated.FinancialRecordWithBalance, error)
+		FinancialRecord,
+	) (FinancialRecordWithBalance, error)
 	UpdateFinancialRecord(
 		context.Context,
 		string,
-		generated.FinancialRecord,
-	) (generated.FinancialRecordWithBalance, error)
+		FinancialRecord,
+	) (FinancialRecordWithBalance, error)
 	DestroyFinancialRecord(context.Context, string) error
 }
 
@@ -33,10 +38,10 @@ func NewFinancialRecordUseCase(rep rep.FinancialRecordRepository) FinancialRecor
 
 func (fru *financialRecordUseCase) GetFinancialRecords(
 	c context.Context,
-) (generated.FinancialRecordDetails, error) {
-	var financialRecordDetails generated.FinancialRecordDetails
-	var financialRecordList []generated.FinancialRecordWithBalance
-	var total generated.Total
+) (FinancialRecordDetails, error) {
+	var financialRecordDetails FinancialRecordDetails
+	var financialRecordList []FinancialRecordWithBalance
+	var total Total
 
 	rows, err := fru.rep.All(c)
 	if err != nil {
@@ -46,7 +51,7 @@ func (fru *financialRecordUseCase) GetFinancialRecords(
 	defer rows.Close()
 
 	for rows.Next() {
-		var financialRecord generated.FinancialRecordWithBalance
+		var financialRecord FinancialRecordWithBalance
 		err := rows.Scan(
 			&financialRecord.Id,
 			&financialRecord.Name,
@@ -87,9 +92,9 @@ func (fru *financialRecordUseCase) GetFinancialRecordsByYears(
 	c context.Context,
 	year string,
 ) (generated.FinancialRecordDetails, error) {
-	var financialRecordDetails generated.FinancialRecordDetails
-	var financialRecordList []generated.FinancialRecordWithBalance
-	var total generated.Total
+	var financialRecordDetails FinancialRecordDetails
+	var financialRecordList []FinancialRecordWithBalance
+	var total Total
 
 	rows, err := fru.rep.AllByPeriod(c, year)
 	if err != nil {
@@ -99,7 +104,7 @@ func (fru *financialRecordUseCase) GetFinancialRecordsByYears(
 	defer rows.Close()
 
 	for rows.Next() {
-		var financialRecord generated.FinancialRecordWithBalance
+		var financialRecord FinancialRecordWithBalance
 		err := rows.Scan(
 			&financialRecord.Id,
 			&financialRecord.Name,
@@ -138,9 +143,9 @@ func (fru *financialRecordUseCase) GetFinancialRecordsByYears(
 
 func (fru *financialRecordUseCase) CreateFinancialRecord(
 	c context.Context,
-	financialRecord generated.FinancialRecord,
-) (generated.FinancialRecordWithBalance, error) {
-	latastFinancialRecordWithBalance := generated.FinancialRecordWithBalance{}
+	financialRecord FinancialRecord,
+) (FinancialRecordWithBalance, error) {
+	latastFinancialRecordWithBalance := FinancialRecordWithBalance{}
 	err := fru.rep.Create(c, financialRecord)
 	if err != nil {
 		return latastFinancialRecordWithBalance, err
@@ -166,9 +171,9 @@ func (fru *financialRecordUseCase) CreateFinancialRecord(
 func (fru *financialRecordUseCase) UpdateFinancialRecord(
 	c context.Context,
 	id string,
-	financialRecord generated.FinancialRecord,
-) (generated.FinancialRecordWithBalance, error) {
-	updateFinancialRecord := generated.FinancialRecordWithBalance{}
+	financialRecord FinancialRecord,
+) (FinancialRecordWithBalance, error) {
+	updateFinancialRecord := FinancialRecordWithBalance{}
 
 	if err := fru.rep.Update(c, id, financialRecord); err != nil {
 		return updateFinancialRecord, err

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -13,6 +13,7 @@ type router struct {
 	bureauController              controller.BureauController
 	departmentController          controller.DepartmentController
 	expenseController             controller.ExpenseController
+	festivalItemController        controller.FestivalItemController
 	financialRecordController     controller.FinancialRecordController
 	fundInformationController     controller.FundInformationController
 	healthcheckController         controller.HealthcheckController
@@ -42,6 +43,7 @@ func NewRouter(
 	bureauController controller.BureauController,
 	departmentController controller.DepartmentController,
 	expenseController controller.ExpenseController,
+	festivalItemController controller.FestivalItemController,
 	financialRecordController controller.FinancialRecordController,
 	fundInformationController controller.FundInformationController,
 	healthController controller.HealthcheckController,
@@ -66,6 +68,7 @@ func NewRouter(
 		bureauController,
 		departmentController,
 		expenseController,
+		festivalItemController,
 		financialRecordController,
 		fundInformationController,
 		healthController,
@@ -157,6 +160,12 @@ func (r router) ProvideRouter(e *echo.Echo) {
 	e.POST("/expenses", r.expenseController.CreateExpense)
 	e.PUT("/expenses/:id", r.expenseController.UpdateExpense)
 	e.DELETE("/expenses/:id", r.expenseController.DestroyExpense)
+
+	// festival items
+	e.GET("/festival_items", r.festivalItemController.IndexFestivalItems)
+	e.POST("/festival_items", r.festivalItemController.CreateFestivalItem)
+	e.PUT("/festival_items/:id", r.festivalItemController.UpdateFestivalItem)
+	e.DELETE("/festival_items/:id", r.festivalItemController.DestroyFestivalItem)
 
 	// financial_records
 	e.GET("/financial_records", r.financialRecordController.IndexFinancialRecords)

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1007,6 +1007,12 @@ paths:
       tags:
         - festival_item
       description: festival_itemの一覧の取得
+      parameters:
+        - name: year
+          in: query
+          description: year
+          schema:
+            type: integer
       responses:
         "200":
           description: festival_itemの一覧を取得

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1013,6 +1013,11 @@ paths:
           description: year
           schema:
             type: integer
+        - name: division_id
+          in: query
+          description: division_id
+          schema:
+            type: integer
       responses:
         "200":
           description: festival_itemの一覧を取得

--- a/view/next-project/src/generated/hooks.ts
+++ b/view/next-project/src/generated/hooks.ts
@@ -78,6 +78,7 @@ import type {
   GetExpensesFiscalyearYear200,
   GetExpensesId200,
   GetExpensesIdDetails200,
+  GetFestivalItemsParams,
   GetFinancialRecordsParams,
   GetFundInformations200,
   GetFundInformationsDetails200,
@@ -2951,15 +2952,22 @@ export type getFestivalItemsResponse = {
   headers: Headers;
 }
 
-export const getGetFestivalItemsUrl = () => {
+export const getGetFestivalItemsUrl = (params?: GetFestivalItemsParams,) => {
+  const normalizedParams = new URLSearchParams();
 
+  Object.entries(params || {}).forEach(([key, value]) => {
+    
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString())
+    }
+  });
 
-  return `/festival_items`
+  return normalizedParams.size ? `/festival_items?${normalizedParams.toString()}` : `/festival_items`
 }
 
-export const getFestivalItems = async ( options?: RequestInit): Promise<getFestivalItemsResponse> => {
+export const getFestivalItems = async (params?: GetFestivalItemsParams, options?: RequestInit): Promise<getFestivalItemsResponse> => {
   
-  return customFetch<Promise<getFestivalItemsResponse>>(getGetFestivalItemsUrl(),
+  return customFetch<Promise<getFestivalItemsResponse>>(getGetFestivalItemsUrl(params),
   {      
     ...options,
     method: 'GET'
@@ -2971,19 +2979,19 @@ export const getFestivalItems = async ( options?: RequestInit): Promise<getFesti
 
 
 
-export const getGetFestivalItemsKey = () => [`/festival_items`] as const;
+export const getGetFestivalItemsKey = (params?: GetFestivalItemsParams,) => [`/festival_items`, ...(params ? [params]: [])] as const;
 
 export type GetFestivalItemsQueryResult = NonNullable<Awaited<ReturnType<typeof getFestivalItems>>>
 export type GetFestivalItemsQueryError = unknown
 
 export const useGetFestivalItems = <TError = unknown>(
-   options?: { swr?:SWRConfiguration<Awaited<ReturnType<typeof getFestivalItems>>, TError> & { swrKey?: Key, enabled?: boolean }, request?: SecondParameter<typeof customFetch> }
+  params?: GetFestivalItemsParams, options?: { swr?:SWRConfiguration<Awaited<ReturnType<typeof getFestivalItems>>, TError> & { swrKey?: Key, enabled?: boolean }, request?: SecondParameter<typeof customFetch> }
 ) => {
   const {swr: swrOptions, request: requestOptions} = options ?? {}
 
   const isEnabled = swrOptions?.enabled !== false
-  const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? getGetFestivalItemsKey() : null);
-  const swrFn = () => getFestivalItems(requestOptions)
+  const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? getGetFestivalItemsKey(params) : null);
+  const swrFn = () => getFestivalItems(params, requestOptions)
 
   const query = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(swrKey, swrFn, swrOptions)
 

--- a/view/next-project/src/generated/model/index.ts
+++ b/view/next-project/src/generated/model/index.ts
@@ -71,6 +71,7 @@ export * from './getExpensesDetailsYear200';
 export * from './getExpensesFiscalyearYear200';
 export * from './getExpensesId200';
 export * from './getExpensesIdDetails200';
+export * from './getFestivalItemsParams';
 export * from './getFinancialRecordsParams';
 export * from './getFundInformations200';
 export * from './getFundInformationsDetails200';


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #905


# 概要
<!-- 開発内容の概要を記載 -->
- 予算管理の物品のAPIを作成した
- openapiの定義修正
  - GETでクエリパラメータ追加 `year` `division_id`
  - 
 
### 作成したAPI
- GET
  - `year`、`division_id`で指定した年度のデータを全件取得
  - (なしだと全件）
- POST
  -  name、divisionId、amount、memoをbodyパラメータでfestival_items、item_bugetのレコードを作成する
- PUT
  -  idをパスパラメータ
  -  name、divisionId、amount、memoをbodyパラメータでfestival_items、item_bugetのレコードを修正する
- DELETE
  -  パスパラメータでidを指定してfestival_items、item_bugetを削除する

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![スクリーンショット 2025-01-09 0 53 35](https://github.com/user-attachments/assets/b5a3e2c1-dd97-4010-baae-b334efee7f61)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- swaggerでfestival_itemのAPIを叩く
- POSTでデータが作成できるか
- PUTでデータが修正できるか
- DELETEでデータの削除ができるか
- GETでデータの取得ができるか
- item_budgets、buy_reportsにデータを取得し、GETで集計ができているか確認する

# 備考
- 局や部門idが存在しないと外部制約エラーで作成できないです
