### PR TITLE
ユーザーの局編集に産学局を追加し、協賛ページに権限制御を実装

### DIFF
--- a/view/next-project/src/components/users/EditModal.tsx
+++ b/view/next-project/src/components/users/EditModal.tsx
@@ -13,7 +13,7 @@ interface ModalProps {
   user: User;
 }
 
-export default function FundInformationEditModal(props: ModalProps) {
+export default function UserEditModal(props: ModalProps) {
   const router = useRouter();
 
   const [formData, setFormData] = useState<User>(props.user);
@@ -50,7 +50,7 @@ export default function FundInformationEditModal(props: ModalProps) {
         <div className='col-span-4 w-full'>
           <Input className='w-full' value={formData.name} onChange={handler('name')} />
         </div>
-        <p>学科</p>
+        <p>局</p>
         <div className='col-span-4 w-full'>
           <Select value={formData.bureauID} onChange={handler('bureauID')}>
             {props.bureaus.map((data) => (

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -86,7 +86,10 @@ export default function SponsorActivities(props: Props) {
 
   useEffect(() => {
     if (!_hasHydrated) return;
-    if (!user?.roleID) return;
+    if (!user?.roleID) {
+      router.push('/');
+      return;
+    }
     if (user.roleID !== 2 && user.roleID !== 3) {
       router.push('/my_page');
     }

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -1,8 +1,11 @@
+import { useRouter } from 'next/router';
 import { useEffect, useMemo, useReducer } from 'react';
 
+import { Loading } from '@/components/common';
 import SponsorActivitiesLayout from '@/components/sponsor-activities/page/SponsorActivitiesLayout';
 import { useSponsorActivitiesQuery } from '@/hooks/sponsor-activities/useSponsorActivitiesQuery';
 import { useSponsorsByYear } from '@/hooks/sponsor-activities/useSponsorsByYear';
+import { useCurrentUser, useUserStore } from '@/store';
 import { get } from '@/utils/api/api_methods';
 import {
   calculateActivitiesTotalAmount,
@@ -76,6 +79,18 @@ export async function getServerSideProps() {
 
 export default function SponsorActivities(props: Props) {
   const { sponsorStyles, sponsors, users, yearPeriods } = props;
+
+  const router = useRouter();
+  const user = useCurrentUser();
+  const _hasHydrated = useUserStore((state) => state._hasHydrated);
+
+  useEffect(() => {
+    if (!_hasHydrated) return;
+    if (!user?.roleID) return;
+    if (user.roleID !== 2 && user.roleID !== 3) {
+      router.push('/my_page');
+    }
+  }, [_hasHydrated, user?.roleID, router]);
 
   const selectableYearPeriods = useMemo(
     () =>
@@ -164,6 +179,9 @@ export default function SponsorActivities(props: Props) {
       payload: { ...filterData, sponsorId: 'all' },
     });
   }, [filterData, sponsorIdSetByYear]);
+
+  if (!_hasHydrated) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3)) return <Loading />;
 
   return (
     <SponsorActivitiesLayout

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -1,10 +1,12 @@
 import clsx from 'clsx';
 import Head from 'next/head';
-import { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
 import OpenDeleteModalButton from '@/components/sponsors/OpenDeleteModalButton';
 import OpenEditModalButton from '@/components/sponsors/OpenEditModalButton';
 import { useGetSponsorsPeriodsYear, useGetYearsPeriods } from '@/generated/hooks';
+import { useCurrentUser, useUserStore } from '@/store';
 import { Card, Loading, Title } from '@components/common';
 import MainLayout from '@components/layout/MainLayout';
 import OpenAddModalButton from '@components/sponsors/OpenAddModalButton';
@@ -14,6 +16,18 @@ import type { NextPage } from 'next';
 const date = new Date();
 
 const Sponsorship: NextPage = () => {
+  const router = useRouter();
+  const user = useCurrentUser();
+  const _hasHydrated = useUserStore((state) => state._hasHydrated);
+
+  useEffect(() => {
+    if (!_hasHydrated) return;
+    if (!user?.roleID) return;
+    if (user.roleID !== 2 && user.roleID !== 3) {
+      router.push('/my_page');
+    }
+  }, [_hasHydrated, user?.roleID, router]);
+
   const {
     data: yearPeriodsData,
     isLoading: isYearPeriodsLoading,
@@ -32,6 +46,8 @@ const Sponsorship: NextPage = () => {
   } = useGetSponsorsPeriodsYear(Number(selectedYear));
   const sponsors = sponsorsData?.data;
 
+  if (!_hasHydrated) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3)) return <Loading />;
   if (isYearPeriodsLoading || isSponsorsLoading) return <Loading />;
   if (yearPeriodsError || sponsorsError) return <div>error...</div>;
 

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -22,7 +22,10 @@ const Sponsorship: NextPage = () => {
 
   useEffect(() => {
     if (!_hasHydrated) return;
-    if (!user?.roleID) return;
+    if (!user?.roleID) {
+      router.push('/');
+      return;
+    }
     if (user.roleID !== 2 && user.roleID !== 3) {
       router.push('/my_page');
     }

--- a/view/next-project/src/pages/sponsorstyles/index.tsx
+++ b/view/next-project/src/pages/sponsorstyles/index.tsx
@@ -1,10 +1,13 @@
 import clsx from 'clsx';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 import OpenDeleteModalButton from '@/components/sponsorstyles/OpenDeleteModalButton';
 import OpenEditModalButton from '@/components/sponsorstyles/OpenEditModalButton';
+import { useCurrentUser, useUserStore } from '@/store';
 import { get } from '@api/api_methods';
-import { Card, Title } from '@components/common';
+import { Card, Loading, Title } from '@components/common';
 import MainLayout from '@components/layout/MainLayout';
 import OpenAddModalButton from '@components/sponsorstyles/OpenAddModalButton';
 import { SponsorStyle } from '@type/common';
@@ -25,6 +28,21 @@ export const getServerSideProps = async () => {
 };
 export default function SponsorStyleList(props: Props) {
   const sponsorStyleList: SponsorStyle[] = props.sponsorstyles;
+
+  const router = useRouter();
+  const user = useCurrentUser();
+  const _hasHydrated = useUserStore((state) => state._hasHydrated);
+
+  useEffect(() => {
+    if (!_hasHydrated) return;
+    if (!user?.roleID) return;
+    if (user.roleID !== 2 && user.roleID !== 3) {
+      router.push('/my_page');
+    }
+  }, [_hasHydrated, user?.roleID, router]);
+
+  if (!_hasHydrated) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3)) return <Loading />;
 
   return (
     <MainLayout>

--- a/view/next-project/src/pages/sponsorstyles/index.tsx
+++ b/view/next-project/src/pages/sponsorstyles/index.tsx
@@ -35,7 +35,10 @@ export default function SponsorStyleList(props: Props) {
 
   useEffect(() => {
     if (!_hasHydrated) return;
-    if (!user?.roleID) return;
+    if (!user?.roleID) {
+      router.push('/');
+      return;
+    }
     if (user.roleID !== 2 && user.roleID !== 3) {
       router.push('/my_page');
     }

--- a/view/next-project/src/pages/users/index.tsx
+++ b/view/next-project/src/pages/users/index.tsx
@@ -42,7 +42,10 @@ export default function Users(props: Props) {
 
   useEffect(() => {
     if (!_hasHydrated) return;
-    if (!user?.roleID) return;
+    if (!user?.roleID) {
+      router.push('/');
+      return;
+    }
     if (user.roleID !== 2 && user.roleID !== 3) {
       router.push('/my_page');
     }

--- a/view/next-project/src/pages/users/index.tsx
+++ b/view/next-project/src/pages/users/index.tsx
@@ -60,6 +60,7 @@ export default function Users(props: Props) {
   });
 
   if (!_hasHydrated) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3)) return <Loading />;
 
   return (
     <MainLayout>

--- a/view/next-project/src/pages/users/index.tsx
+++ b/view/next-project/src/pages/users/index.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import OpenDeleteModalButton from '@/components/users/OpenDeleteModalButton';
-import { useCurrentUser } from '@/store';
+import { useCurrentUser, useUserStore } from '@/store';
 import { get } from '@api/api_methods';
-import { Card, Title } from '@components/common';
+import { Card, Loading, Title } from '@components/common';
 import MainLayout from '@components/layout/MainLayout/MainLayout';
 import OpenEditModalButton from '@components/users/OpenEditModalButton';
 import { ROLES } from '@constants/role';
@@ -36,13 +36,17 @@ export default function Users(props: Props) {
   const router = useRouter();
 
   const user = useCurrentUser();
-  const [currentUser, setCurrentUser] = useState<User>();
+  const _hasHydrated = useUserStore((state) => state._hasHydrated);
   const [selectedBureau, setSelectedBureau] = useState(0);
   const [filterUsers, setFilterUsers] = useState<User[]>(users);
 
   useEffect(() => {
-    setCurrentUser(user);
-  }, [user]);
+    if (!_hasHydrated) return;
+    if (!user?.roleID) return;
+    if (user.roleID !== 2 && user.roleID !== 3) {
+      router.push('/my_page');
+    }
+  }, [_hasHydrated, user?.roleID, router]);
 
   useEffect(() => {
     const newFilterUsers =
@@ -55,20 +59,7 @@ export default function Users(props: Props) {
     ids: [],
   });
 
-  const isAdmin = useMemo(() => {
-    if (currentUser?.roleID === 2 || currentUser?.roleID === 3) {
-      return true;
-    } else {
-      return false;
-    }
-  }, [currentUser?.roleID]);
-
-  useEffect(() => {
-    if (!currentUser?.roleID) return;
-    if (!isAdmin) {
-      router.push('/purchaseorders');
-    }
-  }, [isAdmin, currentUser?.roleID, router]);
+  if (!_hasHydrated) return <Loading />;
 
   return (
     <MainLayout>
@@ -86,7 +77,7 @@ export default function Users(props: Props) {
               value={selectedBureau}
               onChange={(e) => setSelectedBureau(Number(e.target.value))}
             >
-              <option value={0}>全ての学科</option>
+              <option value={0}>全ての局</option>
               {bureaus.map((bureau) => (
                 <option value={bureau.id} key={bureau.id}>
                   {bureau.name}
@@ -103,7 +94,7 @@ export default function Users(props: Props) {
                   <p className='text-black-600 text-center text-sm'>氏名</p>
                 </th>
                 <th className='border-b-primary-1 border-b py-3'>
-                  <p className='text-black-600 text-center text-sm'>学科</p>
+                  <p className='text-black-600 text-center text-sm'>局</p>
                 </th>
                 <th className='border-b-primary-1 border-b py-3'>
                   <p className='text-black-600 text-center text-sm'>権限</p>

--- a/view/next-project/src/pages/yearperiods/index.tsx
+++ b/view/next-project/src/pages/yearperiods/index.tsx
@@ -46,7 +46,10 @@ export default function Periods(props: Props) {
 
   useEffect(() => {
     if (!_hasHydrated) return;
-    if (!user?.roleID) return;
+    if (!user?.roleID) {
+      router.push('/');
+      return;
+    }
     if (user.roleID !== 2 && user.roleID !== 3) {
       router.push('/my_page');
     }

--- a/view/next-project/src/pages/yearperiods/index.tsx
+++ b/view/next-project/src/pages/yearperiods/index.tsx
@@ -53,6 +53,7 @@ export default function Periods(props: Props) {
   }, [_hasHydrated, user?.roleID, router]);
 
   if (!_hasHydrated) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3)) return <Loading />;
 
   return (
     <MainLayout>

--- a/view/next-project/src/pages/yearperiods/index.tsx
+++ b/view/next-project/src/pages/yearperiods/index.tsx
@@ -1,16 +1,16 @@
 import clsx from 'clsx';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect } from 'react';
 
 import OpenAddModalButton from '@/components/yearperiods/OpenAddModalButton';
 import OpenDeleteModalButton from '@/components/yearperiods/OpenDeleteModalButton';
 import OpenEditModalButton from '@/components/yearperiods/OpenEditModalButton';
-import { useCurrentUser } from '@/store';
+import { useCurrentUser, useUserStore } from '@/store';
 import { get } from '@api/api_methods';
-import { Card, Title } from '@components/common';
+import { Card, Loading, Title } from '@components/common';
 import MainLayout from '@components/layout/MainLayout/MainLayout';
-import { User, YearPeriod } from '@type/common';
+import { YearPeriod } from '@type/common';
 
 interface Props {
   yearPeriods: YearPeriod[];
@@ -32,7 +32,7 @@ export default function Periods(props: Props) {
   const router = useRouter();
 
   const user = useCurrentUser();
-  const [currentUser, setCurrentUser] = useState<User>();
+  const _hasHydrated = useUserStore((state) => state._hasHydrated);
 
   const formatYearPeriods =
     yearPeriods &&
@@ -45,26 +45,14 @@ export default function Periods(props: Props) {
     });
 
   useEffect(() => {
-    setCurrentUser(user);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // ログイン中のユーザの権限
-  const isDeveloperOrAdimin = useMemo(() => {
-    if (currentUser?.roleID === 2 || currentUser?.roleID === 3) {
-      return true;
-    } else {
-      return false;
+    if (!_hasHydrated) return;
+    if (!user?.roleID) return;
+    if (user.roleID !== 2 && user.roleID !== 3) {
+      router.push('/my_page');
     }
-  }, [currentUser?.roleID]);
+  }, [_hasHydrated, user?.roleID, router]);
 
-  useEffect(() => {
-    if (!currentUser?.roleID) return;
-    if (!isDeveloperOrAdimin) {
-      router.push('/purchaseorders');
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDeveloperOrAdimin, currentUser?.roleID]);
+  if (!_hasHydrated) return <Loading />;
 
   return (
     <MainLayout>


### PR DESCRIPTION
# 対応Issue
<!-- 対応したIssue番号を記載 -->
<img width="976" height="134" alt="image" src="https://github.com/user-attachments/assets/56040859-0cfa-420f-8c78-169a00da64b0" />


# 概要
<!-- 開発内容の概要を記載 -->
- `/users` ページのユーザ編集モーダルで「産学局」を選択できるように対応（DB側に登録済みのためフロント側はラベル修正と既存パターンに準じた実装）
- 「協賛活動ページ」「協賛スタイルページ」「協賛企業ページ」に財務局長権限（roleID: 2, 3）によるアクセス制御を追加
- `/users` ページと `/yearperiods` ページの権限制御を `_hasHydrated` + `useCurrentUser` パターンに統一し、コードを簡潔化

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- なし

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] `/users` ページの編集モーダルで「産学局」が選択肢に表示されること
- [x] 開発者・財務局長以外のユーザで「協賛活動」「協賛スタイル」「協賛企業」ページにアクセスすると `/my_page` にリダイレクトされること（アクセスできないとこにリダイレクトしてたので）
- [x] 開発者・財務局長は上記ページに正常にアクセスできること
- [x] `/users` ページと `/yearperiods` ページでも同様に権限制御が機能すること

# 備考
- `EditModal.tsx` のコンポーネント名を `FundInformationEditModal` から `UserEditModal` に修正
- 「学科」表記を「局」に統一