### PR TITLE
Feat/yama/change font rendering

### DIFF
--- a/view/next-project/src/utils/createSponsorActivitiesInvoicesPDF.tsx
+++ b/view/next-project/src/utils/createSponsorActivitiesInvoicesPDF.tsx
@@ -5,7 +5,12 @@ import { Invoice } from '@type/common';
 
 Font.register({
   family: 'NotoSansJP',
-  src: 'https://fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Regular.woff2',
+  src: '/fonts/NotoSansJP-Regular.ttf'
+});
+
+Font.registerEmojiSource({
+  format: 'png',
+  url: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/',
 });
 
 const styles = StyleSheet.create({

--- a/view/next-project/src/utils/createSponsorActivitiesReceiptsPDF.tsx
+++ b/view/next-project/src/utils/createSponsorActivitiesReceiptsPDF.tsx
@@ -17,7 +17,12 @@ import { SponsorActivityView } from '@type/common';
 
 Font.register({
   family: 'NotoSansJP',
-  src: 'https://fonts.gstatic.com/ea/notosansjapanese/v6/NotoSansJP-Regular.woff2',
+  src: '/fonts/NotoSansJP-Regular.ttf'
+});
+
+Font.registerEmojiSource({
+  format: 'png',
+  url: 'https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/',
 });
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
https://nut-m-e-g.slack.com/archives/C020WQ3GY07/p1750922545948019

# 概要
PDF作成時に一部の文字が出力されない問題を修正しました。

これまでWebフォントをURLで読み込んでいましたが、フォントがサブセット化されており一部の記号などが読み込まれていなかったようでした。
完全な文字セットを含む`NotoSansJP-Regular.ttf`をプロジェクトの`public/fonts`ディレクトリに配置し、ローカルファイルとして読み込むように変更しました。

ついでに、絵文字の表示にも対応させました。

# 画面スクリーンショット等
| ![image](https://github.com/user-attachments/assets/fb43850d-79cd-4f8c-8b4f-206e902dec86) | ![image](https://github.com/user-attachments/assets/4fac3397-3c1d-47d2-b4d6-17c26e927160) |
| -- | -- |


# テスト項目
<!-- テストしてほしい内容を記載 -->
- 領収書・請求書PDFが正常に生成・ダウンロードできること。
- 生成されたPDF内の日本語（旧字体や特殊な漢字、記号）が文字化けせずに正しく表示されていることを確認。
- （PDF内の絵文字が正しく表示されていることを確認。）
