### PR TITLE
Fix: Replace informal comment in division controller

### DIFF
--- a/api/externals/controller/division_controller.go
+++ b/api/externals/controller/division_controller.go
@@ -104,7 +104,7 @@ func (d *divisionController) DestroyDivision(c echo.Context) error {
 func (d *divisionController) GetDivisionsYears(c echo.Context) error {
 	ctx := c.Request().Context()
 	year := c.QueryParam("year")
-	// usecase層で年度ごとのdivisionOptionを取得するギャル！
+	// Retrieve division options for each year from the usecase layer.
 	divisions, err := d.u.GetDivisionsYears(ctx, year)
 	if err != nil {
 		return err


### PR DESCRIPTION
I replaced an informal comment with a professional explanation in `api/externals/controller/division_controller.go`.

<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #0

# 概要
<!-- 開発内容の概要を記載 -->

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
-
-
-

# 備考
