### PR TITLE
API全体にsessionベースのログイン認証を適用

### DIFF
--- a/api/drivers/server/server.go
+++ b/api/drivers/server/server.go
@@ -5,12 +5,13 @@ import (
 	"os"
 
 	"github.com/NUTFes/FinanSu/api/externals/handler"
+	"github.com/NUTFes/FinanSu/api/externals/repository"
 	"github.com/NUTFes/FinanSu/api/generated"
 	echo "github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
 
-func RunServer(server *handler.Handler) *echo.Echo {
+func RunServer(server *handler.Handler, sessionRepository repository.SessionRepository) *echo.Echo {
 	// echoのインスタンス
 	e := echo.New()
 
@@ -29,8 +30,10 @@ func RunServer(server *handler.Handler) *echo.Echo {
 	// CORS対策
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"http://localhost:3000", "127.0.0.1:3000", "http://localhost:3001", "127.0.0.1:3001", "http://localhost:8000", "127.0.0.1:8000", "https://finansu.nutfes.net", "https://stg-finansu.nutfes.net"}, // ドメイン
-		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete},
+		AllowMethods: []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
+		AllowHeaders: []string{echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept, echo.HeaderAuthorization, "Access-Token"},
 	}))
+	e.Use(SessionAuth(sessionRepository))
 
 	// ルーティング
 

--- a/api/drivers/server/session_auth.go
+++ b/api/drivers/server/session_auth.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"database/sql"
+	"net/http"
+	"strings"
+
+	"github.com/NUTFes/FinanSu/api/externals/repository"
+	"github.com/labstack/echo/v4"
+)
+
+const AuthenticatedUserContextKey = "authenticatedUser"
+
+var publicPaths = map[string]struct{}{
+	"/mail_auth/signin":       {},
+	"/mail_auth/signup":       {},
+	"/password_reset/request": {},
+}
+
+func SessionAuth(sessionRepository repository.SessionRepository) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if c.Request().Method == http.MethodOptions || isPublicPath(c.Request().URL.Path) {
+				return next(c)
+			}
+
+			token := accessToken(c.Request())
+			if token == "" {
+				return echo.NewHTTPError(http.StatusUnauthorized, "access token is required")
+			}
+
+			user, err := sessionRepository.FindActiveUserByAccessToken(c.Request().Context(), token)
+			if err != nil {
+				if err == sql.ErrNoRows {
+					return echo.NewHTTPError(http.StatusUnauthorized, "invalid access token")
+				}
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to authenticate session")
+			}
+
+			c.Set(AuthenticatedUserContextKey, user)
+			return next(c)
+		}
+	}
+}
+
+func accessToken(r *http.Request) string {
+	if token := strings.TrimSpace(r.Header.Get("Access-Token")); token != "" {
+		return token
+	}
+	const bearer = "Bearer "
+	authorization := strings.TrimSpace(r.Header.Get("Authorization"))
+	if len(authorization) > len(bearer) && strings.EqualFold(authorization[:len(bearer)], bearer) {
+		return strings.TrimSpace(authorization[len(bearer):])
+	}
+	return ""
+}
+
+func isPublicPath(path string) bool {
+	if _, ok := publicPaths[path]; ok {
+		return true
+	}
+	return strings.HasPrefix(path, "/password_reset/")
+}

--- a/api/externals/repository/session_repository.go
+++ b/api/externals/repository/session_repository.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"github.com/NUTFes/FinanSu/api/drivers/db"
-	"fmt"
+	"github.com/NUTFes/FinanSu/api/internals/domain"
 )
-
 
 type sessionRepository struct {
 	client db.Client
@@ -16,6 +15,7 @@ type SessionRepository interface {
 	Create(context.Context, string, string, string) error
 	Destroy(context.Context, string) error
 	FindSessionByAccessToken(context.Context, string) *sql.Row
+	FindActiveUserByAccessToken(context.Context, string) (domain.User, error)
 	DestroyByUserID(context.Context, string) error
 }
 
@@ -25,42 +25,51 @@ func NewSessionRepository(client db.Client) SessionRepository {
 
 // 作成
 func (r *sessionRepository) Create(c context.Context, authID string, userID string, accessToken string) error {
-	query := "insert into session (auth_id, user_id, access_token) values (" + authID + ", " + userID + ", '" + accessToken + "')"
-	_, err := r.client.DB().ExecContext(c, query)
+	query := "insert into session (auth_id, user_id, access_token) values (?, ?, ?)"
+	_, err := r.client.DB().ExecContext(c, query, authID, userID, accessToken)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("\x1b[36m%s\n", query)
 	return nil
 }
 
 // 削除
 func (r *sessionRepository) Destroy(c context.Context, accessToken string) error {
 	// access tokenで該当のsessionを削除
-	query := "delete from session where access_token = '" + accessToken + "'"
-	_, err := r.client.DB().ExecContext(c, query)
+	query := "delete from session where access_token = ?"
+	_, err := r.client.DB().ExecContext(c, query, accessToken)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("\x1b[36m%s\n", query)
 	return nil
 }
 
 // アクセストークンからセッションを取得
 func (r *sessionRepository) FindSessionByAccessToken(c context.Context, accessToken string) *sql.Row {
-	query := "select * from session where access_token = '" + accessToken + "'"
-	row := r.client.DB().QueryRowContext(c, query)
-	fmt.Printf("\x1b[36m%s\n", query)
+	query := "select * from session where access_token = ?"
+	row := r.client.DB().QueryRowContext(c, query, accessToken)
 	return row
+}
+
+func (r *sessionRepository) FindActiveUserByAccessToken(c context.Context, accessToken string) (domain.User, error) {
+	var user domain.User
+	err := r.client.DB().QueryRowContext(c, `
+		SELECT u.id, u.name, u.bureau_id, u.role_id, u.is_deleted, u.created_at, u.updated_at
+		FROM session s
+		INNER JOIN users u ON u.id = s.user_id
+		WHERE s.access_token = ? AND u.is_deleted = FALSE
+		LIMIT 1`, accessToken).Scan(
+		&user.ID, &user.Name, &user.BureauID, &user.RoleID, &user.IsDeleted, &user.CreatedAt, &user.UpdatedAt,
+	)
+	return user, err
 }
 
 // user_idからsessionを削除する
 func (r *sessionRepository) DestroyByUserID(c context.Context, userID string) error {
-	query := "delete from session where user_id = " + userID
-	_, err := r.client.DB().ExecContext(c, query)
+	query := "delete from session where user_id = ?"
+	_, err := r.client.DB().ExecContext(c, query, userID)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("\x1b[36m%s\n", query)
 	return nil
 }

--- a/api/internals/di/wire.go
+++ b/api/internals/di/wire.go
@@ -39,8 +39,8 @@ func ProvideCrud(client db.Client) abstract.Crud {
 }
 
 // ProvideServer - ServerのProvider
-func ProvideServer(h *handler.Handler) *echo.Echo {
-	return server.RunServer(h)
+func ProvideServer(h *handler.Handler, sessionRepository repository.SessionRepository) *echo.Echo {
+	return server.RunServer(h, sessionRepository)
 }
 
 // ProvideServerComponents - ServerComponentsのProvider

--- a/api/internals/di/wire_gen.go
+++ b/api/internals/di/wire_gen.go
@@ -76,7 +76,7 @@ func InitializeServer() (*ServerComponents, error) {
 	sponsorshipActivityRepository := repository.NewSponsorshipActivityRepository(client, crud)
 	sponsorshipActivityUseCase := usecase.NewSponsorshipActivityUseCase(sponsorshipActivityRepository, transactionRepository)
 	handlerHandler := handler.NewHandler(activityUseCase, activityInformationUseCase, activityStyleUseCase, bureauUseCase, buyReportUseCase, campusDonationUseCase, departmentUseCase, divisionUseCase, festivalItemUseCase, financialRecordUseCase, incomeUseCase, incomeExpenditureManagementUseCase, mailAuthUseCase, objectUploadUseCase, passwordResetTokenUseCase, sponsorUseCase, sponsorStyleUseCase, teacherUseCase, userUseCase, yearUseCase, sponsorshipActivityUseCase)
-	echo := ProvideServer(handlerHandler)
+	echo := ProvideServer(handlerHandler, sessionRepository)
 	serverComponents := ProvideServerComponents(client, echo)
 	return serverComponents, nil
 }
@@ -105,8 +105,8 @@ func ProvideCrud(client db.Client) abstract.Crud {
 }
 
 // ProvideServer - ServerのProvider
-func ProvideServer(h *handler.Handler) *echo.Echo {
-	return server.RunServer(h)
+func ProvideServer(h *handler.Handler, sessionRepository repository.SessionRepository) *echo.Echo {
+	return server.RunServer(h, sessionRepository)
 }
 
 // ProvideServerComponents - ServerComponentsのProvider

--- a/api/internals/usecase/mail_auth_usecase.go
+++ b/api/internals/usecase/mail_auth_usecase.go
@@ -37,7 +37,7 @@ func (u *mailAuthUseCase) SignUp(c context.Context, email string, password strin
 	}
 
 	// トークン発行
-	accessToken, err := _makeRandomStr(10)
+	accessToken, err := _makeRandomStr(32)
 	if err != nil {
 		return token, err
 	}
@@ -75,7 +75,7 @@ func (u *mailAuthUseCase) SignIn(c context.Context, email string, password strin
 	}
 
 	// トークン発行
-	accessToken, err := _makeRandomStr(10)
+	accessToken, err := _makeRandomStr(32)
 	if err != nil {
 		return token, err
 	}

--- a/view/next-project/src/mutator/custom-instance.ts
+++ b/view/next-project/src/mutator/custom-instance.ts
@@ -1,3 +1,5 @@
+import { authFetch } from '@/utils/api/authFetch';
+
 // NOTE: Supports cases where `content-type` is other than `json`
 const getBody = <T>(c: Response | Request): Promise<T> => {
   const contentType = c.headers.get('content-type');
@@ -45,7 +47,7 @@ export const customFetch = async <T>(url: string, options: RequestInit): Promise
   };
 
   const request = new Request(requestUrl, requestInit);
-  const response = await fetch(request);
+  const response = await authFetch(request);
   const data = await getBody<T>(response);
 
   if (!response.ok) {

--- a/view/next-project/src/utils/api/api_methods.ts
+++ b/view/next-project/src/utils/api/api_methods.ts
@@ -1,5 +1,7 @@
+import { authFetch } from './authFetch';
+
 export const get = async (url: string) => {
-  const res = await fetch(url, {
+  const res = await authFetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -9,7 +11,7 @@ export const get = async (url: string) => {
 };
 
 export const get_with_token = async (url: string, accessToken?: string) => {
-  const res = await fetch(url, {
+  const res = await authFetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -22,12 +24,12 @@ export const get_with_token = async (url: string, accessToken?: string) => {
 };
 
 export const del = async (url: string) => {
-  const res = await fetch(url, { method: 'DELETE' });
+  const res = await authFetch(url, { method: 'DELETE' });
   return await res.json();
 };
 
 export const post = async (url: string, data: unknown) => {
-  const res = await fetch(url, {
+  const res = await authFetch(url, {
     method: 'POST',
     mode: 'cors',
     headers: {
@@ -39,7 +41,7 @@ export const post = async (url: string, data: unknown) => {
 };
 
 export const put = async (url: string, data: unknown) => {
-  const res = await fetch(url, {
+  const res = await authFetch(url, {
     method: 'PUT',
     mode: 'cors',
     headers: {
@@ -51,7 +53,7 @@ export const put = async (url: string, data: unknown) => {
 };
 
 export const multiDel = async (url: string, data: number[]) => {
-  const res = await fetch(url, {
+  const res = await authFetch(url, {
     method: 'DELETE',
     mode: 'cors',
     headers: {
@@ -63,7 +65,7 @@ export const multiDel = async (url: string, data: number[]) => {
 };
 
 export const get_with_token_valid = async (url: string, accessToken?: string) => {
-  const res = await fetch(url, {
+  const res = await authFetch(url, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/view/next-project/src/utils/api/authFetch.ts
+++ b/view/next-project/src/utils/api/authFetch.ts
@@ -1,0 +1,23 @@
+import { useAuthStore } from '@/store/authStore';
+
+const publicPaths = ['/mail_auth/signin', '/mail_auth/signup', '/password_reset/'];
+
+const isPublicRequest = (url: string) => publicPaths.some((path) => url.includes(path));
+
+export const authFetch = async (input: RequestInfo | URL, init: RequestInit = {}) => {
+  const url = input instanceof Request ? input.url : input.toString();
+  const headers = new Headers(input instanceof Request ? input.headers : undefined);
+  new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+
+  if (!isPublicRequest(url)) {
+    const accessToken = useAuthStore.getState().accessToken;
+    if (accessToken) headers.set('Access-Token', accessToken);
+  }
+
+  const response = await fetch(input, { ...init, headers });
+  if (response.status === 401 && typeof window !== 'undefined') {
+    useAuthStore.getState().resetAuth();
+    if (window.location.pathname !== '/') window.location.assign('/');
+  }
+  return response;
+};


### PR DESCRIPTION
# 対応Issue
resolve #1112

# 概要
- Echoの共通middlewareとしてsessionベースの認証を追加
- `Access-Token`と`Authorization: Bearer`の両形式に対応
- sessionと未削除userを結合して照合し、認証済みユーザーをEcho Contextへ格納
- サインイン、サインアップ、パスワードリセット、OPTIONSを認証対象外に設定
- session repositoryのSQLをプレースホルダ化し、アクセストークンを10文字から32文字へ強化
- 生成API clientと既存共通API関数でトークンを自動付与し、401時に認証状態をリセットしてログイン画面へ遷移
- CORSで`Authorization`、`Access-Token`ヘッダーとOPTIONSを許可

# 画面スクリーンショット等
画面変更なし

# テスト項目
- [x] `cd api && go test ./...`
- [x] `cd view/next-project && pnpm type-check`
- [x] `cd view/next-project && pnpm lint`（既存warning 106件、error 0件）
- [ ] 未認証で保護APIを呼ぶと401になること
- [ ] 有効なAccess-TokenまたはBearer tokenで保護APIを呼べること
- [ ] 削除済みユーザーのsessionでは401になること
- [ ] 401受信時にログイン状態が解除され、ログイン画面へ戻ること

# 備考
- JWTやrole/resource単位の認可、有効期限は本PRの対象外です。
- Wire生成コマンドは固定された`golang.org/x/tools`と現在のGoバージョンの互換性エラーで実行できないため、DI変更と同等の差分を`wire_gen.go`へ反映し、`go test ./...`でビルドを確認しています。
