### PR TITLE
購入報告一覧の清算完了確認モーダルの追加

### DIFF
--- a/view/next-project/src/components/purchasereports/CheckSettlementConfirmModal.tsx
+++ b/view/next-project/src/components/purchasereports/CheckSettlementConfirmModal.tsx
@@ -24,11 +24,11 @@ const CheckSettlementConfirmModal: FC<ModalProps> = (props) => {
           <CloseButton onClick={closeModal} />
         </div>
       </div>
-      <div className='mx-auto mb-5 w-fit text-xl text-black-600'>精算完了に変更</div>
+      <div className='mx-auto mb-5 w-fit text-xl text-black-600'>清算完了に変更</div>
       <div className='mx-auto my-5 w-fit text-center'>
-        <p className='text-lg'>この購入報告を精算完了に変更しますか？</p>
+        <p className='text-lg'>この購入報告を清算完了に変更しますか？</p>
         <p className='mt-5 text-sm text-red-600'>
-          一度精算完了にすると、元にに戻すことはできません。
+          一度清算完了にすると、元にに戻すことはできません。
         </p>
       </div>
       <div className=''>

--- a/view/next-project/src/components/purchasereports/CheckSettlementConfirmModal.tsx
+++ b/view/next-project/src/components/purchasereports/CheckSettlementConfirmModal.tsx
@@ -1,0 +1,44 @@
+import React, { Dispatch, FC, SetStateAction } from 'react';
+import { Modal, CloseButton, OutlinePrimaryButton, PrimaryButton } from '@components/common';
+
+interface ModalProps {
+  setShowModal: Dispatch<SetStateAction<boolean>>;
+  id: number;
+  onConfirm: (id: number) => void;
+}
+
+const CheckSettlementConfirmModal: FC<ModalProps> = (props) => {
+  const closeModal = () => {
+    props.setShowModal(false);
+  };
+
+  const handleConfirm = () => {
+    props.onConfirm(props.id);
+    closeModal();
+  };
+
+  return (
+    <Modal className='md:w-1/2'>
+      <div className='w-full'>
+        <div className='ml-auto w-fit'>
+          <CloseButton onClick={closeModal} />
+        </div>
+      </div>
+      <div className='mx-auto mb-5 w-fit text-xl text-black-600'>精算完了に変更</div>
+      <div className='mx-auto my-5 w-fit text-center'>
+        <p className='text-lg'>この購入報告を精算完了に変更しますか？</p>
+        <p className='mt-5 text-sm text-red-600'>
+          一度精算完了にすると、元にに戻すことはできません。
+        </p>
+      </div>
+      <div className=''>
+        <div className='flex flex-row justify-center gap-5'>
+          <OutlinePrimaryButton onClick={closeModal}>キャンセル</OutlinePrimaryButton>
+          <PrimaryButton onClick={handleConfirm}>変更する</PrimaryButton>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default CheckSettlementConfirmModal;

--- a/view/next-project/src/components/purchasereports/CheckSettlementConfirmModal.tsx
+++ b/view/next-project/src/components/purchasereports/CheckSettlementConfirmModal.tsx
@@ -28,7 +28,7 @@ const CheckSettlementConfirmModal: FC<ModalProps> = (props) => {
       <div className='mx-auto my-5 w-fit text-center'>
         <p className='text-lg'>この購入報告を清算完了に変更しますか？</p>
         <p className='mt-5 text-sm text-red-600'>
-          一度清算完了にすると、元にに戻すことはできません。
+          一度清算完了にすると、元に戻すことはできません。
         </p>
       </div>
       <div className=''>

--- a/view/next-project/src/components/purchasereports/OpenCheckSettlementModalButton.tsx
+++ b/view/next-project/src/components/purchasereports/OpenCheckSettlementModalButton.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Checkbox } from '@components/common';
 import CheckSettlementConfirmModal from './CheckSettlementConfirmModal';
+import { Checkbox } from '@components/common';
 
 interface Props {
   id: number;

--- a/view/next-project/src/components/purchasereports/OpenCheckSettlementModalButton.tsx
+++ b/view/next-project/src/components/purchasereports/OpenCheckSettlementModalButton.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { Checkbox } from '@components/common';
+import CheckSettlementConfirmModal from './CheckSettlementConfirmModal';
+
+interface Props {
+  id: number;
+  isChecked: boolean;
+  onConfirm: (id: number) => void;
+  disabled?: boolean;
+}
+
+const OpenCheckSettlementModalButton = ({ id, isChecked, onConfirm, disabled }: Props) => {
+  const [showModal, setShowModal] = useState(false);
+
+  const handleChange = () => {
+    if (!isChecked) {
+      setShowModal(true);
+    } else {
+      onConfirm(id);
+    }
+  };
+
+  return (
+    <>
+      <Checkbox
+        className='accent-primary-5'
+        checked={isChecked}
+        onChange={handleChange}
+        disabled={disabled}
+      />
+
+      {showModal && (
+        <CheckSettlementConfirmModal setShowModal={setShowModal} id={id} onConfirm={onConfirm} />
+      )}
+    </>
+  );
+};
+
+export default OpenCheckSettlementModalButton;

--- a/view/next-project/src/components/purchasereports/index.ts
+++ b/view/next-project/src/components/purchasereports/index.ts
@@ -6,8 +6,10 @@ export { default as EditModal } from './EditModal';
 export { default as OpenAddModalButton } from './OpenAddModalButton';
 export { default as OpenDeleteModalButton } from './OpenDeleteModalButton';
 export { default as OpenEditModalButton } from './OpenEditModalButton';
+export { default as OpenCheckSettlementModalButton } from './OpenCheckSettlementModalButton';
 export { default as PurchaseOrderListModal } from './PurchaseOrderListModal';
 export { default as PurchaseReportAddModal } from './PurchaseReportAddModal';
 export { default as PurchaseReportConfirmModal } from './PurchaseReportConfirmModal';
 export { default as PurchaseReportItemNumModal } from './PurchaseReportItemNumModal'; // "PurchaseReport|temNumModal"を修正しました。
 export { default as ReceiptModal } from './ReceiptModal';
+export { default as CheckSettlementConfirmModal } from './CheckSettlementConfirmModal';

--- a/view/next-project/src/pages/purchase_report_list/index.tsx
+++ b/view/next-project/src/pages/purchase_report_list/index.tsx
@@ -56,9 +56,6 @@ export default function PurchaseReports() {
   const [sealChecks, setSealChecks] = useState<Record<number, boolean>>({});
   const [settlementChecks, setSettlementChecks] = useState<Record<number, boolean>>({});
 
-  const [showSettlementModal, setShowSettlementModal] = useState(false);
-  const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
-
   // NOTE: 初回レンダリングだと値が取ってこれずundefinedになったのでuseEffectで取得している。
   useEffect(() => {
     if (buyReports.length > 0) {

--- a/view/next-project/src/pages/purchase_report_list/index.tsx
+++ b/view/next-project/src/pages/purchase_report_list/index.tsx
@@ -5,6 +5,7 @@ import { TbDownload } from 'react-icons/tb';
 import { useRecoilValue } from 'recoil';
 import DownloadButton from '@/components/common/DownloadButton';
 import PrimaryButton from '@/components/common/OutlinePrimaryButton/OutlinePrimaryButton';
+import { OpenCheckSettlementModalButton } from '@/components/purchasereports';
 import {
   useGetBuyReportsDetails,
   useGetYearsPeriods,
@@ -19,8 +20,6 @@ import { userAtom } from '@/store/atoms';
 import { Card, Checkbox, EditButton, Loading, Title } from '@components/common';
 import MainLayout from '@components/layout/MainLayout';
 import OpenDeleteModalButton from '@components/purchasereports/OpenDeleteModalButton';
-import CheckSettlementConfirmModal from '@components/purchasereports/CheckSettlementConfirmModal';
-import { OpenCheckSettlementModalButton } from '@/components/purchasereports';
 
 export default function PurchaseReports() {
   const router = useRouter();

--- a/view/next-project/src/pages/purchase_report_list/index.tsx
+++ b/view/next-project/src/pages/purchase_report_list/index.tsx
@@ -19,6 +19,8 @@ import { userAtom } from '@/store/atoms';
 import { Card, Checkbox, EditButton, Loading, Title } from '@components/common';
 import MainLayout from '@components/layout/MainLayout';
 import OpenDeleteModalButton from '@components/purchasereports/OpenDeleteModalButton';
+import CheckSettlementConfirmModal from '@components/purchasereports/CheckSettlementConfirmModal';
+import { OpenCheckSettlementModalButton } from '@/components/purchasereports';
 
 export default function PurchaseReports() {
   const router = useRouter();
@@ -55,6 +57,9 @@ export default function PurchaseReports() {
   const [sealChecks, setSealChecks] = useState<Record<number, boolean>>({});
   const [settlementChecks, setSettlementChecks] = useState<Record<number, boolean>>({});
 
+  const [showSettlementModal, setShowSettlementModal] = useState(false);
+  const [selectedReportId, setSelectedReportId] = useState<number | null>(null);
+
   // NOTE: 初回レンダリングだと値が取ってこれずundefinedになったのでuseEffectで取得している。
   useEffect(() => {
     if (buyReports.length > 0) {
@@ -68,27 +73,23 @@ export default function PurchaseReports() {
   }, [buyReports]);
 
   const updateSealCheck = (id: number) => {
-    if (sealChecks[id]) {
-      setSettlementChecks((prevSettlement) => ({
-        ...prevSettlement,
-        [id]: false,
-      }));
+    if (settlementChecks[id]) {
+      return;
     }
-    setSealChecks((prev) => {
-      return {
-        ...prev,
-        [id]: !prev[id],
-      };
-    });
+    setSealChecks((prev) => ({
+      ...prev,
+      [id]: !prev[id],
+    }));
   };
 
   const updateSettlementCheck = (id: number) => {
-    setSettlementChecks((prev) => {
-      return {
-        ...prev,
-        [id]: !prev[id],
-      };
-    });
+    if (settlementChecks[id]) {
+      return;
+    }
+    setSettlementChecks((prev) => ({
+      ...prev,
+      [id]: !prev[id],
+    }));
   };
 
   const handleEdit = (report: BuyReportDetail) => {
@@ -240,12 +241,12 @@ export default function PurchaseReports() {
                           />
                         </td>
                         <td className='px-4 py-2 text-center'>
-                          <Checkbox
-                            className='accent-primary-5'
-                            checked={settlementChecks[report.id ?? 0] || false}
-                            onChange={() => {
-                              setBuyReportId(report.id ?? 0);
-                              updateSettlementCheck(report.id ?? 0);
+                          <OpenCheckSettlementModalButton
+                            id={report.id ?? 0}
+                            isChecked={settlementChecks[report.id ?? 0]}
+                            onConfirm={(id) => {
+                              setBuyReportId(id);
+                              updateSettlementCheck(id);
                             }}
                             disabled={!sealChecks[report.id ?? 0]}
                           />


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->

# 概要
<!-- 開発内容の概要を記載 -->
購入報告一覧でのチェックボックスのルール変更と清算完了確認モーダルの追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
![image](https://github.com/user-attachments/assets/0ab5b920-735b-4632-901b-a29247adc5fc)

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] 封詰めチェックをつけないと清算完了チェックが押せないようになっているか
- [ ] 清算完了チェックを押すとモーダルが出てくるか
- [ ] 清算完了チェックを外せないようになっているか
- [ ] 清算完了チェックがついていない場合は封詰めチェックを外せるか

# 備考
他のモーダルを参考に見よう見真似でやってみました