### PR TITLE
協賛金回収完了から未回収へ変更できないよう修正

### DIFF
--- a/view/next-project/src/components/sponsoractivities/EditModal.tsx
+++ b/view/next-project/src/components/sponsoractivities/EditModal.tsx
@@ -298,9 +298,7 @@ export default function EditModal(props: ModalProps) {
             setFormData({ ...formData, isDone: e.target.value === '回収完了' ? true : false });
           }}
         >
-          <option value='未回収' selected={data.isDone === false}>
-            未回収
-          </option>
+          {!data.isDone && <option value={'未回収'}>未回収</option>}
           <option value='回収完了' selected={data.isDone === true}>
             回収完了
           </option>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
収支管理ページ実装に向けた協賛活動一覧の修正
<!-- 対応したIssue番号を記載 -->

# 概要
<!-- 開発内容の概要を記載 -->
協賛活動一覧の編集モーダルにおいて、協賛金の回収ステータスを「回収完了」から「未回収」に変更できないように修正しました。
# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![image](https://github.com/user-attachments/assets/934a548e-1c98-4b0a-9bc1-a76ab74405dd)

# テスト項目
<!-- テストしてほしい内容を記載 -->
-
-
-

# 備考
