### PR TITLE
ユーザー登録時にmail_authのuser_idがずれる問題を修正

### DIFF
--- a/view/next-project/src/components/auth/SignUpView.tsx
+++ b/view/next-project/src/components/auth/SignUpView.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'react-hook-form';
 
 import { BUREAUS } from '@/constants/bureaus';
 import { useAuthStore, useUserStore } from '@/store';
-import { get } from '@api/api_methods';
 import { signUp } from '@api/signUp';
 import { post } from '@api/user';
 import { PrimaryButton } from '@components/common';
@@ -44,11 +43,9 @@ export default function SignUpView() {
     setIsSignUpNow(true);
     const userUrl: string = process.env.CSR_API_URI + '/users';
     const signUpUrl: string = process.env.CSR_API_URI + '/mail_auth/signup';
-    // userのpost時のResに登録したデータが返ってこないので以下で用意
-    const getRes = await get(userUrl);
-    const userID: number = getRes[getRes.length - 1].id + 1;
     // signIn には登録したuserのIDが必要なので先にUserをpost
-    await post(userUrl, postUserData);
+    const newUser = await post(userUrl, postUserData);
+    const userID: number = newUser.id;
     // signUp
     const req = await signUp(signUpUrl, data, userID);
     const res = await req.json();

--- a/view/next-project/src/components/auth/SignUpView.tsx
+++ b/view/next-project/src/components/auth/SignUpView.tsx
@@ -45,6 +45,11 @@ export default function SignUpView() {
     const signUpUrl: string = process.env.CSR_API_URI + '/mail_auth/signup';
     // signIn には登録したuserのIDが必要なので先にUserをpost
     const newUser = await post(userUrl, postUserData);
+    if (!newUser || !newUser.id) {
+      alert('ユーザーの作成に失敗しました。');
+      setIsSignUpNow(false);
+      return;
+    }
     const userID: number = newUser.id;
     // signUp
     const req = await signUp(signUpUrl, data, userID);

--- a/view/next-project/src/utils/api/user.ts
+++ b/view/next-project/src/utils/api/user.ts
@@ -13,8 +13,7 @@ export const post = async (url: string, data: User) => {
     },
     body: JSON.stringify(data),
   });
-  return await res;
-  // return await res.json();
+  return await res.json();
 };
 
 export const put = async (url: string, data: User) => {


### PR DESCRIPTION
# 対応Issue
resolve #0

# 概要
/users ページ
でユーザー削除後に再登録した際、mail_auth.user_id が意図しないユーザーを指す可能性がある不具合に対して、フロント側の登録フローを修正。

主な対応内容は以下です。
- ユーザーIDの推測ロジックを削除
  - 変更前: GET /users の最終ID + 1 を user_id として使用
  - 変更後: POST /users のレスポンスで返る実IDを user_id として使用
- ユーザー登録API呼び出しのレスポンス処理を修正
  - post 関数が Response オブジェクトではなく JSON を返すように変更
- 不要になった GET /users 呼び出しを削除

# 画面スクリーンショット等
- URL
  - なし（UI変更なし）

スクリーンショット
- なし

# テスト項目
- 新規登録時に、作成された users.id と mail_auth.user_id が一致すること
- ユーザー削除後に同名または別名で再登録しても、作成したユーザーで正常ログインできること

# 備考
- 将来的には、signup をバックエンドで users と mail_auth の同一トランザクション登録に統合すると、より堅牢になるらしい。