### PR TITLE
Fead/wakape/add sponsorship activities filter

### DIFF
--- a/api/externals/repository/sponsorship_activity_repository.go
+++ b/api/externals/repository/sponsorship_activity_repository.go
@@ -63,6 +63,9 @@ func (r *sponsorshipActivityRepository) FindAll(ctx context.Context, sponsorship
 	if sponsorshipActivitiesSearchParams.ActivityStatus != nil {
 		queryDataset = queryDataset.Where(goqu.I("sponsorship_activities.activity_status").Eq(string(*sponsorshipActivitiesSearchParams.ActivityStatus)))
 	}
+	if sponsorshipActivitiesSearchParams.DesignProgress != nil {
+		queryDataset = queryDataset.Where(goqu.I("sponsorship_activities.design_progress").Eq(string(*sponsorshipActivitiesSearchParams.DesignProgress)))
+	}
 	if sponsorshipActivitiesSearchParams.FeasibilityStatus != nil {
 		queryDataset = queryDataset.Where(goqu.I("sponsorship_activities.feasibility_status").Eq(string(*sponsorshipActivitiesSearchParams.FeasibilityStatus)))
 	}

--- a/api/externals/repository/sponsorship_activity_repository.go
+++ b/api/externals/repository/sponsorship_activity_repository.go
@@ -344,6 +344,7 @@ func (r *sponsorshipActivityRepository) Update(ctx context.Context, tx *sql.Tx, 
 			"feasibility_status": activity.FeasibilityStatus,
 			"design_progress":    activity.DesignProgress,
 			"remarks":            activity.Remarks,
+			"updated_at":         goqu.L("CURRENT_TIMESTAMP"),
 		}).
 		Where(goqu.I("id").Eq(activity.ID))
 	query, args, err := dataset.ToSQL()

--- a/api/generated/openapi_gen.go
+++ b/api/generated/openapi_gen.go
@@ -851,6 +851,9 @@ type GetSponsorshipActivitiesParams struct {
 	// ActivityStatus 活動ステータス (ActivityStatusの値を指定)
 	ActivityStatus *ActivityStatus `form:"activity_status,omitempty" json:"activity_status,omitempty"`
 
+	// DesignProgress デザイン進捗ステータス (DesignProgressの値を指定)
+	DesignProgress *DesignProgress `form:"design_progress,omitempty" json:"design_progress,omitempty"`
+
 	// FeasibilityStatus 協賛可否ステータス (FeasibilityStatusの値を指定)
 	FeasibilityStatus *FeasibilityStatus `form:"feasibility_status,omitempty" json:"feasibility_status,omitempty"`
 
@@ -2956,6 +2959,13 @@ func (w *ServerInterfaceWrapper) GetSponsorshipActivities(ctx echo.Context) erro
 	err = runtime.BindQueryParameter("form", true, false, "activity_status", ctx.QueryParams(), &params.ActivityStatus)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter activity_status: %s", err))
+	}
+
+	// ------------- Optional query parameter "design_progress" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "design_progress", ctx.QueryParams(), &params.DesignProgress)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter design_progress: %s", err))
 	}
 
 	// ------------- Optional query parameter "feasibility_status" -------------

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2543,6 +2543,12 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/ActivityStatus"
+        - name: design_progress
+          in: query
+          description: デザイン進捗ステータス (DesignProgressの値を指定)
+          required: false
+          schema:
+            $ref: "#/components/schemas/DesignProgress"
         - name: feasibility_status
           in: query
           description: 協賛可否ステータス (FeasibilityStatusの値を指定)

--- a/view/next-project/src/components/sponsor-activities/FilterModal.tsx
+++ b/view/next-project/src/components/sponsor-activities/FilterModal.tsx
@@ -1,7 +1,12 @@
 import { FC, useMemo, useState } from 'react';
 
-import { FeasibilityStatus } from '@/generated/model';
-import { SORT_OPTIONS, SponsorActivitiesFilterType } from '@/utils/sponsorshipActivity';
+import { ActivityStatus, DesignProgress, FeasibilityStatus } from '@/generated/model';
+import {
+  ACTIVITY_STATUS_OPTIONS,
+  DESIGN_PROGRESS_OPTIONS,
+  SORT_OPTIONS,
+  SponsorActivitiesFilterType,
+} from '@/utils/sponsorshipActivity';
 import { CloseButton, Modal, PrimaryButton, SearchSelect, Select, Title } from '@components/common';
 import { BUREAUS } from '@constants/bureaus';
 import { Sponsor, SponsorStyle, User } from '@type/common';
@@ -75,13 +80,12 @@ interface BasicFilterSectionProps {
   selectedBureauOption: { value: string; label: string } | null;
   userSelectOptions: { value: string; label: string }[];
   selectedUserOption: { value: string; label: string } | null;
-  sponsorSelectOptions: { value: string; label: string }[];
-  selectedSponsorOption: { value: string; label: string } | null;
   draftFilterData: SponsorActivitiesFilterType;
   onBureauChange: (selected: { value: string; label: string } | null) => void;
   onUserChange: (selected: { value: string; label: string } | null) => void;
-  onSponsorChange: (selected: { value: string; label: string } | null) => void;
   onFeasibilityChange: (value: string) => void;
+  onActivityStatusChange: (value: string) => void;
+  onDesignProgressChange: (value: string) => void;
   onSortChange: (value: string) => void;
 }
 
@@ -90,13 +94,12 @@ const BasicFilterSection: FC<BasicFilterSectionProps> = ({
   selectedBureauOption,
   userSelectOptions,
   selectedUserOption,
-  sponsorSelectOptions,
-  selectedSponsorOption,
   draftFilterData,
   onBureauChange,
   onUserChange,
-  onSponsorChange,
   onFeasibilityChange,
+  onActivityStatusChange,
+  onDesignProgressChange,
   onSortChange,
 }) => (
   <>
@@ -120,16 +123,6 @@ const BasicFilterSection: FC<BasicFilterSectionProps> = ({
         onChange={onUserChange}
       />
     </div>
-    <p>企業名</p>
-    <div className='w-full'>
-      <SearchSelect
-        options={sponsorSelectOptions}
-        value={selectedSponsorOption}
-        placeholder='企業名で検索'
-        noOptionMessage='該当する企業がありません'
-        onChange={onSponsorChange}
-      />
-    </div>
     <p>協賛可否</p>
     <div className='w-full'>
       <Select
@@ -140,6 +133,34 @@ const BasicFilterSection: FC<BasicFilterSectionProps> = ({
         <option value={FeasibilityStatus.possible}>可</option>
         <option value={FeasibilityStatus.impossible}>否</option>
         <option value={FeasibilityStatus.unstarted}>未定</option>
+      </Select>
+    </div>
+    <p>活動ステータス</p>
+    <div className='w-full'>
+      <Select
+        value={draftFilterData.activityStatus}
+        onChange={(e) => onActivityStatusChange(e.target.value)}
+      >
+        <option value='all'>すべて</option>
+        {ACTIVITY_STATUS_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </Select>
+    </div>
+    <p>デザイン進捗</p>
+    <div className='w-full'>
+      <Select
+        value={draftFilterData.designProgress}
+        onChange={(e) => onDesignProgressChange(e.target.value)}
+      >
+        <option value='all'>すべて</option>
+        {DESIGN_PROGRESS_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
       </Select>
     </div>
     <p>並び替え</p>
@@ -168,11 +189,6 @@ const FilterModal: FC<ModalProps> = (props) => {
         (style): style is SponsorStyle & { id: number } => style.id !== undefined,
       ),
     [sponsorStyles],
-  );
-  const sponsorOptions = useMemo(
-    () =>
-      sponsors.filter((sponsor): sponsor is Sponsor & { id: number } => sponsor.id !== undefined),
-    [sponsors],
   );
 
   // モーダル用の変数
@@ -208,17 +224,6 @@ const FilterModal: FC<ModalProps> = (props) => {
     [filteredUsers],
   );
 
-  const sponsorSelectOptions = useMemo(
-    () => [
-      { value: 'all', label: '企業名で検索' },
-      ...sponsorOptions.map((sponsor) => ({
-        value: String(sponsor.id),
-        label: sponsor.name,
-      })),
-    ],
-    [sponsorOptions],
-  );
-
   const selectedBureauOption = useMemo(
     () =>
       draftFilterData.bureauId === 'all'
@@ -235,16 +240,6 @@ const FilterModal: FC<ModalProps> = (props) => {
         : userSelectOptions.find((option) => option.value === String(draftFilterData.userId)) ||
           null,
     [userSelectOptions, draftFilterData.userId],
-  );
-
-  const selectedSponsorOption = useMemo(
-    () =>
-      draftFilterData.sponsorId === 'all'
-        ? null
-        : sponsorSelectOptions.find(
-            (option) => option.value === String(draftFilterData.sponsorId),
-          ) || null,
-    [sponsorSelectOptions, draftFilterData.sponsorId],
   );
 
   function filterHandler(event: React.FormEvent<HTMLFormElement>) {
@@ -330,8 +325,6 @@ const FilterModal: FC<ModalProps> = (props) => {
               selectedBureauOption={selectedBureauOption}
               userSelectOptions={userSelectOptions}
               selectedUserOption={selectedUserOption}
-              sponsorSelectOptions={sponsorSelectOptions}
-              selectedSponsorOption={selectedSponsorOption}
               draftFilterData={draftFilterData}
               onBureauChange={(selected) => {
                 if (!selected) return;
@@ -356,17 +349,22 @@ const FilterModal: FC<ModalProps> = (props) => {
                   userId: selected.value === 'all' ? 'all' : Number(selected.value),
                 }));
               }}
-              onSponsorChange={(selected) => {
-                if (!selected) return;
-                setDraftFilterData((prev) => ({
-                  ...prev,
-                  sponsorId: selected.value === 'all' ? 'all' : Number(selected.value),
-                }));
-              }}
               onFeasibilityChange={(value) => {
                 setDraftFilterData((prev) => ({
                   ...prev,
                   feasibilityStatus: value === 'all' ? 'all' : (value as FeasibilityStatus),
+                }));
+              }}
+              onActivityStatusChange={(value) => {
+                setDraftFilterData((prev) => ({
+                  ...prev,
+                  activityStatus: value === 'all' ? 'all' : (value as ActivityStatus),
+                }));
+              }}
+              onDesignProgressChange={(value) => {
+                setDraftFilterData((prev) => ({
+                  ...prev,
+                  designProgress: value === 'all' ? 'all' : (value as DesignProgress),
                 }));
               }}
               onSortChange={(value) => {

--- a/view/next-project/src/components/sponsor-activities/FilterModal.tsx
+++ b/view/next-project/src/components/sponsor-activities/FilterModal.tsx
@@ -9,13 +9,12 @@ import {
 } from '@/utils/sponsorshipActivity';
 import { CloseButton, Modal, PrimaryButton, SearchSelect, Select, Title } from '@components/common';
 import { BUREAUS } from '@constants/bureaus';
-import { Sponsor, SponsorStyle, User } from '@type/common';
+import { SponsorStyle, User } from '@type/common';
 
 interface ModalProps {
   setIsOpen: (isOpen: boolean) => void;
   sponsorStyles: SponsorStyle[];
   users: User[];
-  sponsors: Sponsor[];
   filterData: SponsorActivitiesFilterType;
   setFilterData: (filterData: SponsorActivitiesFilterType) => void;
 }
@@ -135,7 +134,7 @@ const BasicFilterSection: FC<BasicFilterSectionProps> = ({
         <option value={FeasibilityStatus.unstarted}>未定</option>
       </Select>
     </div>
-    <p>活動ステータス</p>
+    <p>ステータス</p>
     <div className='w-full'>
       <Select
         value={draftFilterData.activityStatus}
@@ -149,7 +148,7 @@ const BasicFilterSection: FC<BasicFilterSectionProps> = ({
         ))}
       </Select>
     </div>
-    <p>デザイン進捗</p>
+    <p>デザイン</p>
     <div className='w-full'>
       <Select
         value={draftFilterData.designProgress}
@@ -181,7 +180,7 @@ const BasicFilterSection: FC<BasicFilterSectionProps> = ({
 );
 
 const FilterModal: FC<ModalProps> = (props) => {
-  const { sponsorStyles, users, sponsors, filterData, setFilterData } = props;
+  const { sponsorStyles, users, filterData, setFilterData } = props;
 
   const styleOptions = useMemo(
     () =>

--- a/view/next-project/src/components/sponsor-activities/page/sections/SponsorActivitiesHeader.tsx
+++ b/view/next-project/src/components/sponsor-activities/page/sections/SponsorActivitiesHeader.tsx
@@ -92,7 +92,6 @@ export default function SponsorActivitiesHeader({
                 <FilterModal
                   setIsOpen={onSetFilterOpen}
                   sponsorStyles={sponsorStyles}
-                  sponsors={sponsors}
                   users={users}
                   filterData={filterData}
                   setFilterData={onSetFilterData}

--- a/view/next-project/src/generated/model/getSponsorshipActivitiesParams.ts
+++ b/view/next-project/src/generated/model/getSponsorshipActivitiesParams.ts
@@ -6,6 +6,7 @@
  * OpenAPI spec version: 2.0.0
  */
 import type { ActivityStatus } from './activityStatus';
+import type { DesignProgress } from './designProgress';
 import type { FeasibilityStatus } from './feasibilityStatus';
 import type { GetSponsorshipActivitiesOrder } from './getSponsorshipActivitiesOrder';
 
@@ -22,6 +23,10 @@ export type GetSponsorshipActivitiesParams = {
    * 活動ステータス (ActivityStatusの値を指定)
    */
   activity_status?: ActivityStatus;
+  /**
+   * デザイン進捗ステータス (DesignProgressの値を指定)
+   */
+  design_progress?: DesignProgress;
   /**
    * 協賛可否ステータス (FeasibilityStatusの値を指定)
    */

--- a/view/next-project/src/hooks/sponsor-activities/useSponsorActivitiesQuery.ts
+++ b/view/next-project/src/hooks/sponsor-activities/useSponsorActivitiesQuery.ts
@@ -48,6 +48,12 @@ export function useSponsorActivitiesQuery({
     if (filterData.feasibilityStatus !== 'all') {
       params.feasibility_status = filterData.feasibilityStatus;
     }
+    if (filterData.activityStatus !== 'all') {
+      params.activity_status = filterData.activityStatus;
+    }
+    if (filterData.designProgress !== 'all') {
+      params.design_progress = filterData.designProgress;
+    }
     if (filterData.userId !== 'all') {
       params.user_id = filterData.userId;
     }
@@ -81,11 +87,6 @@ export function useSponsorActivitiesQuery({
       if (filterData.bureauId !== 'all') {
         nextActivities = nextActivities.filter(
           (activity) => activity.user?.bureauID === filterData.bureauId,
-        );
-      }
-      if (filterData.sponsorId !== 'all') {
-        nextActivities = nextActivities.filter(
-          (activity) => activity.sponsor?.id === filterData.sponsorId,
         );
       }
 

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -128,15 +128,6 @@ export default function SponsorActivities(props: Props) {
     [sponsorStyles],
   );
   const allSponsorStyleIdSet = useMemo(() => new Set(allSponsorStyleIds), [allSponsorStyleIds]);
-  const sponsorIdSetByYear = useMemo(
-    () =>
-      new Set(
-        sponsorsByYear
-          .map((sponsor) => sponsor.id)
-          .filter((sponsorId): sponsorId is number => sponsorId !== undefined),
-      ),
-    [sponsorsByYear],
-  );
 
   const isFiltered = useMemo(() => {
     const isStyleFiltered =
@@ -144,7 +135,8 @@ export default function SponsorActivities(props: Props) {
       filterData.styleIds.some((styleId) => !allSponsorStyleIdSet.has(styleId));
     const isBureauFiltered = filterData.bureauId !== 'all';
     const isUserFiltered = filterData.userId !== 'all';
-    const isSponsorFiltered = filterData.sponsorId !== 'all';
+    const isActivityStatusFiltered = filterData.activityStatus !== 'all';
+    const isDesignProgressFiltered = filterData.designProgress !== 'all';
     const isFeasibilityFiltered = filterData.feasibilityStatus !== 'all';
     const isSorted = filterData.selectedSort !== 'default';
 
@@ -152,7 +144,8 @@ export default function SponsorActivities(props: Props) {
       isStyleFiltered ||
       isBureauFiltered ||
       isUserFiltered ||
-      isSponsorFiltered ||
+      isActivityStatusFiltered ||
+      isDesignProgressFiltered ||
       isFeasibilityFiltered ||
       isSorted
     );
@@ -172,16 +165,6 @@ export default function SponsorActivities(props: Props) {
     () => calculateActivitiesTotalAmount(sponsorshipActivities),
     [sponsorshipActivities],
   );
-
-  useEffect(() => {
-    if (filterData.sponsorId === 'all') return;
-    if (sponsorIdSetByYear.has(filterData.sponsorId)) return;
-
-    dispatch({
-      type: 'set-filter-data',
-      payload: { ...filterData, sponsorId: 'all' },
-    });
-  }, [filterData, sponsorIdSetByYear]);
 
   if (!_hasHydrated) return <Loading />;
   if (!user?.roleID || ![2, 3, 4].includes(user.roleID)) return <Loading />;

--- a/view/next-project/src/stories/sponsor-activities/FilterModal.stories.tsx
+++ b/view/next-project/src/stories/sponsor-activities/FilterModal.stories.tsx
@@ -1,7 +1,7 @@
 import { SponsorActivitiesFilterType } from '@/utils/sponsorshipActivity';
 import { FilterModal } from '@components/sponsor-activities';
 
-import { SPONSOR, SPONSOR_STYLE, USER } from '../constants';
+import { SPONSOR_STYLE, USER } from '../constants';
 
 import type { Meta, StoryFn } from '@storybook/react';
 
@@ -31,7 +31,6 @@ Primary.args = {
   setIsOpen: () => {},
   sponsorStyles: [SPONSOR_STYLE],
   users: [USER],
-  sponsors: [SPONSOR],
   filterData,
   setFilterData: () => {},
 };

--- a/view/next-project/src/stories/sponsor-activities/FilterModal.stories.tsx
+++ b/view/next-project/src/stories/sponsor-activities/FilterModal.stories.tsx
@@ -20,7 +20,8 @@ const filterData: SponsorActivitiesFilterType = {
   styleIds: [SPONSOR_STYLE.id || 0],
   bureauId: 'all',
   userId: 'all',
-  sponsorId: 'all',
+  activityStatus: 'all',
+  designProgress: 'all',
   feasibilityStatus: 'all',
   selectedSort: 'default',
 };

--- a/view/next-project/src/utils/sponsorshipActivity.ts
+++ b/view/next-project/src/utils/sponsorshipActivity.ts
@@ -20,7 +20,8 @@ export interface SponsorActivitiesFilterType {
   styleIds: number[];
   bureauId: number | 'all';
   userId: number | 'all';
-  sponsorId: number | 'all';
+  activityStatus: ActivityStatus | 'all';
+  designProgress: DesignProgress | 'all';
   feasibilityStatus: FeasibilityStatus | 'all';
   selectedSort: SponsorActivitiesSortType;
 }
@@ -134,7 +135,8 @@ export const createDefaultSponsorActivitiesFilter = (
       .filter((styleId): styleId is number => styleId !== undefined),
     bureauId: 'all',
     userId: 'all',
-    sponsorId: 'all',
+    activityStatus: 'all',
+    designProgress: 'all',
     feasibilityStatus: 'all',
     selectedSort: 'default',
   };


### PR DESCRIPTION
# 対応Issue
resolve #0

# 概要
協賛活動一覧ページにおける絞り込み（フィルター）機能の改修を行いました。
バックエンドからフロントエンドまで修正しています。

**【Backend (API / OpenAPI)】**
- OpenAPIの定義（`openapi.yaml`）に、絞り込み用のクエリパラメータ `design_progress` を追加
- `make gen` による自動生成コードの更新
- `sponsorship_activity_repository.go` にて、`design_progress` の条件を追加

**【Frontend】**
- 協賛フィルター内の「企業名（sponsorId）」による絞り込み機能を削除
- 新たに「活動ステータス（activityStatus）」と「デザイン進捗（designProgress）」の絞り込みを追加

# 画面スクリーンショット等
- `/sponsorship_activities`
<img width="3837" height="1924" alt="image" src="https://github.com/user-attachments/assets/3111806a-f18c-44b9-96e7-c42fe16bc2d9" />


# テスト項目
- Swagger（`GET /sponsorship_activities`）で `activity_status` や `design_progress` のパラメータを指定した際、正しく絞り込まれたデータが返ってくる
- 協賛活動一覧ページのフィルターモーダルから「企業名」が消え、「活動ステータス」「デザイン進捗」の項目が追加されている
- 「活動ステータス」「デザイン進捗」のプルダウンから任意のステータスを選択して絞り込みを実行した際、一覧の表示が正しく切り替わるか
- ページ送りの変更や年度の切り替えなど、他の操作を行った際にエラーが発生しないか

# 備考