### PR TITLE
fix:loginページの文言の修正

### DIFF
--- a/view/next-project/src/pages/index.tsx
+++ b/view/next-project/src/pages/index.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image';
 import { useState } from 'react';
 
 import { PrimaryButton } from '@/components/common';
-import Link from '@/components/common/Link';
 import SignInView from '@components/auth/SignInView';
 import SignUpView from '@components/auth/SignUpView';
 import LoginLayout from '@components/layout/LoginLayout';
@@ -28,7 +27,7 @@ export default function Home() {
           <div className='my-12 flex flex-col items-center justify-center gap-5'>
             <p className='text-black-600'>登録がまだの方はこちら</p>
             <PrimaryButton onClick={() => setIsMember(!isMember)}>新規登録</PrimaryButton>
-            <Link href='/reset_password/request'>パスワードを忘れた</Link>
+            <p className='text-black-600'>パスワードを忘れた方はSlackまで</p>
           </div>
         </>
       );


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #0

# 概要
<!-- 開発内容の概要を記載 -->
ログイン画面の「パスワードを忘れた」リンクを削除し、Slackへの連絡を促す文言へ変更。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1900" height="909" alt="image" src="https://github.com/user-attachments/assets/d313a44c-56b9-4171-ae61-1528cd579959" />


# テスト項目
<!-- テストしてほしい内容を記載 -->
- ログイン画面に「パスワードを忘れた方はSlackまで」が表示されること
- 「パスワードを忘れた」リンクが表示されないこと
- ログイン機能に影響がないこと

# 備考
