### PR TITLE
購入報告で精算完了になった際に収支管理に追加するようにした

### DIFF
--- a/api/internals/di/di.go
+++ b/api/internals/di/di.go
@@ -71,7 +71,7 @@ func InitializeServer() (db.Client, *echo.Echo) {
 	activityStyleUseCase := usecase.NewActivityStyleUseCase(activityStyleRepository)
 	budgetUseCase := usecase.NewBudgetUseCase(budgetRepository)
 	bureauUseCase := usecase.NewBureauUseCase(bureauRepository)
-	buyReportUseCase := usecase.NewBuyReportUseCase(buyReportRepository, transactionRepository, objectHandleRepository)
+	buyReportUseCase := usecase.NewBuyReportUseCase(buyReportRepository, transactionRepository, objectHandleRepository, incomeExpenditureManagementRepository)
 	departmentUseCase := usecase.NewDepartmentUseCase(departmentRepository)
 	divisionUseCase := usecase.NewDivisionUseCase(divisionRepository)
 	expenseUseCase := usecase.NewExpenseUseCase(expenseRepository)

--- a/api/internals/domain/buy_report.go
+++ b/api/internals/domain/buy_report.go
@@ -13,3 +13,9 @@ type BuyReport struct {
 	CreatedAt      time.Time `json:"createdAt"`
 	UpdatedAt      time.Time `json:"updatedAt"`
 }
+
+type BuyReportForIncomeExpenditureManagement struct {
+	ID     int `json:"id"`
+	YearID int `json:"yearId"`
+	Amount int `json:"amount"`
+}

--- a/api/internals/usecase/buy_report_usecase.go
+++ b/api/internals/usecase/buy_report_usecase.go
@@ -359,7 +359,7 @@ func (bru *buyReportUseCase) UpdateBuyReportStatus(c context.Context, buyReportI
 			}
 			return detail, err
 		}
-		if err := row.Scan(&incomeExpenditureManagementId); err != nil {
+		if err = row.Scan(&incomeExpenditureManagementId); err != nil {
 			if err.Error() != "sql: no rows in result set" {
 				if err = bru.tRep.RollBack(c, tx); err != nil {
 					return detail, err

--- a/api/internals/usecase/buy_report_usecase.go
+++ b/api/internals/usecase/buy_report_usecase.go
@@ -351,7 +351,7 @@ func (bru *buyReportUseCase) UpdateBuyReportStatus(c context.Context, buyReportI
 
 	if *requestBody.IsPacked && *requestBody.IsSettled {
 		var incomeExpenditureManagementId *int
-		// buyRepotIdに紐づく、収支管理を取得
+		// buyReportIdに紐づく、収支管理を取得
 		row, err := bru.iRep.GetIncomeExpenditureManagementByBuyReportId(c, tx, buyReportId)
 		if err != nil {
 			if err = bru.tRep.RollBack(c, tx); err != nil {


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #0

# 概要
<!-- 開発内容の概要を記載 -->
- PUT
[/buy_report/status/{buy_report_id}](http://localhost:8000/#/buy_report/put_buy_report_status__buy_report_id_) の処理を修正した
- 精算済みになった際に収支管理のデータがない場合はincome_expenditure_managementsとbuy_report_income_expenditure_managementsにデータを追加する

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
![image](https://github.com/user-attachments/assets/69cc6566-2cd6-4849-b132-a9b6c48fd3f9)


# テスト項目
<!-- テストしてほしい内容を記載 -->
- 購入報告→精算済み→収支管理に反映されるかを確認する
-
-

# 備考
