### PR TITLE
fix: 協賛ページ権限の調整と請求書編集の手入力対応

### DIFF
--- a/view/next-project/src/components/progress-report/ProgressReportInvoicePdfModal.tsx
+++ b/view/next-project/src/components/progress-report/ProgressReportInvoicePdfModal.tsx
@@ -31,6 +31,8 @@ export default function ProgressReportInvoicePdfModal({
   const totalPrice = useMemo(() => getActivityAmountFromApi(activity), [activity]);
   const [issuedDate, setIssuedDate] = useState(today);
   const [deadline, setDeadline] = useState(today);
+  const [sponsorName, setSponsorName] = useState(baseInvoice.sponsorName);
+  const [managerName, setManagerName] = useState(baseInvoice.managerName);
   const [subject, setSubject] = useState(baseInvoice.subject);
   const [remark, setRemark] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
@@ -39,9 +41,11 @@ export default function ProgressReportInvoicePdfModal({
     if (!isOpen) return;
     setIssuedDate(today);
     setDeadline(today);
+    setSponsorName(baseInvoice.sponsorName);
+    setManagerName(baseInvoice.managerName);
     setSubject(baseInvoice.subject);
     setRemark('');
-  }, [isOpen, today, baseInvoice.subject]);
+  }, [isOpen, today, baseInvoice.sponsorName, baseInvoice.managerName, baseInvoice.subject]);
 
   if (!isOpen) return null;
 
@@ -49,6 +53,8 @@ export default function ProgressReportInvoicePdfModal({
     ...baseInvoice,
     issuedDate,
     deadline,
+    sponsorName,
+    managerName,
     subject,
     remark,
   };
@@ -68,9 +74,19 @@ export default function ProgressReportInvoicePdfModal({
             <div className='grid grid-cols-1 gap-4'>
               <div>
                 <p className='mb-2 ml-1 text-sm text-gray-600'>企業名</p>
-                <Input type='text' value={invoice.sponsorName} readOnly className='mb-3 w-full' />
+                <Input
+                  type='text'
+                  value={sponsorName}
+                  onChange={(event) => setSponsorName(event.target.value)}
+                  className='mb-3 w-full'
+                />
                 <p className='mb-2 ml-1 text-sm text-gray-600'>担当者名(企業)</p>
-                <Input type='text' value={invoice.managerName} readOnly className='mb-3 w-full' />
+                <Input
+                  type='text'
+                  value={managerName}
+                  onChange={(event) => setManagerName(event.target.value)}
+                  className='mb-3 w-full'
+                />
                 <p className='mb-2 ml-1 text-sm text-gray-600'>件名</p>
                 <Input
                   type='text'

--- a/view/next-project/src/components/progress-report/ProgressReportInvoicePdfModal.tsx
+++ b/view/next-project/src/components/progress-report/ProgressReportInvoicePdfModal.tsx
@@ -34,6 +34,7 @@ export default function ProgressReportInvoicePdfModal({
   const [sponsorName, setSponsorName] = useState(baseInvoice.sponsorName);
   const [managerName, setManagerName] = useState(baseInvoice.managerName);
   const [subject, setSubject] = useState(baseInvoice.subject);
+  const [fesStuffName, setFesStuffName] = useState(baseInvoice.fesStuffName);
   const [remark, setRemark] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
 
@@ -44,8 +45,9 @@ export default function ProgressReportInvoicePdfModal({
     setSponsorName(baseInvoice.sponsorName);
     setManagerName(baseInvoice.managerName);
     setSubject(baseInvoice.subject);
+    setFesStuffName(baseInvoice.fesStuffName);
     setRemark('');
-  }, [isOpen, today, baseInvoice.sponsorName, baseInvoice.managerName, baseInvoice.subject]);
+  }, [isOpen, today, baseInvoice.sponsorName, baseInvoice.managerName, baseInvoice.subject, baseInvoice.fesStuffName]);
 
   if (!isOpen) return null;
 
@@ -56,6 +58,7 @@ export default function ProgressReportInvoicePdfModal({
     sponsorName,
     managerName,
     subject,
+    fesStuffName,
     remark,
   };
 
@@ -109,7 +112,12 @@ export default function ProgressReportInvoicePdfModal({
                   className='mb-3 w-full'
                 />
                 <p className='mb-2 ml-1 text-sm text-gray-600'>担当者名(実行委員)</p>
-                <Input type='text' value={invoice.fesStuffName} readOnly className='mb-3 w-full' />
+                <Input
+                  type='text'
+                  value={fesStuffName}
+                  onChange={(event) => setFesStuffName(event.target.value)}
+                  className='mb-3 w-full'
+                />
                 <p className='mb-2 ml-1 text-sm text-gray-600'>合計金額</p>
                 <Input
                   type='text'

--- a/view/next-project/src/components/progress-report/ProgressReportInvoicePdfModal.tsx
+++ b/view/next-project/src/components/progress-report/ProgressReportInvoicePdfModal.tsx
@@ -47,7 +47,14 @@ export default function ProgressReportInvoicePdfModal({
     setSubject(baseInvoice.subject);
     setFesStuffName(baseInvoice.fesStuffName);
     setRemark('');
-  }, [isOpen, today, baseInvoice.sponsorName, baseInvoice.managerName, baseInvoice.subject, baseInvoice.fesStuffName]);
+  }, [
+    isOpen,
+    today,
+    baseInvoice.sponsorName,
+    baseInvoice.managerName,
+    baseInvoice.subject,
+    baseInvoice.fesStuffName,
+  ]);
 
   if (!isOpen) return null;
 

--- a/view/next-project/src/components/sponsor-activities/legacy-documents/invoice/AddPdfDetailModal.tsx
+++ b/view/next-project/src/components/sponsor-activities/legacy-documents/invoice/AddPdfDetailModal.tsx
@@ -59,7 +59,7 @@ export default function AddPdfDetailModal(props: ModalProps) {
   const handler =
     (input: string) =>
     (e: React.ChangeEvent<HTMLSelectElement> | React.ChangeEvent<HTMLInputElement>) => {
-      setInvoiceDate({ ...invoiceData, [input]: e.target.value });
+      setInvoiceDate((prev) => ({ ...prev, [input]: e.target.value }));
     };
 
   const onClose = () => {

--- a/view/next-project/src/components/sponsor-activities/legacy-documents/invoice/EditInvoiceModal.tsx
+++ b/view/next-project/src/components/sponsor-activities/legacy-documents/invoice/EditInvoiceModal.tsx
@@ -22,7 +22,7 @@ export default function EditInvoiceModal(props: ModalProps) {
         | React.ChangeEvent<HTMLInputElement>
         | React.ChangeEvent<HTMLTextAreaElement>,
     ) => {
-      setEditInvoice({ ...editInvoice, [input]: e.target.value });
+      setEditInvoice((prev) => ({ ...prev, [input]: e.target.value }));
     };
 
   const onChangeSponsorStyle = (inputInvoiceSponsorStyle: InvoiceSponsorStyle, index: number) => {

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -90,7 +90,7 @@ export default function SponsorActivities(props: Props) {
       router.push('/');
       return;
     }
-    if (user.roleID !== 2 && user.roleID !== 4) {
+    if (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4) {
       router.push('/my_page');
     }
   }, [_hasHydrated, user?.roleID, router]);
@@ -184,7 +184,7 @@ export default function SponsorActivities(props: Props) {
   }, [filterData, sponsorIdSetByYear]);
 
   if (!_hasHydrated) return <Loading />;
-  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 4)) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4)) return <Loading />;
 
   return (
     <SponsorActivitiesLayout

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -90,7 +90,7 @@ export default function SponsorActivities(props: Props) {
       router.push('/');
       return;
     }
-    if (user.roleID !== 2 && user.roleID !== 3) {
+    if (user.roleID !== 2 && user.roleID !== 4) {
       router.push('/my_page');
     }
   }, [_hasHydrated, user?.roleID, router]);
@@ -184,7 +184,7 @@ export default function SponsorActivities(props: Props) {
   }, [filterData, sponsorIdSetByYear]);
 
   if (!_hasHydrated) return <Loading />;
-  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3)) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 4)) return <Loading />;
 
   return (
     <SponsorActivitiesLayout

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -90,7 +90,7 @@ export default function SponsorActivities(props: Props) {
       router.push('/');
       return;
     }
-    if (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4) {
+    if (![2, 3, 4].includes(user.roleID)) {
       router.push('/my_page');
     }
   }, [_hasHydrated, user?.roleID, router]);

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -185,7 +185,6 @@ export default function SponsorActivities(props: Props) {
 
   if (!_hasHydrated) return <Loading />;
   if (!user?.roleID || ![2, 3, 4].includes(user.roleID)) return <Loading />;
-    return <Loading />;
 
   return (
     <SponsorActivitiesLayout

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -184,7 +184,7 @@ export default function SponsorActivities(props: Props) {
   }, [filterData, sponsorIdSetByYear]);
 
   if (!_hasHydrated) return <Loading />;
-  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4))
+  if (!user?.roleID || ![2, 3, 4].includes(user.roleID)) return <Loading />;
     return <Loading />;
 
   return (

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -184,7 +184,8 @@ export default function SponsorActivities(props: Props) {
   }, [filterData, sponsorIdSetByYear]);
 
   if (!_hasHydrated) return <Loading />;
-  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4)) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4))
+    return <Loading />;
 
   return (
     <SponsorActivitiesLayout

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -36,10 +36,12 @@ const Sponsorship: NextPage = () => {
     isLoading: isYearPeriodsLoading,
     error: yearPeriodsError,
   } = useGetYearsPeriods();
-  const yearPeriods = yearPeriodsData?.data;
+  const yearPeriods = yearPeriodsData?.data ?? [];
 
   const [selectedYear, setSelectedYear] = useState<string>(
-    yearPeriods ? String(yearPeriods[yearPeriods.length - 1].year) : String(date.getFullYear()),
+    yearPeriods.length > 0
+      ? String(yearPeriods[yearPeriods.length - 1].year)
+      : String(date.getFullYear()),
   );
 
   const {
@@ -47,11 +49,10 @@ const Sponsorship: NextPage = () => {
     isLoading: isSponsorsLoading,
     error: sponsorsError,
   } = useGetSponsorsPeriodsYear(Number(selectedYear));
-  const sponsors = sponsorsData?.data;
+  const sponsors = sponsorsData?.data ?? [];
 
   if (!_hasHydrated) return <Loading />;
   if (!user?.roleID || ![2, 3, 4].includes(user.roleID)) return <Loading />;
-    return <Loading />;
   if (isYearPeriodsLoading || isSponsorsLoading) return <Loading />;
   if (yearPeriodsError || sponsorsError) return <div>error...</div>;
 
@@ -70,14 +71,13 @@ const Sponsorship: NextPage = () => {
               defaultValue={selectedYear}
               onChange={(e) => setSelectedYear(e.target.value)}
             >
-              {yearPeriods &&
-                yearPeriods.map((year, index) => {
-                  return (
-                    <option value={year.year} key={index}>
-                      {year.year}年度
-                    </option>
-                  );
-                })}
+              {yearPeriods.map((year, index) => {
+                return (
+                  <option value={year.year} key={index}>
+                    {year.year}年度
+                  </option>
+                );
+              })}
             </select>
           </div>
           <div className='hidden justify-end md:flex'>
@@ -109,7 +109,7 @@ const Sponsorship: NextPage = () => {
               </tr>
             </thead>
             <tbody>
-              {sponsors && sponsors.length > 0 ? (
+              {sponsors.length > 0 ? (
                 sponsors.map((sponsor, index) => (
                   <tr
                     className={clsx(index !== sponsors.length - 1 && 'border-b')}

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -50,7 +50,8 @@ const Sponsorship: NextPage = () => {
   const sponsors = sponsorsData?.data;
 
   if (!_hasHydrated) return <Loading />;
-  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4)) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4))
+    return <Loading />;
   if (isYearPeriodsLoading || isSponsorsLoading) return <Loading />;
   if (yearPeriodsError || sponsorsError) return <div>error...</div>;
 

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -26,7 +26,7 @@ const Sponsorship: NextPage = () => {
       router.push('/');
       return;
     }
-    if (user.roleID !== 2 && user.roleID !== 3) {
+    if (user.roleID !== 2 && user.roleID !== 4) {
       router.push('/my_page');
     }
   }, [_hasHydrated, user?.roleID, router]);
@@ -50,7 +50,7 @@ const Sponsorship: NextPage = () => {
   const sponsors = sponsorsData?.data;
 
   if (!_hasHydrated) return <Loading />;
-  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3)) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 4)) return <Loading />;
   if (isYearPeriodsLoading || isSponsorsLoading) return <Loading />;
   if (yearPeriodsError || sponsorsError) return <div>error...</div>;
 

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -26,7 +26,7 @@ const Sponsorship: NextPage = () => {
       router.push('/');
       return;
     }
-    if (user.roleID !== 2 && user.roleID !== 4) {
+    if (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4) {
       router.push('/my_page');
     }
   }, [_hasHydrated, user?.roleID, router]);
@@ -50,7 +50,7 @@ const Sponsorship: NextPage = () => {
   const sponsors = sponsorsData?.data;
 
   if (!_hasHydrated) return <Loading />;
-  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 4)) return <Loading />;
+  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4)) return <Loading />;
   if (isYearPeriodsLoading || isSponsorsLoading) return <Loading />;
   if (yearPeriodsError || sponsorsError) return <div>error...</div>;
 

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -50,7 +50,7 @@ const Sponsorship: NextPage = () => {
   const sponsors = sponsorsData?.data;
 
   if (!_hasHydrated) return <Loading />;
-  if (!user?.roleID || (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4))
+  if (!user?.roleID || ![2, 3, 4].includes(user.roleID)) return <Loading />;
     return <Loading />;
   if (isYearPeriodsLoading || isSponsorsLoading) return <Loading />;
   if (yearPeriodsError || sponsorsError) return <div>error...</div>;

--- a/view/next-project/src/pages/sponsors/index.tsx
+++ b/view/next-project/src/pages/sponsors/index.tsx
@@ -26,7 +26,7 @@ const Sponsorship: NextPage = () => {
       router.push('/');
       return;
     }
-    if (user.roleID !== 2 && user.roleID !== 3 && user.roleID !== 4) {
+    if (![2, 3, 4].includes(user.roleID)) {
       router.push('/my_page');
     }
   }, [_hasHydrated, user?.roleID, router]);

--- a/view/next-project/src/utils/createSponsorActivitiesInvoicesPDF.tsx
+++ b/view/next-project/src/utils/createSponsorActivitiesInvoicesPDF.tsx
@@ -208,7 +208,10 @@ const MyDocument = ({ invoiceItem, deadline, issuedDate }: MyDocumentProps) => {
                 <Text style={[styles.text_M, { marginLeft: '5pt', flexShrink: 0 }]}>御中</Text>
               </View>
               <Text style={[styles.text_S, styles.marginBottom]}>
-                ご担当 : {invoiceItem.managerName && invoiceItem.managerName.trim() !== '' ? `${invoiceItem.managerName} 様` : ''}
+                ご担当 :{' '}
+                {invoiceItem.managerName && invoiceItem.managerName.trim() !== ''
+                  ? `${invoiceItem.managerName} 様`
+                  : ''}
               </Text>
               <Text style={[styles.text_S, styles.underLine]}>
                 件名 : <Text style={styles.text_M}>{invoiceItem.subject || '技大祭企業協賛'}</Text>

--- a/view/next-project/src/utils/createSponsorActivitiesInvoicesPDF.tsx
+++ b/view/next-project/src/utils/createSponsorActivitiesInvoicesPDF.tsx
@@ -208,7 +208,7 @@ const MyDocument = ({ invoiceItem, deadline, issuedDate }: MyDocumentProps) => {
                 <Text style={[styles.text_M, { marginLeft: '5pt', flexShrink: 0 }]}>御中</Text>
               </View>
               <Text style={[styles.text_S, styles.marginBottom]}>
-                ご担当 : {invoiceItem.managerName} 様
+                ご担当 : {invoiceItem.managerName && invoiceItem.managerName.trim() !== '' ? `${invoiceItem.managerName} 様` : ''}
               </Text>
               <Text style={[styles.text_S, styles.underLine]}>
                 件名 : <Text style={styles.text_M}>{invoiceItem.subject || '技大祭企業協賛'}</Text>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
<img width="1112" height="290" alt="image" src="https://github.com/user-attachments/assets/d991dd1d-3761-4563-a12c-db3b79dc10cc" />

# 概要
<!-- 開発内容の概要を記載 -->
本ブランチでの変更内容は以下の通りです。
- 協賛活動一覧ページ（`/sponsor-activities`）および協賛活動ページ（`/sponsors`）における権限設定の調整
- 請求書PDFモーダル等で、内容を手入力できるように修正

# 画面スクリーンショット等
<img width="2160" height="1440" alt="image" src="https://github.com/user-attachments/assets/5cae5917-7978-47b2-958c-2668fddeff8a" />

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [x] 権限に応じて協賛・スポンサーページが正しく表示されること
- [x] 請求書作成（PDF）時に手入力での内容編集が可能で、正しく反映されること

# 備考
