### PR TITLE
[マイページ]部門予算・詳細取得

### DIFF
--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -43,7 +43,7 @@ func (f *festivalItemController) IndexFestivalItemsForMypage(c echo.Context) err
 	year := c.QueryParam("year")
 	var festivalItemDetails []FestivalItemsForMyPage
 
-	festivalItemDetails, err := f.u.GetFestvalItemsForMypage(ctx, year, userId)
+	festivalItemDetails, err := f.u.GetFestivalItemsForMypage(ctx, year, userId)
 	if err != nil {
 		return err
 	}

--- a/api/externals/controller/festival_item_controller.go
+++ b/api/externals/controller/festival_item_controller.go
@@ -14,6 +14,7 @@ type festivalItemController struct {
 
 type FestivalItemController interface {
 	IndexFestivalItems(echo.Context) error
+	IndexFestivalItemsForMypage(echo.Context) error
 	CreateFestivalItem(echo.Context) error
 	UpdateFestivalItem(echo.Context) error
 	DestroyFestivalItem(echo.Context) error
@@ -30,6 +31,19 @@ func (f *festivalItemController) IndexFestivalItems(c echo.Context) error {
 	var festivalItemDetails FestivalItemDetails
 
 	festivalItemDetails, err := f.u.GetFestivalItems(ctx, year, divisionId)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, festivalItemDetails)
+}
+
+func (f *festivalItemController) IndexFestivalItemsForMypage(c echo.Context) error {
+	ctx := c.Request().Context()
+	userId := c.Param("user_id")
+	year := c.QueryParam("year")
+	var festivalItemDetails []FestivalItemsForMyPage
+
+	festivalItemDetails, err := f.u.GetFestvalItemsForMypage(ctx, year, userId)
 	if err != nil {
 		return err
 	}
@@ -76,3 +90,4 @@ func (f *festivalItemController) DestroyFestivalItem(c echo.Context) error {
 
 type FestivalItemDetails = generated.FestivalItemDetails
 type FestivalItem = generated.FestivalItem
+type FestivalItemsForMyPage = generated.FestivalItemsForMyPage

--- a/api/externals/repository/festival_item_repository.go
+++ b/api/externals/repository/festival_item_repository.go
@@ -246,7 +246,7 @@ var selectFestivalItemForMypageQuery = dialect.Select(
 	goqu.COALESCE(goqu.I("buy_reports.id"), 0).As("buyReportId"),
 	goqu.COALESCE(goqu.I("buy_reports.paid_by"), "").As("paidBy"),
 	goqu.COALESCE(goqu.I("buy_reports.amount"), 0).As("reportAmount"),
-	goqu.COALESCE(goqu.I("buy_reports.created_at"), "2025-01-29 20:53:44").As("reportDate"),
+	goqu.COALESCE(goqu.I("buy_reports.created_at"), "2000-01-01 00:00:00").As("reportDate"),
 	goqu.COALESCE(goqu.I("buy_statuses.is_packed"), 0).As("isPacked"),
 	goqu.COALESCE(goqu.I("buy_statuses.is_settled"), 0).As("isSettled")).
 	From("festival_items").

--- a/api/externals/repository/festival_item_repository.go
+++ b/api/externals/repository/festival_item_repository.go
@@ -29,7 +29,7 @@ type FestivalItemRepository interface {
 	StartTransaction(context.Context) (*sql.Tx, error)
 	RollBack(context.Context, *sql.Tx) error
 	Commit(context.Context, *sql.Tx) error
-	GetDetailByDivisionId(context.Context, string, string) (*sql.Rows, error)
+	GetDetailsByDivisionId(context.Context, string, string) (*sql.Rows, error)
 }
 
 func NewFestivalItemRepository(c db.Client, ac abstract.Crud) FestivalItemRepository {
@@ -193,7 +193,7 @@ func (fir *festivalItemRepository) Commit(c context.Context, tx *sql.Tx) error {
 }
 
 // 年度別と部門で取得
-func (fir *festivalItemRepository) GetDetailByDivisionId(
+func (fir *festivalItemRepository) GetDetailsByDivisionId(
 	c context.Context,
 	year string,
 	userId string,

--- a/api/generated/openapi_gen.go
+++ b/api/generated/openapi_gen.go
@@ -381,6 +381,12 @@ type GetFestivalItemsParams struct {
 	DivisionId *int `form:"division_id,omitempty" json:"division_id,omitempty"`
 }
 
+// GetFestivalItemsDetailsUserIdParams defines parameters for GetFestivalItemsDetailsUserId.
+type GetFestivalItemsDetailsUserIdParams struct {
+	// YearId year_id
+	YearId *int `form:"year_id,omitempty" json:"year_id,omitempty"`
+}
+
 // GetFinancialRecordsParams defines parameters for GetFinancialRecords.
 type GetFinancialRecordsParams struct {
 	// Year year
@@ -794,8 +800,8 @@ type ServerInterface interface {
 	// (POST /festival_items)
 	PostFestivalItems(ctx echo.Context) error
 
-	// (GET /festival_items/details/{division_id})
-	GetFestivalItemsDetailsDivisionId(ctx echo.Context, divisionId int) error
+	// (GET /festival_items/details/{user_id})
+	GetFestivalItemsDetailsUserId(ctx echo.Context, userId int, params GetFestivalItemsDetailsUserIdParams) error
 
 	// (DELETE /festival_items/{id})
 	DeleteFestivalItemsId(ctx echo.Context, id int) error
@@ -1934,19 +1940,28 @@ func (w *ServerInterfaceWrapper) PostFestivalItems(ctx echo.Context) error {
 	return err
 }
 
-// GetFestivalItemsDetailsDivisionId converts echo context to params.
-func (w *ServerInterfaceWrapper) GetFestivalItemsDetailsDivisionId(ctx echo.Context) error {
+// GetFestivalItemsDetailsUserId converts echo context to params.
+func (w *ServerInterfaceWrapper) GetFestivalItemsDetailsUserId(ctx echo.Context) error {
 	var err error
-	// ------------- Path parameter "division_id" -------------
-	var divisionId int
+	// ------------- Path parameter "user_id" -------------
+	var userId int
 
-	err = runtime.BindStyledParameterWithOptions("simple", "division_id", ctx.Param("division_id"), &divisionId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "user_id", ctx.Param("user_id"), &userId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter division_id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter user_id: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetFestivalItemsDetailsUserIdParams
+	// ------------- Optional query parameter "year_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "year_id", ctx.QueryParams(), &params.YearId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter year_id: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments
-	err = w.Handler.GetFestivalItemsDetailsDivisionId(ctx, divisionId)
+	err = w.Handler.GetFestivalItemsDetailsUserId(ctx, userId, params)
 	return err
 }
 
@@ -3151,7 +3166,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/expenses/:id/details", wrapper.GetExpensesIdDetails)
 	router.GET(baseURL+"/festival_items", wrapper.GetFestivalItems)
 	router.POST(baseURL+"/festival_items", wrapper.PostFestivalItems)
-	router.GET(baseURL+"/festival_items/details/:division_id", wrapper.GetFestivalItemsDetailsDivisionId)
+	router.GET(baseURL+"/festival_items/details/:user_id", wrapper.GetFestivalItemsDetailsUserId)
 	router.DELETE(baseURL+"/festival_items/:id", wrapper.DeleteFestivalItemsId)
 	router.PUT(baseURL+"/festival_items/:id", wrapper.PutFestivalItemsId)
 	router.GET(baseURL+"/financial_records", wrapper.GetFinancialRecords)

--- a/api/generated/openapi_gen.go
+++ b/api/generated/openapi_gen.go
@@ -383,8 +383,8 @@ type GetFestivalItemsParams struct {
 
 // GetFestivalItemsDetailsUserIdParams defines parameters for GetFestivalItemsDetailsUserId.
 type GetFestivalItemsDetailsUserIdParams struct {
-	// YearId year_id
-	YearId *int `form:"year_id,omitempty" json:"year_id,omitempty"`
+	// Year year
+	Year *int `form:"year,omitempty" json:"year,omitempty"`
 }
 
 // GetFinancialRecordsParams defines parameters for GetFinancialRecords.
@@ -1953,11 +1953,11 @@ func (w *ServerInterfaceWrapper) GetFestivalItemsDetailsUserId(ctx echo.Context)
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params GetFestivalItemsDetailsUserIdParams
-	// ------------- Optional query parameter "year_id" -------------
+	// ------------- Optional query parameter "year" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "year_id", ctx.QueryParams(), &params.YearId)
+	err = runtime.BindQueryParameter("form", true, false, "year", ctx.QueryParams(), &params.Year)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter year_id: %s", err))
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter year: %s", err))
 	}
 
 	// Invoke the callback with all the unmarshaled arguments

--- a/api/generated/openapi_gen.go
+++ b/api/generated/openapi_gen.go
@@ -16,7 +16,7 @@ import (
 const (
 	Empty BuyReportInformationStatus = "確認中"
 	N1    BuyReportInformationStatus = "封詰め"
-	N2    BuyReportInformationStatus = "生産完了"
+	N2    BuyReportInformationStatus = "清算完了"
 )
 
 // Defines values for GetActivitiesFilteredDetailsParamsIsDone.

--- a/api/internals/domain/festival_item.go
+++ b/api/internals/domain/festival_item.go
@@ -12,3 +12,20 @@ type FestivalItem struct {
 	CreatedAt  time.Time `json:"createdAt"`
 	UpdatedAt  time.Time `json:"updatedAt"`
 }
+
+type FestivalItemForMyPageColumn struct {
+	UserName            string
+	FinancialRecordName string
+	DivisionId          int
+	DivisionName        string
+	FestivalItemId      int
+	FestivalItemName    string
+	Year                int
+	BudgetAmount        int
+	BuyReportId         int
+	PaidBy              string
+	ReportAmount        int
+	ReportDate          string
+	IsPacked            bool
+	IsSettled           bool
+}

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -215,7 +215,7 @@ func (fiu *festivalItemUseCase) GetFestivalItemsForMypage(
 
 	var festivalItemForMyPageColumns []domain.FestivalItemForMyPageColumn
 
-	rows, err := fiu.rep.GetDetailByDivisionId(c, year, userId)
+	rows, err := fiu.rep.GetDetailsByDivisionId(c, year, userId)
 	if err != nil {
 		return festivalItemDetailsList, err
 	}

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -247,6 +247,22 @@ func (fiu *festivalItemUseCase) GetFestvalItemsForMypage(
 		festivalItemForMyPageColumns = append(festivalItemForMyPageColumns, festivalItemForMyPageColumn)
 	}
 
+	festivalItemDetailsList = convertColumnToGenerated(festivalItemForMyPageColumns)
+
+	return festivalItemDetailsList, nil
+}
+
+type FestivalItemDetails = generated.FestivalItemDetails
+type FestivalItem = generated.FestivalItem
+type FestivalItemWithBalance = generated.FestivalItemWithBalance
+type FestivalItemDetailsForMypage = generated.FestivalItemsForMyPage
+type FestivalItemWithReport = generated.FestivalItemWithReport
+type BuyReport = generated.BuyReportInformation
+
+func convertColumnToGenerated(festivalItemForMyPageColumns []domain.FestivalItemForMyPageColumn) []FestivalItemDetailsForMypage {
+	var festivalItemDetailsList []FestivalItemDetailsForMypage
+
+	// 部門ごとにマップを作成
 	var festivalItemDetailsForMypageMap = make(map[string]FestivalItemDetailsForMypage)
 	var festivalItemMaps = make(map[string]map[string]FestivalItemWithReport)
 
@@ -329,21 +345,9 @@ func (fiu *festivalItemUseCase) GetFestvalItemsForMypage(
 		newFestivalItemDetails.FestivalItems = &festivalItemWithReports
 		festivalItemDetailsList = append(festivalItemDetailsList, newFestivalItemDetails)
 	}
-
-	return festivalItemDetailsList, nil
+	return festivalItemDetailsList
 }
-
-type FestivalItemDetails = generated.FestivalItemDetails
-type FestivalItem = generated.FestivalItem
-type FestivalItemWithBalance = generated.FestivalItemWithBalance
-type FestivalItemDetailsForMypage = generated.FestivalItemsForMyPage
-type FestivalItemWithReport = generated.FestivalItemWithReport
-type BuyReport = generated.BuyReportInformation
 
 var empty = generated.Empty
 var isPacked = generated.N1
 var isSettled = generated.N2
-
-// func convertColumnToGenerated(column domain.FestivalItemForMyPageColumn) []FestivalItemDetailsForMypage {
-// 	r
-// }

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -282,9 +282,11 @@ func convertColumnToGenerated(festivalItemForMyPageColumns []domain.FestivalItem
 		// totalがなければ定義
 		if festivalItemWithReport.FestivalItemTotal == nil {
 			expense, budget, balance := 0, 0, 0
-			var total Total
-			total.Expense, total.Budget, total.Balance = &expense, &budget, &balance
-			festivalItemWithReport.FestivalItemTotal = &total
+			festivalItemWithReport.FestivalItemTotal = &Total{
+				Expense: &expense,
+				Budget:  &budget,
+				Balance: &balance,
+			}
 		}
 
 		*festivalItemWithReport.FestivalItemTotal.Budget += festivalItemForMyPageColumn.BudgetAmount
@@ -293,15 +295,15 @@ func convertColumnToGenerated(festivalItemForMyPageColumns []domain.FestivalItem
 
 		buyReports := festivalItemWithReport.BuyReports
 		if buyReports == nil {
-			var buyReportSlice []generated.BuyReportInformation
-			buyReports = &buyReportSlice
+			buyReports = &[]generated.BuyReportInformation{}
 		}
 
-		var buyReport BuyReport
-		buyReport.Id = &festivalItemForMyPageColumn.BuyReportId
-		buyReport.BuyReportName = &festivalItemForMyPageColumn.PaidBy
-		buyReport.Amount = &festivalItemForMyPageColumn.ReportAmount
-		buyReport.ReportDate = &festivalItemForMyPageColumn.ReportDate
+		buyReport := BuyReport{
+			Id:            &festivalItemForMyPageColumn.BuyReportId,
+			BuyReportName: &festivalItemForMyPageColumn.PaidBy,
+			Amount:        &festivalItemForMyPageColumn.ReportAmount,
+			ReportDate:    &festivalItemForMyPageColumn.ReportDate,
+		}
 
 		if festivalItemForMyPageColumn.IsSettled {
 			buyReport.Status = &isSettled
@@ -311,6 +313,7 @@ func convertColumnToGenerated(festivalItemForMyPageColumns []domain.FestivalItem
 			buyReport.Status = &empty
 		}
 
+		// 報告が0以上のみ、buyReportsに追加
 		if *buyReport.Amount > 0 {
 			*buyReports = append(*buyReports, buyReport)
 		}
@@ -323,9 +326,11 @@ func convertColumnToGenerated(festivalItemForMyPageColumns []domain.FestivalItem
 		// divisionのtotalがなければ定義
 		if festivalItemDetailsForMypage.DivisionTotal == nil {
 			expense, budget, balance := 0, 0, 0
-			var total Total
-			total.Expense, total.Budget, total.Balance = &expense, &budget, &balance
-			festivalItemDetailsForMypage.DivisionTotal = &total
+			festivalItemDetailsForMypage.DivisionTotal = &Total{
+				Expense: &expense,
+				Budget:  &budget,
+				Balance: &balance,
+			}
 		}
 
 		festivalItemDetailsForMypageMap[festivalItemForMyPageColumn.DivisionName] = festivalItemDetailsForMypage

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -15,7 +15,7 @@ type festivalItemUseCase struct {
 
 type FestivalItemUseCase interface {
 	GetFestivalItems(context.Context, string, string) (FestivalItemDetails, error)
-	GetFestvalItemsForMypage(context.Context, string, string) ([]FestivalItemDetailsForMypage, error)
+	GetFestivalItemsForMypage(context.Context, string, string) ([]FestivalItemDetailsForMypage, error)
 	CreateFestivalItem(
 		context.Context,
 		FestivalItem,
@@ -206,12 +206,11 @@ func (fiu *festivalItemUseCase) DestroyFestivalItem(c context.Context, id string
 	return nil
 }
 
-func (fiu *festivalItemUseCase) GetFestvalItemsForMypage(
+func (fiu *festivalItemUseCase) GetFestivalItemsForMypage(
 	c context.Context,
 	year string,
 	userId string,
 ) ([]FestivalItemDetailsForMypage, error) {
-	// var festivalItemDetails FestivalItemDetailsForMypage
 	var festivalItemDetailsList []FestivalItemDetailsForMypage
 
 	var festivalItemForMyPageColumns []domain.FestivalItemForMyPageColumn

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -305,11 +305,12 @@ func convertColumnToGenerated(festivalItemForMyPageColumns []domain.FestivalItem
 			ReportDate:    &festivalItemForMyPageColumn.ReportDate,
 		}
 
-		if festivalItemForMyPageColumn.IsSettled {
+		switch {
+		case festivalItemForMyPageColumn.IsSettled:
 			buyReport.Status = &isSettled
-		} else if festivalItemForMyPageColumn.IsPacked {
+		case festivalItemForMyPageColumn.IsPacked:
 			buyReport.Status = &isPacked
-		} else {
+		default:
 			buyReport.Status = &empty
 		}
 

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -272,8 +272,8 @@ func convertColumnToGenerated(festivalItemForMyPageColumns []domain.FestivalItem
 		festivalItemDetailsForMypage.FinancialRecordName = &festivalItemForMyPageColumn.FinancialRecordName
 
 		// 予算と支出データ集計
-		festivalItemMap := festivalItemMaps[festivalItemForMyPageColumn.DivisionName]
-		if festivalItemMap == nil {
+		festivalItemMap, ok := festivalItemMaps[festivalItemForMyPageColumn.DivisionName]
+		if !ok {
 			festivalItemMap = make(map[string]FestivalItemWithReport)
 		}
 		festivalItemWithReport := festivalItemMap[festivalItemForMyPageColumn.FestivalItemName]

--- a/api/internals/usecase/festival_item_usecase.go
+++ b/api/internals/usecase/festival_item_usecase.go
@@ -261,7 +261,7 @@ type BuyReport = generated.BuyReportInformation
 func convertColumnToGenerated(festivalItemForMyPageColumns []domain.FestivalItemForMyPageColumn) []FestivalItemDetailsForMypage {
 	var festivalItemDetailsList []FestivalItemDetailsForMypage
 
-	// 部門ごとにマップを作成
+	// NOTE ColumnsをDetailsListの型に合わせてマッピングする。値が無い場合は初期化する。
 	var festivalItemDetailsForMypageMap = make(map[string]FestivalItemDetailsForMypage)
 	var festivalItemMaps = make(map[string]map[string]FestivalItemWithReport)
 

--- a/api/router/router.go
+++ b/api/router/router.go
@@ -175,6 +175,7 @@ func (r router) ProvideRouter(e *echo.Echo) {
 
 	// festival items
 	e.GET("/festival_items", r.festivalItemController.IndexFestivalItems)
+	e.GET("/festival_items/details/:user_id", r.festivalItemController.IndexFestivalItemsForMypage)
 	e.POST("/festival_items", r.festivalItemController.CreateFestivalItem)
 	e.PUT("/festival_items/:id", r.festivalItemController.UpdateFestivalItem)
 	e.DELETE("/festival_items/:id", r.festivalItemController.DestroyFestivalItem)

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1230,16 +1230,21 @@ paths:
             application/json:
               schema:
                 type: object
-  /festival_items/details/{division_id}:
+  /festival_items/details/{user_id}:
     get:
       tags:
         - festival_item
-      description: divisionの予算一覧の取得
+      description: ユーザーのマイページの予算一覧の取得
       parameters:
-        - name: division_id
+        - name: user_id
           in: path
-          description: division_id
+          description: user_id
           required: true
+          schema:
+            type: integer
+        - name: year_id
+          in: query
+          description: year_id
           schema:
             type: integer
       responses:
@@ -1248,7 +1253,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/festivalItemsForMyPage"
+                type: array
+                items:
+                  $ref: "#/components/schemas/festivalItemsForMyPage"
   /financial_records:
     get:
       tags:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1242,9 +1242,9 @@ paths:
           required: true
           schema:
             type: integer
-        - name: year_id
+        - name: year
           in: query
-          description: year_id
+          description: year
           schema:
             type: integer
       responses:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2662,7 +2662,7 @@ components:
           enum:
             - 確認中
             - 封詰め
-            - 生産完了
+            - 清算完了
     buyReportDetail:
       description: 購入報告ページで表示する詳細情報
       type: object

--- a/view/next-project/src/generated/hooks.ts
+++ b/view/next-project/src/generated/hooks.ts
@@ -84,6 +84,7 @@ import type {
   GetExpensesFiscalyearYear200,
   GetExpensesId200,
   GetExpensesIdDetails200,
+  GetFestivalItemsDetailsUserIdParams,
   GetFestivalItemsParams,
   GetFinancialRecordsParams,
   GetFundInformations200,
@@ -3486,23 +3487,32 @@ export const useDeleteFestivalItemsId = <TError = unknown>(
 }
 
 /**
- * divisionの予算一覧の取得
+ * ユーザーのマイページの予算一覧の取得
  */
-export type getFestivalItemsDetailsDivisionIdResponse = {
+export type getFestivalItemsDetailsUserIdResponse = {
   data: FestivalItemsForMyPage;
   status: number;
   headers: Headers;
 }
 
-export const getGetFestivalItemsDetailsDivisionIdUrl = (divisionId: number,) => {
+export const getGetFestivalItemsDetailsUserIdUrl = (userId: number,
+    params?: GetFestivalItemsDetailsUserIdParams,) => {
+  const normalizedParams = new URLSearchParams();
 
+  Object.entries(params || {}).forEach(([key, value]) => {
+    
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString())
+    }
+  });
 
-  return `/festival_items/details/${divisionId}`
+  return normalizedParams.size ? `/festival_items/details/${userId}?${normalizedParams.toString()}` : `/festival_items/details/${userId}`
 }
 
-export const getFestivalItemsDetailsDivisionId = async (divisionId: number, options?: RequestInit): Promise<getFestivalItemsDetailsDivisionIdResponse> => {
+export const getFestivalItemsDetailsUserId = async (userId: number,
+    params?: GetFestivalItemsDetailsUserIdParams, options?: RequestInit): Promise<getFestivalItemsDetailsUserIdResponse> => {
   
-  return customFetch<Promise<getFestivalItemsDetailsDivisionIdResponse>>(getGetFestivalItemsDetailsDivisionIdUrl(divisionId),
+  return customFetch<Promise<getFestivalItemsDetailsUserIdResponse>>(getGetFestivalItemsDetailsUserIdUrl(userId,params),
   {      
     ...options,
     method: 'GET'
@@ -3514,19 +3524,21 @@ export const getFestivalItemsDetailsDivisionId = async (divisionId: number, opti
 
 
 
-export const getGetFestivalItemsDetailsDivisionIdKey = (divisionId: number,) => [`/festival_items/details/${divisionId}`] as const;
+export const getGetFestivalItemsDetailsUserIdKey = (userId: number,
+    params?: GetFestivalItemsDetailsUserIdParams,) => [`/festival_items/details/${userId}`, ...(params ? [params]: [])] as const;
 
-export type GetFestivalItemsDetailsDivisionIdQueryResult = NonNullable<Awaited<ReturnType<typeof getFestivalItemsDetailsDivisionId>>>
-export type GetFestivalItemsDetailsDivisionIdQueryError = unknown
+export type GetFestivalItemsDetailsUserIdQueryResult = NonNullable<Awaited<ReturnType<typeof getFestivalItemsDetailsUserId>>>
+export type GetFestivalItemsDetailsUserIdQueryError = unknown
 
-export const useGetFestivalItemsDetailsDivisionId = <TError = unknown>(
-  divisionId: number, options?: { swr?:SWRConfiguration<Awaited<ReturnType<typeof getFestivalItemsDetailsDivisionId>>, TError> & { swrKey?: Key, enabled?: boolean }, request?: SecondParameter<typeof customFetch> }
+export const useGetFestivalItemsDetailsUserId = <TError = unknown>(
+  userId: number,
+    params?: GetFestivalItemsDetailsUserIdParams, options?: { swr?:SWRConfiguration<Awaited<ReturnType<typeof getFestivalItemsDetailsUserId>>, TError> & { swrKey?: Key, enabled?: boolean }, request?: SecondParameter<typeof customFetch> }
 ) => {
   const {swr: swrOptions, request: requestOptions} = options ?? {}
 
-  const isEnabled = swrOptions?.enabled !== false && !!(divisionId)
-  const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? getGetFestivalItemsDetailsDivisionIdKey(divisionId) : null);
-  const swrFn = () => getFestivalItemsDetailsDivisionId(divisionId, requestOptions)
+  const isEnabled = swrOptions?.enabled !== false && !!(userId)
+  const swrKey = swrOptions?.swrKey ?? (() => isEnabled ? getGetFestivalItemsDetailsUserIdKey(userId,params) : null);
+  const swrFn = () => getFestivalItemsDetailsUserId(userId,params, requestOptions)
 
   const query = useSwr<Awaited<ReturnType<typeof swrFn>>, TError>(swrKey, swrFn, swrOptions)
 

--- a/view/next-project/src/generated/hooks.ts
+++ b/view/next-project/src/generated/hooks.ts
@@ -3490,7 +3490,7 @@ export const useDeleteFestivalItemsId = <TError = unknown>(
  * ユーザーのマイページの予算一覧の取得
  */
 export type getFestivalItemsDetailsUserIdResponse = {
-  data: FestivalItemsForMyPage;
+  data: FestivalItemsForMyPage[];
   status: number;
   headers: Headers;
 }

--- a/view/next-project/src/generated/model/index.ts
+++ b/view/next-project/src/generated/model/index.ts
@@ -81,6 +81,7 @@ export * from './getExpensesDetailsYear200';
 export * from './getExpensesFiscalyearYear200';
 export * from './getExpensesId200';
 export * from './getExpensesIdDetails200';
+export * from './getFestivalItemsDetailsUserIdParams';
 export * from './getFestivalItemsParams';
 export * from './getFinancialRecordsParams';
 export * from './getFundInformations200';


### PR DESCRIPTION
<!-- 対応したIssue番号を記載 -->
resolve #914

# 概要
- ここの一覧表示のAPIです
![スクリーンショット 2025-01-31 11 28 32](https://github.com/user-attachments/assets/d1b22337-f036-4394-8918-1c6a9f6eabda)

<!-- 開発内容の概要を記載 -->
- usecaseの処理が長くなったので、1つだけで出します
- GET `/festival_items/details/{user_id}`
  - userが属する部門（division)の予算・支出をなどを返します 
  - クエリパラメータでyearを渡すと、年度のものを返します

```
[
  {
    "divisionTotal": {
      "budget": 100000,
      "expense": 10000,
      "balance": 90000
    },
    "financialRecordName": "企画局",
    "divisionName": "ビンゴ部門",
    "festivalItems": [
      {
        "festivalItemTotal": {
          "budget": 100000,
          "expense": 10000,
          "balance": 90000
        },
        "festivalItemName": "ビンゴ景品",
        "buyReports": [
          {
            "id": 1,
            "buyReportName": "段ボール",
            "amount": 1000,
            "reportDate": "2024-01-01",
            "status": "確認中"
          }
        ]
      }
    ]
  }
]
```
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
-


# 備考
- 動作確認のためにテーブルにデータ追加する必要があります
  - financial_records
  - divisions
  - user_groups
  - festival_items
  - item_budgets
  - buy_reports
  - buy_status