### PR TITLE
[fix]合計金額を金のものだけが見えるように修正

### DIFF
--- a/api/externals/handler/sponsorship_activity_handler.go
+++ b/api/externals/handler/sponsorship_activity_handler.go
@@ -21,7 +21,7 @@ func (h *Handler) GetSponsorshipActivities(c echo.Context, sponsorshipActivities
 	for _, currentSponsorshipActivity := range retrievedSponsorshipActivities {
 		if currentSponsorshipActivity.SponsorStyles != nil {
 			for _, currentSponsorStyleLink := range *currentSponsorshipActivity.SponsorStyles {
-				if currentSponsorStyleLink.Style != nil {
+				if currentSponsorStyleLink.Style != nil && currentSponsorStyleLink.Category != nil && string(*currentSponsorStyleLink.Category) == "money" {
 					totalAmountOfSponsorStyles += currentSponsorStyleLink.Style.Price
 				}
 			}

--- a/api/externals/repository/sponsorship_activity_repository.go
+++ b/api/externals/repository/sponsorship_activity_repository.go
@@ -60,6 +60,9 @@ func (r *sponsorshipActivityRepository) FindAll(ctx context.Context, sponsorship
 	if sponsorshipActivitiesSearchParams.UserId != nil {
 		queryDataset = queryDataset.Where(goqu.I("sponsorship_activities.user_id").Eq(*sponsorshipActivitiesSearchParams.UserId))
 	}
+	if sponsorshipActivitiesSearchParams.BureauId != nil {
+		queryDataset = queryDataset.Where(goqu.I("users.bureau_id").Eq(*sponsorshipActivitiesSearchParams.BureauId))
+	}
 	if sponsorshipActivitiesSearchParams.ActivityStatus != nil {
 		queryDataset = queryDataset.Where(goqu.I("sponsorship_activities.activity_status").Eq(string(*sponsorshipActivitiesSearchParams.ActivityStatus)))
 	}

--- a/api/generated/openapi_gen.go
+++ b/api/generated/openapi_gen.go
@@ -860,6 +860,9 @@ type GetSponsorshipActivitiesParams struct {
 	// UserId 担当者ID
 	UserId *int `form:"user_id,omitempty" json:"user_id,omitempty"`
 
+	// BureauId 所属局ID
+	BureauId *int `form:"bureau_id,omitempty" json:"bureau_id,omitempty"`
+
 	// SponsorStyleIds 協賛プランID（複数指定可）
 	SponsorStyleIds *[]int `form:"sponsor_style_ids,omitempty" json:"sponsor_style_ids,omitempty"`
 
@@ -2980,6 +2983,13 @@ func (w *ServerInterfaceWrapper) GetSponsorshipActivities(ctx echo.Context) erro
 	err = runtime.BindQueryParameter("form", true, false, "user_id", ctx.QueryParams(), &params.UserId)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter user_id: %s", err))
+	}
+
+	// ------------- Optional query parameter "bureau_id" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "bureau_id", ctx.QueryParams(), &params.BureauId)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter bureau_id: %s", err))
 	}
 
 	// ------------- Optional query parameter "sponsor_style_ids" -------------

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2561,6 +2561,12 @@ paths:
           required: false
           schema:
             type: integer
+        - name: bureau_id
+          in: query
+          description: 所属局ID
+          required: false
+          schema:
+            type: integer
         - name: sponsor_style_ids
           in: query
           description: "協賛プランID（複数指定可）"

--- a/view/next-project/src/generated/model/getSponsorshipActivitiesParams.ts
+++ b/view/next-project/src/generated/model/getSponsorshipActivitiesParams.ts
@@ -36,6 +36,10 @@ export type GetSponsorshipActivitiesParams = {
    */
   user_id?: number;
   /**
+   * 所属局ID
+   */
+  bureau_id?: number;
+  /**
    * 協賛プランID（複数指定可）
    */
   sponsor_style_ids?: number[];

--- a/view/next-project/src/hooks/sponsor-activities/useSponsorActivitiesQuery.ts
+++ b/view/next-project/src/hooks/sponsor-activities/useSponsorActivitiesQuery.ts
@@ -60,6 +60,9 @@ export function useSponsorActivitiesQuery({
     if (filterData.userId !== 'all') {
       params.user_id = filterData.userId;
     }
+    if (filterData.bureauId !== 'all') {
+      params.bureau_id = filterData.bureauId;
+    }
     if (
       filterData.styleIds.length > 0 &&
       filterData.styleIds.length !== allSponsorStyleIds.length
@@ -85,14 +88,9 @@ export function useSponsorActivitiesQuery({
       const response = await getSponsorshipActivities(params, {
         signal: abortController.signal,
       });
-      setTotalAmount(response.data.totalAmount || 0);
-      let nextActivities = response.data.activities || [];
+      const nextActivities = response.data.activities || [];
 
-      if (filterData.bureauId !== 'all') {
-        nextActivities = nextActivities.filter(
-          (activity) => activity.user?.bureauID === filterData.bureauId,
-        );
-      }
+      setTotalAmount(response.data.totalAmount || 0);
 
       setActivities(
         filterData.selectedSort === 'priceSort' || filterData.selectedSort === 'priceDesSort'

--- a/view/next-project/src/hooks/sponsor-activities/useSponsorActivitiesQuery.ts
+++ b/view/next-project/src/hooks/sponsor-activities/useSponsorActivitiesQuery.ts
@@ -15,6 +15,7 @@ interface UseSponsorActivitiesQueryParams {
 
 interface UseSponsorActivitiesQueryResult {
   activities: SponsorshipActivity[];
+  totalAmount: number;
   isLoading: boolean;
   fetchSponsorshipActivities: () => Promise<void>;
 }
@@ -25,6 +26,7 @@ export function useSponsorActivitiesQuery({
   allSponsorStyleIds,
 }: UseSponsorActivitiesQueryParams): UseSponsorActivitiesQueryResult {
   const [activities, setActivities] = useState<SponsorshipActivity[]>([]);
+  const [totalAmount, setTotalAmount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const fetchAbortControllerRef = useRef<AbortController | null>(null);
 
@@ -37,6 +39,7 @@ export function useSponsorActivitiesQuery({
 
     if (allSponsorStyleIds.length > 0 && filterData.styleIds.length === 0) {
       setActivities([]);
+      setTotalAmount(0);
       setIsLoading(false);
       return;
     }
@@ -82,6 +85,7 @@ export function useSponsorActivitiesQuery({
       const response = await getSponsorshipActivities(params, {
         signal: abortController.signal,
       });
+      setTotalAmount(response.data.totalAmount || 0);
       let nextActivities = response.data.activities || [];
 
       if (filterData.bureauId !== 'all') {
@@ -100,6 +104,7 @@ export function useSponsorActivitiesQuery({
         return;
       }
       setActivities([]);
+      setTotalAmount(0);
     } finally {
       if (fetchAbortControllerRef.current === abortController) {
         setIsLoading(false);
@@ -117,6 +122,7 @@ export function useSponsorActivitiesQuery({
 
   return {
     activities,
+    totalAmount,
     isLoading,
     fetchSponsorshipActivities,
   };

--- a/view/next-project/src/pages/sponsor-activities/index.tsx
+++ b/view/next-project/src/pages/sponsor-activities/index.tsx
@@ -8,7 +8,6 @@ import { useSponsorsByYear } from '@/hooks/sponsor-activities/useSponsorsByYear'
 import { useCurrentUser, useUserStore } from '@/store';
 import { get } from '@/utils/api/api_methods';
 import {
-  calculateActivitiesTotalAmount,
   createDefaultSponsorActivitiesFilter,
   SponsorActivitiesFilterType,
 } from '@/utils/sponsorshipActivity';
@@ -153,6 +152,7 @@ export default function SponsorActivities(props: Props) {
 
   const {
     activities: sponsorshipActivities,
+    totalAmount,
     isLoading,
     fetchSponsorshipActivities,
   } = useSponsorActivitiesQuery({
@@ -160,11 +160,6 @@ export default function SponsorActivities(props: Props) {
     filterData,
     allSponsorStyleIds,
   });
-
-  const totalAmount = useMemo(
-    () => calculateActivitiesTotalAmount(sponsorshipActivities),
-    [sponsorshipActivities],
-  );
 
   if (!_hasHydrated) return <Loading />;
   if (!user?.roleID || ![2, 3, 4].includes(user.roleID)) return <Loading />;


### PR DESCRIPTION
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #0

# 概要
<!-- 開発内容の概要を記載 -->
協賛活動一覧における合計金額（`totalAmount`）の集計対象を、物品協賛（goods）を含めず資金協賛（money）のみの金額となるよう修正しました。

具体的には以下の対応を行っています：
- **バックエンド**: 協賛活動一覧APIにおいて、紐づくプランの `Category` が `"money"` であるもののみを合計金額に加算するよう修正しました。
- **フロントエンド**: 画面側で独自に行われていた全プランの再計算ロジックを削除し、APIのレスポンスとして返却される `totalAmount`（資金協賛のみの合計）をそのまま画面の表示に用いるよう変更しました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
- `URL`
スクリーンショット

# テスト項目
<!-- テストしてほしい内容を記載 -->
- 協賛活動一覧ページを表示した際、合計金額が「資金協賛（money）」のプランの金額のみの合計になっていること
- ステータスやプランなどのフィルターで絞り込みを行った際、絞り込み条件に応じた合計金額にリアルタイムで更新されること

# 備考